### PR TITLE
fix(ci): checkout main branch for release-triggered workflow

### DIFF
--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
       - name: Get release version
         id: version
@@ -37,4 +39,5 @@ jobs:
             
             Release: ${{ github.event.release.html_url }}
           branch: update-readme-${{ steps.version.outputs.version }}
+          base: main
           delete-branch: true


### PR DESCRIPTION
## Summary
- Fix the `update-readme-version` workflow that fails when triggered by a release
- Add `ref: main` to checkout the main branch instead of the release tag (detached HEAD)
- Add `base: main` to explicitly set the PR target branch

## Context
When triggered by a release event, GitHub Actions checks out the release tag, not a branch. The `create-pull-request` action requires a branch context to work properly.

Fixes: https://github.com/atruedeveloper/kmp-ble/actions/runs/23218370813/job/67484894741