### PR TITLE
chore: update repository URLs from gary-quinn to atruedeveloper

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
               targets: [
                   .binaryTarget(
                       name: "KmpBle",
-                      url: "https://github.com/gary-quinn/kmp-ble/releases/download/${VERSION}/KmpBle.xcframework.zip",
+                      url: "https://github.com/atruedeveloper/kmp-ble/releases/download/${VERSION}/KmpBle.xcframework.zip",
                       checksum: "${CHECKSUM}"
                   ),
               ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "KmpBle",
-            url: "https://github.com/gary-quinn/kmp-ble/releases/download/v0.1.1/KmpBle.xcframework.zip",
+            url: "https://github.com/atruedeveloper/kmp-ble/releases/download/v0.1.1/KmpBle.xcframework.zip",
             checksum: "294400179971a68812b316885f90d88ff2d496dc62d931da1be9009b673cc840"
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kmp-ble
 
-[![CI](https://github.com/gary-quinn/kmp-ble/actions/workflows/ci.yml/badge.svg)](https://github.com/gary-quinn/kmp-ble/actions/workflows/ci.yml)
-[![Publish](https://github.com/gary-quinn/kmp-ble/actions/workflows/publish.yml/badge.svg)](https://github.com/gary-quinn/kmp-ble/actions/workflows/publish.yml)
+[![CI](https://github.com/atruedeveloper/kmp-ble/actions/workflows/ci.yml/badge.svg)](https://github.com/atruedeveloper/kmp-ble/actions/workflows/ci.yml)
+[![Publish](https://github.com/atruedeveloper/kmp-ble/actions/workflows/publish.yml/badge.svg)](https://github.com/atruedeveloper/kmp-ble/actions/workflows/publish.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.atruedev/kmp-ble)](https://central.sonatype.com/artifact/com.atruedev/kmp-ble)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.10-purple.svg)](https://kotlinlang.org)
@@ -38,7 +38,7 @@ class MyApp : Application() {
 In Xcode: **File > Add Package Dependencies** and enter:
 
 ```
-https://github.com/gary-quinn/kmp-ble
+https://github.com/atruedeveloper/kmp-ble
 ```
 
 Select the version and add `KmpBle` to your target.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ mavenPublishing {
     pom {
         name.set("kmp-ble")
         description.set("Kotlin Multiplatform BLE library for Android and iOS")
-        url.set("https://github.com/gary-quinn/kmp-ble")
+        url.set("https://github.com/atruedeveloper/kmp-ble")
         licenses {
             license {
                 name.set("Apache-2.0")
@@ -110,15 +110,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("gary-quinn")
+                id.set("atruedeveloper")
                 name.set("Gary Quinn")
                 email.set("gary@atruedev.com")
             }
         }
         scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
+            url.set("https://github.com/atruedeveloper/kmp-ble")
+            connection.set("scm:git:git://github.com/atruedeveloper/kmp-ble.git")
+            developerConnection.set("scm:git:ssh://github.com/atruedeveloper/kmp-ble.git")
         }
     }
 }


### PR DESCRIPTION
## Summary
Update all repository references from `gary-quinn/kmp-ble` to `atruedeveloper/kmp-ble`.

## Changes
- **README.md**: CI/Publish badges, Swift Package Manager URL
- **Package.swift**: XCFramework download URL  
- **publish.yml**: Package.swift template URL
- **build.gradle.kts**: POM metadata (project URL, SCM URLs, developer ID)