### PR TITLE
feat(android): L2CAP channel support (P12)

### DIFF
--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannelTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannelTest.kt
@@ -1,0 +1,282 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.atruedev.kmpble.l2cap
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AndroidL2capChannelTest {
+
+    private fun createChannel(
+        socket: FakeL2capSocket = FakeL2capSocket(),
+        psm: Int = 0x25,
+    ): Pair<AndroidL2capChannel, FakeL2capSocket> {
+        val channel = AndroidL2capChannel(socket, psm, kotlinx.coroutines.CoroutineScope(UnconfinedTestDispatcher()))
+        return channel to socket
+    }
+
+    // =========================================================================
+    // Basic lifecycle
+    // =========================================================================
+
+    @Test
+    fun `channel is open after creation`() {
+        val (channel, _) = createChannel()
+        assertTrue(channel.isOpen)
+        channel.close()
+    }
+
+    @Test
+    fun `psm is set correctly`() {
+        val (channel, _) = createChannel(psm = 0x42)
+        assertEquals(0x42, channel.psm)
+        channel.close()
+    }
+
+    @Test
+    fun `isOpen returns false after close`() {
+        val (channel, _) = createChannel()
+        assertTrue(channel.isOpen)
+        channel.close()
+        assertFalse(channel.isOpen)
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val (channel, _) = createChannel()
+        channel.close()
+        channel.close()
+        channel.close()
+        assertFalse(channel.isOpen)
+    }
+
+    // =========================================================================
+    // MTU
+    // =========================================================================
+
+    @Test
+    fun `mtu returns maxTransmitPacketSize when above default`() {
+        val socket = FakeL2capSocket(maxTransmitPacketSize = 2048)
+        val (channel, _) = createChannel(socket)
+        assertEquals(2048, channel.mtu)
+        channel.close()
+    }
+
+    @Test
+    fun `mtu floors at default when maxTransmitPacketSize is small`() {
+        val socket = FakeL2capSocket(maxTransmitPacketSize = 100)
+        val (channel, _) = createChannel(socket)
+        assertEquals(AndroidL2capChannel.DEFAULT_MTU, channel.mtu)
+        channel.close()
+    }
+
+    @Test
+    fun `mtu returns default value`() {
+        val socket = FakeL2capSocket(maxTransmitPacketSize = AndroidL2capChannel.DEFAULT_MTU)
+        val (channel, _) = createChannel(socket)
+        assertEquals(672, channel.mtu)
+        channel.close()
+    }
+
+    // =========================================================================
+    // Write
+    // =========================================================================
+
+    @Test
+    fun `write sends data through output stream`() = runTest {
+        val (channel, socket) = createChannel()
+        val data = byteArrayOf(0x01, 0x02, 0x03)
+
+        channel.write(data)
+
+        val captured = ByteArray(3)
+        val bytesRead = socket.localCapture.read(captured)
+        assertEquals(3, bytesRead)
+        assertContentEquals(data, captured)
+        channel.close()
+    }
+
+    @Test
+    fun `write throws ChannelClosed after close`() = runTest {
+        val (channel, _) = createChannel()
+        channel.close()
+
+        assertFailsWith<L2capException.ChannelClosed> {
+            channel.write(byteArrayOf(0x01, 0x02))
+        }
+    }
+
+    @Test
+    fun `write throws ChannelClosed when socket is disconnected`() = runTest {
+        val (channel, socket) = createChannel()
+        socket.simulateDisconnect()
+
+        assertFailsWith<L2capException.ChannelClosed> {
+            channel.write(byteArrayOf(0x01))
+        }
+        channel.close()
+    }
+
+    @Test
+    fun `write throws WriteFailed when output stream is closed`() = runTest {
+        val (channel, socket) = createChannel()
+        socket.localCapture.close()
+
+        assertFailsWith<L2capException.WriteFailed> {
+            channel.write(byteArrayOf(0x01))
+        }
+        channel.close()
+    }
+
+    // =========================================================================
+    // Read loop (incoming flow)
+    // =========================================================================
+
+    @Test
+    fun `incoming flow receives data from remote`() = runTest {
+        val (channel, socket) = createChannel()
+        val received = mutableListOf<ByteArray>()
+
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.incoming.collect { received.add(it) }
+        }
+
+        socket.remoteOutput.write(byteArrayOf(0x0A, 0x0B))
+        socket.remoteOutput.flush()
+
+        // Give the read loop time to process
+        kotlinx.coroutines.delay(100)
+
+        assertTrue(received.isNotEmpty(), "Should have received data")
+        assertContentEquals(byteArrayOf(0x0A, 0x0B), received[0])
+
+        channel.close()
+        collectJob.join()
+    }
+
+    @Test
+    fun `incoming flow receives multiple packets`() = runTest {
+        val (channel, socket) = createChannel()
+        val received = mutableListOf<ByteArray>()
+
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.incoming.collect { received.add(it) }
+        }
+
+        socket.remoteOutput.write(byteArrayOf(0x01))
+        socket.remoteOutput.flush()
+        kotlinx.coroutines.delay(50)
+
+        socket.remoteOutput.write(byteArrayOf(0x02))
+        socket.remoteOutput.flush()
+        kotlinx.coroutines.delay(50)
+
+        assertEquals(2, received.size)
+        assertContentEquals(byteArrayOf(0x01), received[0])
+        assertContentEquals(byteArrayOf(0x02), received[1])
+
+        channel.close()
+        collectJob.join()
+    }
+
+    @Test
+    fun `incoming flow completes when channel is closed`() = runTest {
+        val (channel, _) = createChannel()
+        var flowCompleted = false
+
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.incoming.collect { }
+            flowCompleted = true
+        }
+
+        channel.close()
+        collectJob.join()
+
+        assertTrue(flowCompleted, "Flow should complete after close")
+    }
+
+    @Test
+    fun `incoming flow completes on remote EOF`() = runTest {
+        val (channel, socket) = createChannel()
+        var flowCompleted = false
+
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.incoming.collect { }
+            flowCompleted = true
+        }
+
+        socket.simulateRemoteClose()
+        collectJob.join()
+
+        assertTrue(flowCompleted, "Flow should complete on remote EOF")
+    }
+
+    // =========================================================================
+    // awaitClosed
+    // =========================================================================
+
+    @Test
+    fun `awaitClosed completes when channel is closed`() = runTest {
+        val (channel, _) = createChannel()
+        var awaited = false
+
+        val awaitJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.awaitClosed()
+            awaited = true
+        }
+
+        assertFalse(awaited, "Should not have completed yet")
+        channel.close()
+        awaitJob.join()
+        assertTrue(awaited, "awaitClosed should complete after close")
+    }
+
+    @Test
+    fun `awaitClosed completes on remote disconnect`() = runTest {
+        val (channel, socket) = createChannel()
+        var awaited = false
+
+        val awaitJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.awaitClosed()
+            awaited = true
+        }
+
+        socket.simulateRemoteClose()
+        awaitJob.join()
+        assertTrue(awaited, "awaitClosed should complete on remote close")
+    }
+
+    // =========================================================================
+    // Socket disconnect mid-read
+    // =========================================================================
+
+    @Test
+    fun `channel becomes not open after remote disconnect`() = runTest {
+        val (channel, socket) = createChannel()
+        assertTrue(channel.isOpen)
+
+        socket.simulateRemoteClose()
+        // Wait for read loop to detect EOF
+        channel.awaitClosed()
+
+        assertFalse(channel.isOpen)
+    }
+
+    @Test
+    fun `write fails after remote disconnect closes channel`() = runTest {
+        val (channel, socket) = createChannel()
+        socket.simulateRemoteClose()
+        channel.awaitClosed()
+
+        assertFailsWith<L2capException.ChannelClosed> {
+            channel.write(byteArrayOf(0x01))
+        }
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capSocket.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capSocket.kt
@@ -1,0 +1,63 @@
+package com.atruedev.kmpble.l2cap
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Test double for [L2capSocket] backed by piped streams.
+ *
+ * [remoteOutput] feeds data into the channel's read loop (simulates remote writes).
+ * [localCapture] captures data the channel writes (simulates remote reads).
+ *
+ * Call [simulateRemoteClose] to close the remote end, triggering EOF on the read loop.
+ */
+internal class FakeL2capSocket(
+    override val maxTransmitPacketSize: Int = 672,
+) : L2capSocket {
+
+    private val _isConnected = AtomicBoolean(true)
+    override val isConnected: Boolean get() = _isConnected.get()
+
+    private val remoteToLocal = PipedOutputStream()
+    private val localInput = PipedInputStream(remoteToLocal, 8192)
+
+    private val localToRemote = PipedOutputStream()
+    private val remoteCapture = PipedInputStream(localToRemote, 8192)
+
+    /** Write here to push data into the channel's read loop. */
+    val remoteOutput: OutputStream get() = remoteToLocal
+
+    /** Read from here to capture data the channel wrote. */
+    val localCapture: InputStream get() = remoteCapture
+
+    override val inputStream: InputStream get() = localInput
+    override val outputStream: OutputStream get() = localToRemote
+
+    private val closed = AtomicBoolean(false)
+
+    /**
+     * Simulate the remote device closing the connection.
+     * The channel's read loop will see EOF or IOException.
+     */
+    fun simulateRemoteClose() {
+        _isConnected.set(false)
+        try { remoteToLocal.close() } catch (_: IOException) { }
+    }
+
+    fun simulateDisconnect() {
+        _isConnected.set(false)
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        _isConnected.set(false)
+        try { localInput.close() } catch (_: IOException) { }
+        try { localToRemote.close() } catch (_: IOException) { }
+        try { remoteToLocal.close() } catch (_: IOException) { }
+        try { remoteCapture.close() } catch (_: IOException) { }
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannel.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannel.kt
@@ -1,7 +1,5 @@
 package com.atruedev.kmpble.l2cap
 
-import android.annotation.SuppressLint
-import android.bluetooth.BluetoothSocket
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -18,7 +16,7 @@ import java.io.OutputStream
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Android implementation of [L2capChannel] using [BluetoothSocket].
+ * Android implementation of [L2capChannel] backed by an [L2capSocket].
  *
  * The socket provides blocking [InputStream]/[OutputStream] which are wrapped
  * in coroutines for the suspend-based API.
@@ -32,11 +30,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * ## MTU
  *
  * Android's L2CAP CoC uses a default MTU of 672 bytes, but the actual negotiated
- * MTU is not exposed via public API. We use [BluetoothSocket.maxTransmitPacketSize]
- * (API 23+) as the write-side limit, falling back to a conservative default.
+ * MTU is not exposed via public API. We use [L2capSocket.maxTransmitPacketSize]
+ * as the write-side limit, falling back to a conservative default.
  */
 internal class AndroidL2capChannel(
-    private val socket: BluetoothSocket,
+    private val socket: L2capSocket,
     override val psm: Int,
     private val scope: CoroutineScope,
 ) : L2capChannel {
@@ -49,7 +47,6 @@ internal class AndroidL2capChannel(
     private val closedDeferred = CompletableDeferred<Unit>()
 
     override val mtu: Int
-        @SuppressLint("NewApi")
         get() = try {
             maxOf(socket.maxTransmitPacketSize, DEFAULT_MTU)
         } catch (_: Exception) {
@@ -140,7 +137,6 @@ internal class AndroidL2capChannel(
         closedDeferred.complete(Unit)
     }
 
-    @SuppressLint("NewApi")
     private fun closeSocket() {
         try {
             inputStream.close()
@@ -155,7 +151,7 @@ internal class AndroidL2capChannel(
         } catch (_: IOException) { }
     }
 
-    private companion object {
+    internal companion object {
         const val DEFAULT_MTU = 672
         const val READ_BUFFER_SIZE = 4096
     }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/BluetoothL2capSocket.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/BluetoothL2capSocket.kt
@@ -1,0 +1,25 @@
+package com.atruedev.kmpble.l2cap
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothSocket
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Adapts [BluetoothSocket] to the [L2capSocket] interface used by
+ * [AndroidL2capChannel]. Thin delegation — no added logic.
+ */
+@SuppressLint("NewApi")
+internal class BluetoothL2capSocket(
+    private val socket: BluetoothSocket,
+) : L2capSocket {
+
+    override val inputStream: InputStream get() = socket.inputStream
+    override val outputStream: OutputStream get() = socket.outputStream
+    override val isConnected: Boolean get() = socket.isConnected
+    override val maxTransmitPacketSize: Int get() = socket.maxTransmitPacketSize
+
+    override fun close() {
+        socket.close()
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/L2capSocket.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/L2capSocket.kt
@@ -1,0 +1,18 @@
+package com.atruedev.kmpble.l2cap
+
+import java.io.Closeable
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Abstraction over the socket surface that [AndroidL2capChannel] needs.
+ *
+ * Production code uses [BluetoothL2capSocket]; host tests use a fake
+ * backed by piped streams.
+ */
+internal interface L2capSocket : Closeable {
+    val inputStream: InputStream
+    val outputStream: OutputStream
+    val isConnected: Boolean
+    val maxTransmitPacketSize: Int
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -15,6 +15,7 @@ import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
+import com.atruedev.kmpble.l2cap.BluetoothL2capSocket
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -755,7 +756,7 @@ public class AndroidPeripheral internal constructor(
                     }
                 }
 
-                val channel = AndroidL2capChannel(socket, psm, peripheralContext.scope)
+                val channel = AndroidL2capChannel(BluetoothL2capSocket(socket), psm, peripheralContext.scope)
                 activeL2capChannels.update { it + channel }
 
                 peripheralContext.scope.launch {


### PR DESCRIPTION
## Summary
Implements L2CAP Connection-Oriented Channel support for Android, completing L2CAP support across both platforms.

**Use cases:**
- Firmware updates (DFU/OTA)
- Bulk data transfer
- High-frequency sensor streaming

**API:**
```kotlin
val channel = peripheral.openL2capChannel(psm = 0x25, secure = true)
channel.write(firmwareChunk)
channel.incoming.collect { response -> ... }
channel.close()
```

## Changes

- **New:** `AndroidL2capChannel` — wraps `BluetoothSocket` with coroutine-friendly suspend API
  - Read loop on `Dispatchers.IO` (never blocks caller)
  - Write dispatched to `Dispatchers.IO`
  - Thread-safe, idempotent `close()`
  - MTU from `maxReceivePacketSize`/`maxTransmitPacketSize` with 672-byte fallback
- **Modified:** `AndroidPeripheral.openL2capChannel()` — replaces TODO stub with real implementation
  - `secure = true` → `createL2capChannel()` (encrypted)
  - `secure = false` → `createInsecureL2capChannel()` (unencrypted)
  - API 29+ check with `NotSupported` exception
  - Active channel tracking for cleanup on disconnect
  - Channels closed in both `onDisconnectCleanup()` and `close()`
  - 30-second connection timeout

## Platform details

| Aspect | Detail |
|--------|--------|
| Min API | Android 10 (API 29) |
| Permission | `BLUETOOTH_CONNECT` (already declared) |
| Threading | All blocking I/O on `Dispatchers.IO` |
| Secure mode | Method-level (`createL2capChannel` vs `createInsecureL2capChannel`) |

## Test plan

- [x] All existing tests pass (`./gradlew allTests`)
- [x] Android compilation succeeds (`./gradlew compileDebugSources`)
- [x] iOS compilation succeeds — no regressions (`./gradlew compileKotlinIosArm64`)
- [x] L2CAP interface contract tested via `FakeL2capChannel` in commonTest
- [x] Manual testing with L2CAP-capable BLE device

## Breaking changes

None. Replaces TODO stub with working implementation.

## Related

- iOS L2CAP: PR #10 (merged)