### PR TITLE
docs: fix auto-approval for README update

### DIFF
--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -30,6 +30,7 @@ jobs:
           sed -i "s|implementation(\"com.atruedev:kmp-ble:[^\"]*\")|implementation(\"com.atruedev:kmp-ble:$VERSION\")|g" README.md
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "docs: update README for v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Added missing 'id: create-pr' to ensure subsequent auto-approve step triggers.