### PR TITLE
Add GATT server, extended advertising, pairing, and benchmarking

### DIFF
--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/App.kt
@@ -11,7 +11,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.adapter.BluetoothAdapter
+import com.atruedev.kmpble.connection.StateRestorationConfig
+import com.atruedev.kmpble.connection.enableStateRestoration
 import com.atruedev.kmpble.logging.BleLogConfig
 import com.atruedev.kmpble.logging.PrintBleLogger
 import com.atruedev.kmpble.scanner.Advertisement
@@ -19,12 +22,21 @@ import com.atruedev.kmpble.scanner.Advertisement
 sealed interface Screen {
     data object Scanner : Screen
     data class DeviceDetail(val advertisement: Advertisement) : Screen
+    data object Server : Screen
 }
 
+@OptIn(ExperimentalBleApi::class)
 @Composable
 fun App() {
     // Wire up structured logging to console
-    LaunchedEffect(Unit) { BleLogConfig.logger = PrintBleLogger() }
+    LaunchedEffect(Unit) {
+        BleLogConfig.logger = PrintBleLogger()
+
+        // Enable iOS Core Bluetooth state restoration.
+        // On Android this is a no-op. On iOS, this allows the system to restore
+        // BLE connections after the app is terminated in the background.
+        enableStateRestoration(StateRestorationConfig(identifier = "com.atruedev.kmpble.sample"))
+    }
 
     val adapter = remember { BluetoothAdapter() }
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Scanner) }
@@ -38,9 +50,13 @@ fun App() {
                     when (val screen = currentScreen) {
                         Screen.Scanner -> ScannerScreen(
                             onDeviceSelected = { currentScreen = Screen.DeviceDetail(it) },
+                            onServerTapped = { currentScreen = Screen.Server },
                         )
                         is Screen.DeviceDetail -> DeviceDetailScreen(
                             advertisement = screen.advertisement,
+                            onBack = { currentScreen = Screen.Scanner },
+                        )
+                        Screen.Server -> ServerScreen(
                             onBack = { currentScreen = Screen.Scanner },
                         )
                     }

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BleViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BleViewModel.kt
@@ -2,6 +2,13 @@ package com.atruedev.kmpble.sample
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.benchmark.LatencyTracker
+import com.atruedev.kmpble.benchmark.ThroughputMeter
+import com.atruedev.kmpble.benchmark.bleStopwatch
+import com.atruedev.kmpble.bonding.PairingEvent
+import com.atruedev.kmpble.bonding.PairingHandler
+import com.atruedev.kmpble.bonding.PairingResponse
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
@@ -16,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Lifecycle-scoped peripheral management.
@@ -46,6 +54,71 @@ class BleViewModel(advertisement: Advertisement) : ViewModel() {
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
+
+    // --- Pairing Handler ---
+    // Pending pairing event waiting for user response
+    private val _pairingEvent = MutableStateFlow<PairingEvent?>(null)
+    val pairingEvent: StateFlow<PairingEvent?> = _pairingEvent.asStateFlow()
+
+    // Continuation for pairing response
+    private var pairingContinuation: ((PairingResponse) -> Unit)? = null
+
+    @OptIn(ExperimentalBleApi::class)
+    val pairingHandler = PairingHandler { event ->
+        _pairingEvent.value = event
+        suspendCancellableCoroutine { cont ->
+            pairingContinuation = { response ->
+                _pairingEvent.value = null
+                pairingContinuation = null
+                cont.resumeWith(Result.success(response))
+            }
+        }
+    }
+
+    fun respondToPairing(response: PairingResponse) {
+        pairingContinuation?.invoke(response)
+    }
+
+    // --- Benchmark ---
+    private val _benchmarkResult = MutableStateFlow<String?>(null)
+    val benchmarkResult: StateFlow<String?> = _benchmarkResult.asStateFlow()
+
+    @OptIn(ExperimentalBleApi::class)
+    fun benchmarkConnect(options: ConnectionOptions) {
+        viewModelScope.launch {
+            try {
+                _benchmarkResult.value = "Benchmarking connect..."
+                peripheral.disconnect()
+                val result = bleStopwatch("connect") { peripheral.connect(options) }
+                _benchmarkResult.value = "Connect: ${result.duration}"
+            } catch (e: Exception) {
+                _benchmarkResult.value = "Error: ${formatError(e)}"
+            }
+        }
+    }
+
+    @OptIn(ExperimentalBleApi::class)
+    fun benchmarkReads(characteristic: Characteristic, count: Int = 10) {
+        viewModelScope.launch {
+            try {
+                _benchmarkResult.value = "Reading $count times..."
+                val meter = ThroughputMeter()
+                val latency = LatencyTracker()
+                meter.start()
+                repeat(count) {
+                    latency.measure {
+                        val data = peripheral.read(characteristic)
+                        meter.record(data.size)
+                    }
+                }
+                val throughput = meter.stop("reads")
+                val stats = latency.summarize("read latency")
+                _benchmarkResult.value = "$throughput\n$stats"
+            } catch (e: Exception) {
+                _benchmarkResult.value = "Error: ${formatError(e)}"
+            }
+        }
+    }
 
     fun connect(options: ConnectionOptions = ConnectionOptions()) {
         viewModelScope.launch {

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/DeviceDetailScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/DeviceDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -41,9 +40,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.bonding.BondState
+import com.atruedev.kmpble.bonding.PairingEvent
+import com.atruedev.kmpble.bonding.PairingResponse
 import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionRecipe
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.Characteristic
@@ -53,7 +56,7 @@ import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.scanner.Advertisement
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalBleApi::class)
 @Composable
 fun DeviceDetailScreen(
     advertisement: Advertisement,
@@ -70,6 +73,8 @@ fun DeviceDetailScreen(
     val mtu by vm.mtu.collectAsState()
     val maxWriteLen by vm.maximumWriteValueLength.collectAsState()
     val error by vm.error.collectAsState()
+    val pairingEvent by vm.pairingEvent.collectAsState()
+    val benchmarkResult by vm.benchmarkResult.collectAsState()
 
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -79,6 +84,11 @@ fun DeviceDetailScreen(
             snackbar.showSnackbar(it)
             vm.clearError()
         }
+    }
+
+    // Pairing dialog overlay
+    pairingEvent?.let { event ->
+        PairingDialog(event = event, onRespond = { vm.respondToPairing(it) })
     }
 
     Scaffold(
@@ -98,11 +108,14 @@ fun DeviceDetailScreen(
             modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            // Connection section
+            // Connection section with recipe picker
             item { ConnectionSection(state, bond, vm) }
 
             // Info section
             item { InfoSection(rssi, mtu, maxWriteLen, vm) }
+
+            // Benchmark section
+            item { BenchmarkSection(state, services, benchmarkResult, vm) }
 
             // Services section
             val serviceList = services
@@ -125,12 +138,21 @@ fun DeviceDetailScreen(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
+private enum class RecipeOption(val label: String) {
+    Custom("Custom"),
+    Medical("Medical"),
+    Fitness("Fitness"),
+    IoT("IoT"),
+    Consumer("Consumer"),
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalBleApi::class)
 @Composable
 private fun ConnectionSection(state: State, bond: BondState, vm: BleViewModel) {
     var autoConnect by remember { mutableStateOf(false) }
     var useReconnection by remember { mutableStateOf(false) }
     var bondingPref by remember { mutableStateOf(BondingPreference.IfRequired) }
+    var selectedRecipe by remember { mutableStateOf(RecipeOption.Custom) }
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -146,28 +168,42 @@ private fun ConnectionSection(state: State, bond: BondState, vm: BleViewModel) {
 
             Spacer(Modifier.height(8.dp))
 
-            // Connection options
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("autoConnect", style = MaterialTheme.typography.bodySmall)
-                Spacer(Modifier.width(8.dp))
-                Switch(checked = autoConnect, onCheckedChange = { autoConnect = it })
-            }
-
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Reconnection", style = MaterialTheme.typography.bodySmall)
-                Spacer(Modifier.width(8.dp))
-                Switch(checked = useReconnection, onCheckedChange = { useReconnection = it })
-            }
-
-            // Bonding preference chips
-            Text("Bonding", style = MaterialTheme.typography.bodySmall)
+            // Connection Recipe picker
+            Text("Connection Recipe", style = MaterialTheme.typography.bodySmall)
             FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                for (pref in BondingPreference.entries) {
+                for (recipe in RecipeOption.entries) {
                     FilterChip(
-                        selected = bondingPref == pref,
-                        onClick = { bondingPref = pref },
-                        label = { Text(pref.name, style = MaterialTheme.typography.labelSmall) },
+                        selected = selectedRecipe == recipe,
+                        onClick = { selectedRecipe = recipe },
+                        label = { Text(recipe.label, style = MaterialTheme.typography.labelSmall) },
                     )
+                }
+            }
+
+            // Show custom options only when Custom recipe is selected
+            if (selectedRecipe == RecipeOption.Custom) {
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("autoConnect", style = MaterialTheme.typography.bodySmall)
+                    Spacer(Modifier.width(8.dp))
+                    Switch(checked = autoConnect, onCheckedChange = { autoConnect = it })
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Reconnection", style = MaterialTheme.typography.bodySmall)
+                    Spacer(Modifier.width(8.dp))
+                    Switch(checked = useReconnection, onCheckedChange = { useReconnection = it })
+                }
+
+                Text("Bonding", style = MaterialTheme.typography.bodySmall)
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    for (pref in BondingPreference.entries) {
+                        FilterChip(
+                            selected = bondingPref == pref,
+                            onClick = { bondingPref = pref },
+                            label = { Text(pref.name, style = MaterialTheme.typography.labelSmall) },
+                        )
+                    }
                 }
             }
 
@@ -177,8 +213,12 @@ private fun ConnectionSection(state: State, bond: BondState, vm: BleViewModel) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = {
-                        vm.connect(
-                            ConnectionOptions(
+                        val options = when (selectedRecipe) {
+                            RecipeOption.Medical -> ConnectionRecipe.MEDICAL
+                            RecipeOption.Fitness -> ConnectionRecipe.FITNESS
+                            RecipeOption.IoT -> ConnectionRecipe.IOT
+                            RecipeOption.Consumer -> ConnectionRecipe.CONSUMER
+                            RecipeOption.Custom -> ConnectionOptions(
                                 autoConnect = autoConnect,
                                 bondingPreference = bondingPref,
                                 reconnectionStrategy = if (useReconnection) {
@@ -187,7 +227,11 @@ private fun ConnectionSection(state: State, bond: BondState, vm: BleViewModel) {
                                     ReconnectionStrategy.None
                                 },
                             )
-                        )
+                        }.let { base ->
+                            // Attach pairing handler to all connections
+                            base.copy(pairingHandler = vm.pairingHandler)
+                        }
+                        vm.connect(options)
                     },
                     enabled = state is State.Disconnected,
                 ) { Text("Connect") }
@@ -380,6 +424,136 @@ private fun PropertyBadge(label: String) {
         onClick = {},
         label = { Text(label, style = MaterialTheme.typography.labelSmall) },
     )
+}
+
+@OptIn(ExperimentalBleApi::class)
+@Composable
+private fun PairingDialog(event: PairingEvent, onRespond: (PairingResponse) -> Unit) {
+    var pinInput by remember { mutableStateOf("") }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Pairing Request", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            when (event) {
+                is PairingEvent.NumericComparison -> {
+                    Text(
+                        "Confirm the number matches: ${event.numericValue}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = { onRespond(PairingResponse.Confirm(true)) }) {
+                            Text("Confirm")
+                        }
+                        OutlinedButton(onClick = { onRespond(PairingResponse.Confirm(false)) }) {
+                            Text("Reject")
+                        }
+                    }
+                }
+
+                is PairingEvent.PasskeyRequest -> {
+                    Text("Enter the passkey:", style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(4.dp))
+                    OutlinedTextField(
+                        value = pinInput,
+                        onValueChange = { pinInput = it },
+                        label = { Text("PIN") },
+                        singleLine = true,
+                        modifier = Modifier.width(120.dp),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(
+                        onClick = { pinInput.toIntOrNull()?.let { onRespond(PairingResponse.ProvidePin(it)) } },
+                    ) { Text("Submit") }
+                }
+
+                is PairingEvent.PasskeyNotification -> {
+                    Text(
+                        "Passkey displayed on device: ${event.passkey}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = { onRespond(PairingResponse.Confirm(true)) }) {
+                        Text("OK")
+                    }
+                }
+
+                is PairingEvent.JustWorksConfirmation -> {
+                    Text("Allow pairing with this device?", style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = { onRespond(PairingResponse.Confirm(true)) }) {
+                            Text("Allow")
+                        }
+                        OutlinedButton(onClick = { onRespond(PairingResponse.Confirm(false)) }) {
+                            Text("Deny")
+                        }
+                    }
+                }
+
+                is PairingEvent.OutOfBandDataRequest -> {
+                    Text("OOB pairing requested. Providing empty OOB data.", style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = { onRespond(PairingResponse.ProvideOobData(ByteArray(16))) }) {
+                        Text("Provide OOB Data")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalBleApi::class)
+@Composable
+private fun BenchmarkSection(
+    state: State,
+    services: List<DiscoveredService>?,
+    benchmarkResult: String?,
+    vm: BleViewModel,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Benchmarks", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                "Measure connection time and GATT read throughput/latency.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            // Find the first readable characteristic for benchmarking
+            val readableChar = services?.flatMap { it.characteristics }
+                ?.firstOrNull { it.properties.read }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = { vm.benchmarkConnect(ConnectionOptions()) },
+                    enabled = state is State.Connected || state is State.Disconnected,
+                ) { Text("Bench Connect") }
+
+                OutlinedButton(
+                    onClick = { readableChar?.let { vm.benchmarkReads(it) } },
+                    enabled = state is State.Connected && readableChar != null,
+                ) { Text("Bench Reads") }
+            }
+
+            benchmarkResult?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
 }
 
 private fun stateLabel(state: State): String = when (state) {

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
@@ -17,16 +17,20 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -38,39 +42,62 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-fun ScannerScreen(onDeviceSelected: (Advertisement) -> Unit) {
+fun ScannerScreen(
+    onDeviceSelected: (Advertisement) -> Unit,
+    onServerTapped: () -> Unit = {},
+) {
     val devices = remember { mutableStateMapOf<Identifier, Advertisement>() }
     val scope = rememberCoroutineScope()
 
-    // Create a scanner with the filter DSL — FirstThenChanges deduplicates and
-    // only emits updates when RSSI changes significantly.
-    val scanner = remember {
-        Scanner {
-            emission = EmissionPolicy.FirstThenChanges(rssiThreshold = 5)
-        }
-    }
+    // Toggle between legacy-only and extended (BLE 5.0) scanning
+    var legacyOnly by remember { mutableStateOf(true) }
 
-    // Start scanning and close scanner on dispose
-    DisposableEffect(scanner) {
-        val scanJob = scope.launch {
+    // (Re)start scanning when legacyOnly changes
+    DisposableEffect(legacyOnly) {
+        devices.clear()
+        val scanner = Scanner {
+            emission = EmissionPolicy.FirstThenChanges(rssiThreshold = 5)
+            this.legacyOnly = legacyOnly
+        }
+        val job = scope.launch {
             scanner.advertisements.collect { advertisement ->
                 devices[advertisement.identifier] = advertisement
             }
         }
         onDispose {
-            scanJob.cancel()
+            job.cancel()
             scanner.close()
         }
     }
 
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("kmp-ble Scanner") })
+            TopAppBar(
+                title = { Text("kmp-ble Scanner") },
+                actions = {
+                    TextButton(onClick = onServerTapped) {
+                        Text("Server")
+                    }
+                },
+            )
         },
     ) { padding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
+            // BLE 5.0 extended advertising toggle
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Extended Ads (BLE 5.0)", style = MaterialTheme.typography.bodySmall)
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = !legacyOnly,
+                    onCheckedChange = { legacyOnly = !it },
+                )
+            }
+
             if (devices.isEmpty()) {
                 Column(
                     modifier = Modifier.fillMaxSize(),
@@ -144,6 +171,18 @@ private fun DeviceCard(advertisement: Advertisement, onClick: () -> Unit) {
                         )
                     }
                 }
+            }
+
+            // BLE 5.0 extended advertisement fields
+            if (!advertisement.isLegacy) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Extended | PHY: ${advertisement.primaryPhy}" +
+                        (advertisement.secondaryPhy?.let { " / $it" } ?: "") +
+                        (advertisement.advertisingSid?.let { " | SID: $it" } ?: ""),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
             }
 
             if (!advertisement.isConnectable) {

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
@@ -1,0 +1,368 @@
+package com.atruedev.kmpble.sample
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.scanner.uuidFrom
+import com.atruedev.kmpble.server.AdvertiseConfig
+import com.atruedev.kmpble.server.AdvertiseInterval
+import com.atruedev.kmpble.server.Advertiser
+import com.atruedev.kmpble.server.ExtendedAdvertiseConfig
+import com.atruedev.kmpble.server.ExtendedAdvertiser
+import com.atruedev.kmpble.server.GattServer
+import com.atruedev.kmpble.server.ServerConnectionEvent
+import kotlinx.coroutines.launch
+
+private val SAMPLE_SERVICE_UUID = uuidFrom("180D") // Heart Rate
+private val SAMPLE_CHAR_UUID = uuidFrom("2A37")    // Heart Rate Measurement
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalBleApi::class, ExperimentalLayoutApi::class)
+@Composable
+fun ServerScreen(onBack: () -> Unit) {
+    val scope = rememberCoroutineScope()
+    val snackbar = remember { SnackbarHostState() }
+
+    // GATT Server
+    var serverOpen by remember { mutableStateOf(false) }
+    var heartRate by remember { mutableStateOf(72) }
+    val server = remember {
+        GattServer {
+            service(SAMPLE_SERVICE_UUID) {
+                characteristic(SAMPLE_CHAR_UUID) {
+                    properties {
+                        read = true
+                        notify = true
+                    }
+                    permissions { read = true }
+                    onRead { _ -> BleData(byteArrayOf(0x00, heartRate.toByte())) }
+                }
+            }
+        }
+    }
+
+    // Legacy Advertiser
+    val advertiser = remember { Advertiser() }
+    val isAdvertising by advertiser.isAdvertising.collectAsState()
+
+    // Extended Advertiser (BLE 5.0)
+    val extAdvertiser = remember { ExtendedAdvertiser() }
+    val activeSets by extAdvertiser.activeSets.collectAsState()
+
+    // Connection events log
+    var connectionLog by remember { mutableStateOf(listOf<String>()) }
+
+    // Track server connection events
+    if (serverOpen) {
+        DisposableEffect(Unit) {
+            val job = scope.launch {
+                server.connectionEvents.collect { event ->
+                    val msg = when (event) {
+                        is ServerConnectionEvent.Connected -> "Connected: ${event.device.value.take(8)}"
+                        is ServerConnectionEvent.Disconnected -> "Disconnected: ${event.device.value.take(8)}"
+                    }
+                    connectionLog = (listOf(msg) + connectionLog).take(20)
+                }
+            }
+            onDispose { job.cancel() }
+        }
+    }
+
+    // Cleanup on dispose
+    DisposableEffect(Unit) {
+        onDispose {
+            advertiser.close()
+            extAdvertiser.close()
+            server.close()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("GATT Server & Advertiser") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Text("<", style = MaterialTheme.typography.titleLarge)
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // GATT Server section
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("GATT Server", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(8.dp))
+
+                        Text(
+                            "Hosts a Heart Rate service (0x180D) with a readable/notifiable measurement characteristic.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        FilterChip(
+                            selected = serverOpen,
+                            onClick = {},
+                            label = { Text(if (serverOpen) "Open" else "Closed") },
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            server.open()
+                                            serverOpen = true
+                                        } catch (e: Exception) {
+                                            snackbar.showSnackbar("Open failed: ${e.message}")
+                                        }
+                                    }
+                                },
+                                enabled = !serverOpen,
+                            ) { Text("Open") }
+
+                            OutlinedButton(
+                                onClick = {
+                                    server.close()
+                                    serverOpen = false
+                                },
+                                enabled = serverOpen,
+                            ) { Text("Close") }
+                        }
+
+                        if (serverOpen) {
+                            Spacer(Modifier.height(8.dp))
+
+                            // Heart rate simulator
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text("HR: $heartRate bpm", style = MaterialTheme.typography.bodySmall)
+                                OutlinedButton(onClick = { heartRate = (60..180).random() }) {
+                                    Text("Randomize")
+                                }
+                                OutlinedButton(
+                                    onClick = {
+                                        scope.launch {
+                                            try {
+                                                server.notify(
+                                                    SAMPLE_CHAR_UUID,
+                                                    null,
+                                                    BleData(byteArrayOf(0x00, heartRate.toByte())),
+                                                )
+                                            } catch (e: Exception) {
+                                                snackbar.showSnackbar("Notify failed: ${e.message}")
+                                            }
+                                        }
+                                    },
+                                ) { Text("Notify All") }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Legacy Advertiser section
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Legacy Advertiser", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(8.dp))
+
+                        FilterChip(
+                            selected = isAdvertising,
+                            onClick = {},
+                            label = { Text(if (isAdvertising) "Advertising" else "Stopped") },
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = {
+                                    try {
+                                        advertiser.startAdvertising(
+                                            AdvertiseConfig(
+                                                name = "kmp-ble Sample",
+                                                serviceUuids = listOf(SAMPLE_SERVICE_UUID),
+                                                connectable = true,
+                                            ),
+                                        )
+                                    } catch (e: Exception) {
+                                        scope.launch { snackbar.showSnackbar("Start failed: ${e.message}") }
+                                    }
+                                },
+                                enabled = !isAdvertising,
+                            ) { Text("Start") }
+
+                            OutlinedButton(
+                                onClick = { advertiser.stopAdvertising() },
+                                enabled = isAdvertising,
+                            ) { Text("Stop") }
+                        }
+                    }
+                }
+            }
+
+            // Extended Advertiser section (BLE 5.0)
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Extended Advertiser (BLE 5.0)", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(8.dp))
+
+                        Text(
+                            "Supports larger payloads, PHY selection, and multiple concurrent advertising sets.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        Text(
+                            "Active sets: ${activeSets.size}",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            extAdvertiser.startAdvertisingSet(
+                                                ExtendedAdvertiseConfig(
+                                                    name = "kmp-ble Ext",
+                                                    serviceUuids = listOf(SAMPLE_SERVICE_UUID),
+                                                    connectable = true,
+                                                    primaryPhy = Phy.Le1M,
+                                                    secondaryPhy = Phy.Le2M,
+                                                    interval = AdvertiseInterval.Balanced,
+                                                ),
+                                            )
+                                        } catch (e: Exception) {
+                                            snackbar.showSnackbar("Start failed: ${e.message}")
+                                        }
+                                    }
+                                },
+                            ) { Text("Add Set (1M/2M)") }
+
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            extAdvertiser.startAdvertisingSet(
+                                                ExtendedAdvertiseConfig(
+                                                    name = "kmp-ble LR",
+                                                    serviceUuids = listOf(SAMPLE_SERVICE_UUID),
+                                                    connectable = true,
+                                                    primaryPhy = Phy.LeCoded,
+                                                    secondaryPhy = Phy.LeCoded,
+                                                    interval = AdvertiseInterval.LowPower,
+                                                ),
+                                            )
+                                        } catch (e: Exception) {
+                                            snackbar.showSnackbar("Start failed: ${e.message}")
+                                        }
+                                    }
+                                },
+                            ) { Text("Add Set (Coded)") }
+                        }
+
+                        if (activeSets.isNotEmpty()) {
+                            Spacer(Modifier.height(8.dp))
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                for (setId in activeSets) {
+                                    FilterChip(
+                                        selected = true,
+                                        onClick = {
+                                            scope.launch { extAdvertiser.stopAdvertisingSet(setId) }
+                                        },
+                                        label = { Text("Set $setId (tap to stop)") },
+                                    )
+                                }
+                            }
+                        }
+
+                        Spacer(Modifier.height(4.dp))
+                        OutlinedButton(
+                            onClick = { extAdvertiser.close() },
+                            enabled = activeSets.isNotEmpty(),
+                        ) { Text("Stop All") }
+                    }
+                }
+            }
+
+            // Connection log
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Connection Events", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(8.dp))
+
+                        if (connectionLog.isEmpty()) {
+                            Text(
+                                "No connection events yet. Open the server and connect a client.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        } else {
+                            for (entry in connectionLog) {
+                                Text(entry, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+            }
+
+            item { Spacer(Modifier.height(16.dp)) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive BLE peripheral/server-side functionality and testing capabilities to the kmp-ble sample app, including GATT server hosting, BLE 5.0 extended advertising, pairing event handling, and performance benchmarking tools.

## Key Changes

### New Server Screen (`ServerScreen.kt`)
- Added a complete GATT server implementation that hosts a Heart Rate service (0x180D) with a readable/notifiable measurement characteristic
- Implemented legacy `Advertiser` for standard BLE advertising with configurable name and service UUIDs
- Implemented `ExtendedAdvertiser` (BLE 5.0) supporting:
  - Multiple concurrent advertising sets
  - PHY selection (1M, 2M, Coded)
  - Larger payload support
  - Configurable advertising intervals
- Added connection event logging to track device connections/disconnections
- Heart rate simulator with randomization and manual notification triggering

### Enhanced Device Detail Screen
- **Pairing Support**: Added `PairingDialog` UI component that handles multiple pairing methods:
  - Numeric comparison confirmation
  - Passkey entry and notification
  - Just Works confirmation
  - Out-of-Band (OOB) data requests
- **Connection Recipes**: Introduced preset connection profiles (Medical, Fitness, IoT, Consumer) alongside custom options for simplified connection setup
- **Benchmarking Section**: Added performance measurement tools:
  - Connection time benchmarking
  - GATT read throughput and latency measurement
  - Results display with formatted statistics

### ViewModel Enhancements (`BleViewModel.kt`)
- Integrated `PairingHandler` with suspend/resume pattern for interactive pairing flows
- Added `benchmarkConnect()` for measuring connection establishment time
- Added `benchmarkReads()` for measuring read throughput and latency using `ThroughputMeter` and `LatencyTracker`
- Proper state management for pairing events and benchmark results

### Scanner Screen Updates
- Added toggle for BLE 5.0 extended advertising discovery (legacy-only vs. extended)
- Added "Server" button in top app bar to navigate to server screen
- Display extended advertisement metadata (PHY, SID) for BLE 5.0 devices
- Dynamic scanner reconfiguration when toggling extended ads

### App Navigation
- Extended `Screen` sealed interface with `Server` screen variant
- Added state restoration configuration for iOS Core Bluetooth (no-op on Android)

## Notable Implementation Details
- Pairing handler uses Kotlin coroutines with `suspendCancellableCoroutine` for non-blocking UI interaction
- Connection recipes use `ConnectionRecipe` enum with preset `ConnectionOptions`
- Benchmarking utilities leverage experimental BLE API (`bleStopwatch`, `ThroughputMeter`, `LatencyTracker`)
- All new features properly marked with `@OptIn(ExperimentalBleApi::class)` annotations
- Proper resource cleanup with `DisposableEffect` for scanner and server lifecycle management

https://claude.ai/code/session_01W2kXzn2RkP8qN8BNV5F9AG