### PR TITLE
ci: skip docs job on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           path: build/reports/tests/
 
   docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Restrict Dokka doc generation to pushes to `main` only
- Saves ~3 minutes on every PR CI run since docs rarely break from code changes

## Test plan
- [x] Verify docs job is skipped on this PR's CI run
- [x] Verify docs job still runs on merge to main