### PR TITLE
docs: remove unverified consumer count from roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,7 @@ Quality:
 - CI green on both Android and iOS targets
 
 Community:
-- Validated in production by at least 3 external teams (currently 31 companies on Maven Central — track which are production)
+- Validated in production by at least 3 external teams
 - Migration guide published
 - API docs site live with full coverage
 


### PR DESCRIPTION
## Summary
- Removes the unverified "31 companies on Maven Central" claim from the v1.0 readiness criteria in ROADMAP.md

## Test plan
- [x] Verify ROADMAP.md renders correctly on GitHub