### PR TITLE
perf(dfu): eliminate hot-path allocations with zero-copy patterns

### DIFF
--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuDetector.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuDetector.kt
@@ -38,10 +38,9 @@ public object DfuDetector {
     @OptIn(ExperimentalUuidApi::class)
     public fun detect(peripheral: Peripheral): DfuProtocolType? {
         val services = peripheral.services.value ?: return null
-        val serviceUuids = services.map { it.uuid }.toSet()
 
         return serviceToProtocol.firstOrNull { (uuid, _) ->
-            uuid in serviceUuids
+            services.any { it.uuid == uuid }
         }?.second
     }
 }

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Cbor.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Cbor.kt
@@ -79,7 +79,7 @@ internal object Cbor {
     }
 
     /** Compute UTF-8 encoded byte length without allocating a ByteArray. */
-    private fun utf8ByteLength(s: String): Int {
+    internal fun utf8ByteLength(s: String): Int {
         var bytes = 0
         var i = 0
         while (i < s.length) {
@@ -174,8 +174,7 @@ internal object Cbor {
             0 -> value to nextOffset
             1 -> (-1 - value) to nextOffset
             2 -> {
-                val bytes = data.copyOfRange(nextOffset, nextOffset + value.toInt())
-                bytes to (nextOffset + value.toInt())
+                ByteSlice(data, nextOffset, value.toInt()) to (nextOffset + value.toInt())
             }
             3 -> {
                 val str = data.decodeToString(nextOffset, nextOffset + value.toInt())
@@ -217,10 +216,9 @@ private class CborWriter(private val target: ByteArray) {
                 pos += value.length
             }
             is String -> {
-                val bytes = value.encodeToByteArray()
-                writeHead(3, bytes.size.toLong())
-                bytes.copyInto(target, pos)
-                pos += bytes.size
+                val byteLen = Cbor.utf8ByteLength(value)
+                writeHead(3, byteLen.toLong())
+                pos = encodeUtf8Into(value, target, pos)
             }
             is Boolean -> {
                 target[pos++] = if (value) 0xF5.toByte() else 0xF4.toByte()
@@ -231,6 +229,40 @@ private class CborWriter(private val target: ByteArray) {
 
     fun writeInt(value: Long) {
         if (value >= 0) writeHead(0, value) else writeHead(1, -1 - value)
+    }
+
+    /** Encode a String as UTF-8 directly into [dest] at [startPos]. Returns the new position. */
+    private fun encodeUtf8Into(s: String, dest: ByteArray, startPos: Int): Int {
+        var p = startPos
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            when {
+                c.code <= 0x7F -> {
+                    dest[p++] = c.code.toByte()
+                }
+                c.code <= 0x7FF -> {
+                    dest[p++] = (0xC0 or (c.code shr 6)).toByte()
+                    dest[p++] = (0x80 or (c.code and 0x3F)).toByte()
+                }
+                c.isHighSurrogate() -> {
+                    val low = s[i + 1]
+                    val cp = 0x10000 + ((c.code - 0xD800) shl 10) + (low.code - 0xDC00)
+                    dest[p++] = (0xF0 or (cp shr 18)).toByte()
+                    dest[p++] = (0x80 or ((cp shr 12) and 0x3F)).toByte()
+                    dest[p++] = (0x80 or ((cp shr 6) and 0x3F)).toByte()
+                    dest[p++] = (0x80 or (cp and 0x3F)).toByte()
+                    i++ // skip low surrogate
+                }
+                else -> {
+                    dest[p++] = (0xE0 or (c.code shr 12)).toByte()
+                    dest[p++] = (0x80 or ((c.code shr 6) and 0x3F)).toByte()
+                    dest[p++] = (0x80 or (c.code and 0x3F)).toByte()
+                }
+            }
+            i++
+        }
+        return p
     }
 
     fun writeHead(majorType: Int, value: Long) {
@@ -270,4 +302,14 @@ private class CborWriter(private val target: ByteArray) {
  * of a larger array. The encoder copies directly from [source] into the output buffer,
  * so no intermediate allocation is required.
  */
-internal class ByteSlice(val source: ByteArray, val offset: Int, val length: Int)
+internal class ByteSlice(val source: ByteArray, val offset: Int, val length: Int) {
+    fun toByteArray(): ByteArray = source.copyOfRange(offset, offset + length)
+
+    fun contentEquals(other: ByteArray): Boolean {
+        if (length != other.size) return false
+        for (i in 0 until length) {
+            if (source[offset + i] != other[i]) return false
+        }
+        return true
+    }
+}

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/PacketWriter.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/PacketWriter.kt
@@ -20,9 +20,19 @@ internal class PacketWriter(
         var pos = offset
         var packetCount = 0
 
+        // Pre-allocate a single reusable buffer for full-sized packets.
+        // Only the final (potentially shorter) packet allocates a fresh array.
+        val packetBuffer = ByteArray(packetSize)
+
         while (pos < data.size) {
             val end = min(pos + packetSize, data.size)
-            transport.sendData(data.copyOfRange(pos, end))
+            val len = end - pos
+            data.copyInto(packetBuffer, 0, pos, end)
+            if (len == packetSize) {
+                transport.sendData(packetBuffer)
+            } else {
+                transport.sendData(packetBuffer.copyOfRange(0, len))
+            }
             pos = end
             packetCount++
 

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
@@ -63,8 +63,18 @@ internal object Sha256 {
         return result
     }
 
-    fun digestHex(data: ByteArray): String =
-        digest(data).joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+    private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+    fun digestHex(data: ByteArray): String {
+        val hash = digest(data)
+        val chars = CharArray(64)
+        for (i in hash.indices) {
+            val b = hash[i].toInt() and 0xFF
+            chars[i * 2] = HEX_CHARS[b shr 4]
+            chars[i * 2 + 1] = HEX_CHARS[b and 0x0F]
+        }
+        return String(chars)
+    }
 
     private fun processBlock(h: UIntArray, w: UIntArray, data: ByteArray, blockStart: Int) {
         for (t in 0 until 16) {

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/EspOtaDfuProtocol.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/EspOtaDfuProtocol.kt
@@ -50,9 +50,16 @@ public class EspOtaDfuProtocol : DfuProtocol {
         val firmwareData = firmware.firmware
         val tracker = ThroughputTracker()
         val chunkSize = transport.mtu
+        val sha256 = Sha256.digest(firmwareData)
+
+        // Pre-allocate a single reusable buffer for full-sized chunks.
+        // Only the final (potentially shorter) chunk allocates a fresh array.
+        val chunkBuffer = ByteArray(chunkSize)
 
         // ESP OTA does not support resume — a fresh OTA Begin is required on
         // each attempt because the device resets its OTA state on error.
+        // Hash verification and OTA End are inside retry scope: if the
+        // device drops mid-verify, the entire transfer retries from scratch.
         retryOnFailure(options.retryCount, options.retryDelay) {
             val beginResponse = transport.sendCommand(encodeOtaBegin(firmwareData.size))
             validateResponse(beginResponse, EspOtaOpcode.OTA_BEGIN.toInt(), "OTA Begin")
@@ -63,8 +70,13 @@ public class EspOtaDfuProtocol : DfuProtocol {
                 currentCoroutineContext().ensureActive()
 
                 val end = min(offset + chunkSize, firmwareData.size)
-                val chunk = firmwareData.copyOfRange(offset, end)
-                transport.sendData(chunk)
+                val len = end - offset
+                firmwareData.copyInto(chunkBuffer, 0, offset, end)
+                if (len == chunkSize) {
+                    transport.sendData(chunkBuffer)
+                } else {
+                    transport.sendData(chunkBuffer.copyOfRange(0, len))
+                }
                 offset = end
 
                 tracker.record(offset.toLong())
@@ -78,13 +90,12 @@ public class EspOtaDfuProtocol : DfuProtocol {
                     ),
                 )
             }
+
+            emit(DfuProgress.Verifying(0))
+
+            val endResponse = transport.sendCommand(encodeOtaEnd(sha256))
+            validateResponse(endResponse, EspOtaOpcode.OTA_END.toInt(), "OTA End")
         }
-
-        emit(DfuProgress.Verifying(0))
-
-        val sha256 = Sha256.digest(firmwareData)
-        val endResponse = transport.sendCommand(encodeOtaEnd(sha256))
-        validateResponse(endResponse, EspOtaOpcode.OTA_END.toInt(), "OTA End")
 
         emit(DfuProgress.Completing)
 

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeader.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeader.kt
@@ -21,17 +21,6 @@ internal data class SmpHeader(
     val sequence: Int,
     val commandId: Int,
 ) {
-    fun encode(): ByteArray = byteArrayOf(
-        op.toByte(),
-        flags.toByte(),
-        (length shr 8).toByte(),
-        (length and 0xFF).toByte(),
-        (group shr 8).toByte(),
-        (group and 0xFF).toByte(),
-        sequence.toByte(),
-        commandId.toByte(),
-    )
-
     /** Write this header directly into [target] at [offset]. No intermediate allocation. */
     fun encodeInto(target: ByteArray, offset: Int = 0) {
         target[offset] = op.toByte()

--- a/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/internal/CborTest.kt
+++ b/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/internal/CborTest.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.dfu.internal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class CborTest {
 
@@ -27,8 +28,8 @@ class CborTest {
         val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
         val encoded = Cbor.encodeMap(mapOf(0 to payload))
         val decoded = Cbor.decodeMap(encoded)
-        val result = assertIs<ByteArray>(decoded[0])
-        assertEquals(payload.toList(), result.toList())
+        val result = assertIs<ByteSlice>(decoded[0])
+        assertTrue(result.contentEquals(payload))
     }
 
     @Test
@@ -73,7 +74,7 @@ class CborTest {
         )
         val decoded = Cbor.decodeMap(encoded)
         assertEquals(4, decoded.size)
-        assertIs<ByteArray>(decoded[0])
+        assertIs<ByteSlice>(decoded[0])
         assertEquals(256L, decoded[1])
         assertEquals("firmware", decoded[2])
         assertEquals(0L, decoded[3])
@@ -84,8 +85,26 @@ class CborTest {
         val largePayload = ByteArray(300) { it.toByte() }
         val encoded = Cbor.encodeMap(mapOf(0 to largePayload))
         val decoded = Cbor.decodeMap(encoded)
-        val result = assertIs<ByteArray>(decoded[0])
-        assertEquals(300, result.size)
-        assertEquals(largePayload.toList(), result.toList())
+        val result = assertIs<ByteSlice>(decoded[0])
+        assertEquals(300, result.length)
+        assertEquals(largePayload.toList(), result.toByteArray().toList())
+    }
+
+    @Test
+    fun byteSliceRoundTripThroughEncoder() {
+        val source = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
+        val slice = ByteSlice(source, 1, 2) // [0xBB, 0xCC]
+        val encoded = Cbor.encodeMap(mapOf(0 to slice))
+        val decoded = Cbor.decodeMap(encoded)
+        val result = assertIs<ByteSlice>(decoded[0])
+        assertTrue(result.contentEquals(byteArrayOf(0xBB.toByte(), 0xCC.toByte())))
+    }
+
+    @Test
+    fun utf8MultiByteStringRoundTrip() {
+        val encoded = Cbor.encodeStringMap(mapOf("café" to 1, "日本語" to 2))
+        val decoded = Cbor.decodeStringMap(encoded)
+        assertEquals(1L, decoded["café"])
+        assertEquals(2L, decoded["日本語"])
     }
 }

--- a/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/protocol/McuBootDfuProtocolTest.kt
+++ b/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/protocol/McuBootDfuProtocolTest.kt
@@ -114,7 +114,10 @@ class McuBootDfuProtocolTest {
             sequence = 0,
             commandId = 0,
         )
-        return header.encode() + payload
+        val packet = ByteArray(SmpHeader.SIZE + payload.size)
+        header.encodeInto(packet)
+        payload.copyInto(packet, SmpHeader.SIZE)
+        return packet
     }
 
 }

--- a/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeaderTest.kt
+++ b/kmp-ble-dfu/src/commonTest/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeaderTest.kt
@@ -5,6 +5,12 @@ import kotlin.test.assertEquals
 
 class SmpHeaderTest {
 
+    private fun SmpHeader.encodeToByteArray(): ByteArray {
+        val buf = ByteArray(SmpHeader.SIZE)
+        encodeInto(buf)
+        return buf
+    }
+
     @Test
     fun roundTripEncodeDecode() {
         val header = SmpHeader(
@@ -15,7 +21,7 @@ class SmpHeaderTest {
             sequence = 42,
             commandId = SmpCommand.IMAGE_UPLOAD,
         )
-        val encoded = header.encode()
+        val encoded = header.encodeToByteArray()
         assertEquals(SmpHeader.SIZE, encoded.size)
 
         val decoded = SmpHeader.decode(encoded)
@@ -25,7 +31,7 @@ class SmpHeaderTest {
     @Test
     fun encodesBigEndianLength() {
         val header = SmpHeader(op = 0, flags = 0, length = 0x0102, group = 0, sequence = 0, commandId = 0)
-        val encoded = header.encode()
+        val encoded = header.encodeToByteArray()
         assertEquals(0x01.toByte(), encoded[2])
         assertEquals(0x02.toByte(), encoded[3])
     }
@@ -33,7 +39,7 @@ class SmpHeaderTest {
     @Test
     fun encodesBigEndianGroup() {
         val header = SmpHeader(op = 0, flags = 0, length = 0, group = 0x0304, sequence = 0, commandId = 0)
-        val encoded = header.encode()
+        val encoded = header.encodeToByteArray()
         assertEquals(0x03.toByte(), encoded[4])
         assertEquals(0x04.toByte(), encoded[5])
     }
@@ -42,7 +48,7 @@ class SmpHeaderTest {
     fun decodeFromOffset() {
         val prefix = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
         val header = SmpHeader(op = 2, flags = 0, length = 10, group = 1, sequence = 5, commandId = 1)
-        val data = prefix + header.encode()
+        val data = prefix + header.encodeToByteArray()
         val decoded = SmpHeader.decode(data, offset = 2)
         assertEquals(header, decoded)
     }
@@ -50,7 +56,7 @@ class SmpHeaderTest {
     @Test
     fun zeroLengthHeader() {
         val header = SmpHeader(op = SmpOp.READ, flags = 0, length = 0, group = 0, sequence = 0, commandId = 0)
-        val encoded = header.encode()
+        val encoded = header.encodeToByteArray()
         val decoded = SmpHeader.decode(encoded)
         assertEquals(0, decoded.length)
         assertEquals(SmpOp.READ, decoded.op)


### PR DESCRIPTION
- Replace String.encodeToByteArray() in CBOR encoder with direct UTF-8 encoding into pre-allocated target buffer (encodeUtf8Into)
- Return ByteSlice views instead of copyOfRange in CBOR decoder
- Pre-allocate and reuse chunk buffers in PacketWriter and EspOtaDfuProtocol instead of allocating per iteration
- Replace joinToString hex encoding in Sha256 with zero-alloc CharArray + lookup table
- Remove allocating SmpHeader.encode() in favor of encodeInto()
- Eliminate intermediate List+HashSet in DfuDetector
- Move hash verification inside retryOnFailure scope in ESP OTA
- Add ByteSlice.toByteArray(), ByteSlice.contentEquals() helpers
- Add CBOR ByteSlice round-trip and UTF-8 multi-byte string tests