### PR TITLE
fix(server): handle Prepared Write (Write Long) in GattServer

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -426,55 +426,30 @@ internal class AndroidGattServer(
                         return@launch
                     }
 
-                    val assembled = assembleWriteFragments(fragments)
-                    var failed = false
-
-                    for (write in assembled) {
-                        val handler = writeHandlers[write.charUuid]
-                        if (handler == null) {
+                    when (val result = assembleWriteFragments(fragments)) {
+                        is AssemblyResult.PayloadTooLarge -> {
                             logEvent(
                                 BleLogEvent.ServerRequest(
                                     deviceId,
-                                    "execute-write-rejected (no handler)",
-                                    write.charUuid,
-                                    GattStatus.WriteNotPermitted,
+                                    "execute-write-rejected (${result.actualSize}B exceeds limit)",
+                                    result.charUuid,
+                                    GattStatus.InvalidAttributeLength,
                                 ),
                             )
-                            failed = true
-                            break
+                            sendResponseSafe(
+                                device,
+                                requestId,
+                                BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
+                                0,
+                                null,
+                            )
                         }
 
-                        try {
-                            val status = handler(deviceId, BleData(write.data), true)
-                            logEvent(
-                                BleLogEvent.ServerRequest(
-                                    deviceId,
-                                    "execute-write (${write.data.size}B)",
-                                    write.charUuid,
-                                    status,
-                                ),
-                            )
-                            if (status != null && status != GattStatus.Success) {
-                                failed = true
-                                break
-                            }
-                        } catch (e: Exception) {
-                            if (e is kotlinx.coroutines.CancellationException) throw e
-                            logEvent(
-                                BleLogEvent.ServerRequest(
-                                    deviceId,
-                                    "execute-write-failed (handler threw)",
-                                    write.charUuid,
-                                    GattStatus.Failure,
-                                ),
-                            )
-                            failed = true
-                            break
+                        is AssemblyResult.Success -> {
+                            val gattStatus = dispatchAssembledWrites(deviceId, result.writes)
+                            sendResponseSafe(device, requestId, gattStatus, 0, null)
                         }
                     }
-
-                    val resultStatus = if (failed) BluetoothGatt.GATT_FAILURE else BluetoothGatt.GATT_SUCCESS
-                    sendResponseSafe(device, requestId, resultStatus, 0, null)
                 }
             }
 
@@ -893,11 +868,7 @@ internal class AndroidGattServer(
         }
 
         val buffer = preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
-        val projectedSize =
-            maxOf(
-                buffer.maxOfOrNull { it.offset + it.bytes.size } ?: 0,
-                offset + (value?.size ?: 0),
-            )
+        val projectedSize = projectedBufferSize(buffer, offset, value?.size ?: 0)
         if (projectedSize > MAX_PREPARED_WRITE_BUFFER_BYTES) {
             preparedWriteBuffer.remove(device.address)
             logEvent(
@@ -926,6 +897,53 @@ internal class AndroidGattServer(
         if (responseNeeded) {
             sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
         }
+    }
+
+    private suspend fun dispatchAssembledWrites(
+        deviceId: Identifier,
+        writes: List<AssembledWrite>,
+    ): Int {
+        for (write in writes) {
+            val handler = writeHandlers[write.charUuid]
+            if (handler == null) {
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write-rejected (no handler)",
+                        write.charUuid,
+                        GattStatus.WriteNotPermitted,
+                    ),
+                )
+                return BluetoothGatt.GATT_FAILURE
+            }
+
+            try {
+                val status = handler(deviceId, BleData(write.data), true)
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write (${write.data.size}B)",
+                        write.charUuid,
+                        status,
+                    ),
+                )
+                if (status != null && status != GattStatus.Success) {
+                    return BluetoothGatt.GATT_FAILURE
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write-failed (handler threw)",
+                        write.charUuid,
+                        GattStatus.Failure,
+                    ),
+                )
+                return BluetoothGatt.GATT_FAILURE
+            }
+        }
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     private fun sendResponseSafe(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/PreparedWriteAssembler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/PreparedWriteAssembler.kt
@@ -2,42 +2,86 @@ package com.atruedev.kmpble.server
 
 import kotlin.uuid.Uuid
 
-internal class WriteFragment(
+internal data class WriteFragment(
     val charUuid: Uuid,
     val offset: Int,
     val bytes: ByteArray,
-)
+) {
+    override fun equals(other: Any?): Boolean =
+        other is WriteFragment &&
+            charUuid == other.charUuid &&
+            offset == other.offset &&
+            bytes.contentEquals(other.bytes)
 
-internal class AssembledWrite(
+    override fun hashCode(): Int {
+        var result = charUuid.hashCode()
+        result = 31 * result + offset
+        result = 31 * result + bytes.contentHashCode()
+        return result
+    }
+}
+
+internal data class AssembledWrite(
     val charUuid: Uuid,
     val data: ByteArray,
-)
+) {
+    override fun equals(other: Any?): Boolean =
+        other is AssembledWrite && charUuid == other.charUuid && data.contentEquals(other.data)
 
-/** BLE spec: maximum characteristic value length (Core Spec Vol 3, Part F, 3.2.9). */
+    override fun hashCode(): Int = 31 * charUuid.hashCode() + data.contentHashCode()
+}
+
+/** BLE Core Spec Vol 3, Part F, 3.2.9: maximum characteristic value length. */
 internal const val MAX_CHARACTERISTIC_VALUE_SIZE = 512
 
-/** Server-side cap on buffered Prepared Write bytes per device to bound memory usage. */
+/** Per-device cap on total buffered Prepared Write bytes across all characteristics. */
 internal const val MAX_PREPARED_WRITE_BUFFER_BYTES = 4096
+
+internal sealed class AssemblyResult {
+    data class Success(
+        val writes: List<AssembledWrite>,
+    ) : AssemblyResult()
+
+    data class PayloadTooLarge(
+        val charUuid: Uuid,
+        val actualSize: Int,
+    ) : AssemblyResult()
+}
 
 /**
  * Assemble Prepared Write fragments into contiguous byte arrays, grouped by characteristic.
  *
- * Fragments are sorted by offset. Overlapping ranges use last-write-wins semantics
- * (BLE Reliable Write behavior). Throws [IllegalArgumentException] if the assembled
- * size exceeds [MAX_CHARACTERISTIC_VALUE_SIZE].
+ * Fragments are sorted by offset within each group. Overlapping ranges use
+ * last-write-wins semantics per BLE Reliable Write behavior.
  */
-internal fun assembleWriteFragments(fragments: List<WriteFragment>): List<AssembledWrite> =
-    fragments
-        .groupBy { it.charUuid }
-        .map { (charUuid, charFragments) ->
-            val sorted = charFragments.sortedBy { it.offset }
-            val totalSize = sorted.maxOf { it.offset + it.bytes.size }
-            require(totalSize <= MAX_CHARACTERISTIC_VALUE_SIZE) {
-                "Assembled write ($totalSize bytes) exceeds BLE max characteristic value size ($MAX_CHARACTERISTIC_VALUE_SIZE)"
+internal fun assembleWriteFragments(fragments: List<WriteFragment>): AssemblyResult {
+    if (fragments.isEmpty()) return AssemblyResult.Success(emptyList())
+
+    val writes =
+        fragments
+            .groupBy { it.charUuid }
+            .map { (charUuid, charFragments) ->
+                val sorted = charFragments.sortedBy { it.offset }
+                val totalSize = sorted.maxOf { it.offset + it.bytes.size }
+                if (totalSize > MAX_CHARACTERISTIC_VALUE_SIZE) {
+                    return AssemblyResult.PayloadTooLarge(charUuid, totalSize)
+                }
+                val assembled = ByteArray(totalSize)
+                for (fragment in sorted) {
+                    fragment.bytes.copyInto(assembled, destinationOffset = fragment.offset)
+                }
+                AssembledWrite(charUuid, assembled)
             }
-            val assembled = ByteArray(totalSize)
-            for (fragment in sorted) {
-                fragment.bytes.copyInto(assembled, destinationOffset = fragment.offset)
-            }
-            AssembledWrite(charUuid, assembled)
-        }
+    return AssemblyResult.Success(writes)
+}
+
+/** Total projected byte footprint of buffered fragments (max end-offset across all entries). */
+internal fun projectedBufferSize(
+    buffer: List<WriteFragment>,
+    newOffset: Int,
+    newSize: Int,
+): Int =
+    maxOf(
+        buffer.maxOfOrNull { it.offset + it.bytes.size } ?: 0,
+        newOffset + newSize,
+    )

--- a/src/commonTest/kotlin/com/atruedev/kmpble/server/PreparedWriteAssemblerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/server/PreparedWriteAssemblerTest.kt
@@ -1,0 +1,148 @@
+package com.atruedev.kmpble.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class PreparedWriteAssemblerTest {
+    private val charA = Uuid.parse("0000aa01-0000-1000-8000-00805f9b34fb")
+    private val charB = Uuid.parse("0000aa02-0000-1000-8000-00805f9b34fb")
+
+    @Test
+    fun empty_fragments_returns_empty_list() {
+        val result = assembleWriteFragments(emptyList())
+        assertIs<AssemblyResult.Success>(result)
+        assertTrue(result.writes.isEmpty())
+    }
+
+    @Test
+    fun single_fragment_at_offset_zero() {
+        val data = byteArrayOf(1, 2, 3)
+        val result = assembleWriteFragments(listOf(WriteFragment(charA, 0, data)))
+
+        assertIs<AssemblyResult.Success>(result)
+        assertEquals(1, result.writes.size)
+        assertEquals(charA, result.writes[0].charUuid)
+        assertTrue(data.contentEquals(result.writes[0].data))
+    }
+
+    @Test
+    fun multiple_sequential_fragments_assembled_in_order() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, byteArrayOf(0x10, 0x20)),
+                WriteFragment(charA, 2, byteArrayOf(0x30, 0x40)),
+                WriteFragment(charA, 4, byteArrayOf(0x50)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        assertEquals(1, result.writes.size)
+        assertTrue(byteArrayOf(0x10, 0x20, 0x30, 0x40, 0x50).contentEquals(result.writes[0].data))
+    }
+
+    @Test
+    fun out_of_order_fragments_sorted_by_offset() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 3, byteArrayOf(0x40)),
+                WriteFragment(charA, 0, byteArrayOf(0x10)),
+                WriteFragment(charA, 1, byteArrayOf(0x20, 0x30)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        assertTrue(byteArrayOf(0x10, 0x20, 0x30, 0x40).contentEquals(result.writes[0].data))
+    }
+
+    @Test
+    fun overlapping_fragments_use_last_write_wins() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())),
+                WriteFragment(charA, 1, byteArrayOf(0xDD.toByte(), 0xEE.toByte())),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        // Byte at offset 1 overwritten by second fragment
+        assertTrue(byteArrayOf(0xAA.toByte(), 0xDD.toByte(), 0xEE.toByte()).contentEquals(result.writes[0].data))
+    }
+
+    @Test
+    fun multiple_characteristics_grouped_independently() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, byteArrayOf(1, 2)),
+                WriteFragment(charB, 0, byteArrayOf(3, 4, 5)),
+                WriteFragment(charA, 2, byteArrayOf(6)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        assertEquals(2, result.writes.size)
+
+        val writeA = result.writes.first { it.charUuid == charA }
+        val writeB = result.writes.first { it.charUuid == charB }
+        assertTrue(byteArrayOf(1, 2, 6).contentEquals(writeA.data))
+        assertTrue(byteArrayOf(3, 4, 5).contentEquals(writeB.data))
+    }
+
+    @Test
+    fun exceeding_max_characteristic_size_returns_payload_too_large() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, ByteArray(MAX_CHARACTERISTIC_VALUE_SIZE + 1)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.PayloadTooLarge>(result)
+        assertEquals(charA, result.charUuid)
+        assertEquals(MAX_CHARACTERISTIC_VALUE_SIZE + 1, result.actualSize)
+    }
+
+    @Test
+    fun exactly_max_characteristic_size_succeeds() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, ByteArray(MAX_CHARACTERISTIC_VALUE_SIZE)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        assertEquals(MAX_CHARACTERISTIC_VALUE_SIZE, result.writes[0].data.size)
+    }
+
+    @Test
+    fun offset_gap_leaves_zero_filled_bytes() {
+        val fragments =
+            listOf(
+                WriteFragment(charA, 0, byteArrayOf(0x01)),
+                WriteFragment(charA, 4, byteArrayOf(0x05)),
+            )
+
+        val result = assembleWriteFragments(fragments)
+        assertIs<AssemblyResult.Success>(result)
+        val data = result.writes[0].data
+        assertEquals(5, data.size)
+        assertEquals(0x01, data[0])
+        assertEquals(0x00, data[1])
+        assertEquals(0x00, data[2])
+        assertEquals(0x00, data[3])
+        assertEquals(0x05, data[4])
+    }
+
+    @Test
+    fun projected_buffer_size_with_empty_buffer() {
+        assertEquals(10, projectedBufferSize(emptyList(), 0, 10))
+    }
+
+    @Test
+    fun projected_buffer_size_accounts_for_existing_fragments() {
+        val existing = listOf(WriteFragment(charA, 0, ByteArray(20)))
+        assertEquals(20, projectedBufferSize(existing, 5, 10))
+        assertEquals(25, projectedBufferSize(existing, 5, 20))
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -384,9 +384,19 @@ internal class IosGattServer(
         val firstRequest = requests.first()
 
         scope.launch {
+            // CoreBluetooth delivers fragmented writes as a batch with non-zero offsets
+            val hasFragments = requests.any { it.offset.toInt() > 0 }
             val writes: List<Pair<Uuid, BleData>> =
-                if (requests.any { it.offset.toInt() > 0 }) {
-                    assembleFragmentedWrites(requests)
+                if (hasFragments) {
+                    val assembled = assembleFragmentedWrites(requests)
+                    if (assembled == null) {
+                        peripheral.respondToRequest(
+                            firstRequest,
+                            withResult = CBATTErrorInvalidAttributeValueLength,
+                        )
+                        return@launch
+                    }
+                    assembled
                 } else {
                     requests.map { request ->
                         val data = if (request.value != null) bleDataFromNSData(request.value!!) else emptyBleData()
@@ -394,13 +404,8 @@ internal class IosGattServer(
                     }
                 }
 
-            val result = dispatchWrites(requests.first().centralId, requests.first().central, writes)
-
-            if (result != null) {
-                peripheral.respondToRequest(firstRequest, withResult = result)
-            } else {
-                peripheral.respondToRequest(firstRequest, withResult = CBATTErrorSuccess)
-            }
+            val errorCode = dispatchWrites(requests.first().centralId, requests.first().central, writes)
+            peripheral.respondToRequest(firstRequest, withResult = errorCode ?: CBATTErrorSuccess)
         }
     }
 
@@ -445,14 +450,27 @@ internal class IosGattServer(
         return null
     }
 
-    private fun assembleFragmentedWrites(requests: List<CBATTRequest>): List<Pair<Uuid, BleData>> {
+    private fun assembleFragmentedWrites(requests: List<CBATTRequest>): List<Pair<Uuid, BleData>>? {
         val fragments =
             requests.map { request ->
                 val nsData = request.value
                 val bytes = if (nsData != null) bleDataFromNSData(nsData).toByteArray() else byteArrayOf()
                 WriteFragment(request.charUuid, request.offset.toInt(), bytes)
             }
-        return assembleWriteFragments(fragments).map { it.charUuid to BleData(it.data) }
+        return when (val result = assembleWriteFragments(fragments)) {
+            is AssemblyResult.Success -> result.writes.map { it.charUuid to BleData(it.data) }
+            is AssemblyResult.PayloadTooLarge -> {
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        requests.first().centralId,
+                        "write-rejected (${result.actualSize}B exceeds limit)",
+                        result.charUuid,
+                        GattStatus.InvalidAttributeLength,
+                    ),
+                )
+                null
+            }
+        }
     }
 
     private fun handleSubscribe(


### PR DESCRIPTION
## Problem

GattServer rejected all Prepared Write requests with `RequestNotSupported`. When a central writes data larger than ATT_MTU, the BLE stack splits it into Prepare Write + Execute Write requests. Rejecting these caused silent data truncation — only the first MTU-sized chunk reached the `onWrite` handler.

Discovered via kmp-uwb where serialized `NIDiscoveryToken` (~150 bytes) was truncated to 20 bytes during BLE OOB exchange.

## Approach

Extract fragment assembly into a shared pure function in `commonMain` (`PreparedWriteAssembler.kt`), used by both platform implementations.

**Shared (`commonMain`):**
- `assembleWriteFragments()` groups fragments by characteristic, sorts by offset, validates against BLE spec max (512 bytes), and assembles into contiguous byte arrays
- Returns sealed `AssemblyResult` (Success | PayloadTooLarge) instead of throwing — callers handle errors explicitly
- `WriteFragment` / `AssembledWrite` as data classes for structural equality
- `projectedBufferSize()` pure function for offset-aware buffer limit checks

**Android:**
- Buffer `preparedWrite=true` fragments per device on the `limitedParallelism(1)` dispatcher
- On `onExecuteWrite`, assemble via `AssemblyResult` `when` dispatch and deliver complete payload
- Clean up buffer on disconnect or cancel
- Extract `dispatchAssembledWrites` to eliminate inline handler loop

**iOS:**
- Detect fragmented `CBATTRequest` batches via non-zero `offset`
- Assemble before dispatching to write handlers, with explicit error handling for `PayloadTooLarge`
- Extract `dispatchWrites` to share handler invocation between single and assembled write paths

## Test plan
- [x] `compileKotlinIosSimulatorArm64`
- [x] `compileDebugKotlin`
- [x] `testAndroidHostTest` — including new `PreparedWriteAssemblerTest` (9 tests covering assembly ordering, overlap, multi-characteristic grouping, boundary validation, gap fill, projected buffer size)
- [x] `ktlintCheck`
- [x] Manual: kmp-uwb BLE OOB exchange with default MTU