### PR TITLE
fix(server): harden Prepared Write with shared assembler and buffer limits

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -156,16 +156,9 @@ internal class AndroidGattServer(
     private val readHandlers = mutableMapOf<Uuid, suspend (Identifier) -> BleData>()
     private val writeHandlers = mutableMapOf<Uuid, suspend (Identifier, BleData, Boolean) -> GattStatus?>()
 
-    // Prepared Write (Write Long) buffer: per-device accumulation of chunks.
-    // Key = device address, Value = list of (characteristicUuid, offset, bytes).
-    // Filled during preparedWrite requests, drained on executeWrite.
-    private data class PreparedChunk(
-        val charUuid: Uuid,
-        val offset: Int,
-        val value: ByteArray,
-    )
-
-    private val preparedWriteBuffer = mutableMapOf<String, MutableList<PreparedChunk>>()
+    // Prepared Write (Write Long) buffer: per-device fragment accumulation.
+    // Filled during preparedWrite requests, drained on executeWrite or disconnect.
+    private val preparedWriteBuffer = mutableMapOf<String, MutableList<WriteFragment>>()
 
     // O(1) lookup cache: characteristic UUID -> native characteristic (built during open)
     private val characteristicCache = mutableMapOf<Uuid, BluetoothGattCharacteristic>()
@@ -225,6 +218,7 @@ internal class AndroidGattServer(
                         BluetoothProfile.STATE_DISCONNECTED -> {
                             connectedDevices.remove(deviceId)
                             deviceMtu.remove(deviceId)
+                            preparedWriteBuffer.remove(device.address)
                             // Remove all subscriptions for this device
                             subscriptionModes.keys.removeAll { it.device == deviceId }
                             for ((_, subscribers) in subscribersByChar) {
@@ -318,10 +312,9 @@ internal class AndroidGattServer(
                     val deviceId = Identifier(device.address)
                     val charUuid = characteristic.uuid.toKotlinUuid()
 
-                    // Prepared writes (Write Long): buffer chunks until Execute Write
+                    // Prepared writes (Write Long): buffer fragments until Execute Write
                     if (preparedWrite) {
-                        val handler = writeHandlers[charUuid]
-                        if (handler == null) {
+                        if (writeHandlers[charUuid] == null) {
                             logEvent(
                                 BleLogEvent.ServerRequest(
                                     deviceId,
@@ -342,9 +335,31 @@ internal class AndroidGattServer(
                             return@launch
                         }
 
-                        preparedWriteBuffer
-                            .getOrPut(device.address) { mutableListOf() }
-                            .add(PreparedChunk(charUuid, offset, value ?: byteArrayOf()))
+                        val buffer = preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
+                        val bufferedBytes = buffer.sumOf { it.bytes.size } + (value?.size ?: 0)
+                        if (bufferedBytes > MAX_PREPARED_WRITE_BUFFER_BYTES) {
+                            preparedWriteBuffer.remove(device.address)
+                            logEvent(
+                                BleLogEvent.ServerRequest(
+                                    deviceId,
+                                    "prepared-write-rejected (buffer limit ${bufferedBytes}B)",
+                                    charUuid,
+                                    GattStatus.InvalidAttributeLength,
+                                ),
+                            )
+                            if (responseNeeded) {
+                                sendResponseSafe(
+                                    device,
+                                    requestId,
+                                    BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
+                                    offset,
+                                    null,
+                                )
+                            }
+                            return@launch
+                        }
+
+                        buffer.add(WriteFragment(charUuid, offset, value ?: byteArrayOf()))
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,
@@ -456,11 +471,10 @@ internal class AndroidGattServer(
                 execute: Boolean,
             ) {
                 scope.launch {
-                    val chunks = preparedWriteBuffer.remove(device.address)
+                    val fragments = preparedWriteBuffer.remove(device.address)
                     val deviceId = Identifier(device.address)
 
-                    if (!execute || chunks.isNullOrEmpty()) {
-                        // Client cancelled the prepared write — discard buffered data
+                    if (!execute || fragments.isNullOrEmpty()) {
                         logEvent(
                             BleLogEvent.ServerClientEvent(
                                 deviceId,
@@ -471,18 +485,17 @@ internal class AndroidGattServer(
                         return@launch
                     }
 
-                    // Group chunks by characteristic and assemble each into a single byte array
-                    val grouped = chunks.groupBy { it.charUuid }
+                    val assembled = assembleWriteFragments(fragments)
                     var failed = false
 
-                    for ((charUuid, charChunks) in grouped) {
-                        val handler = writeHandlers[charUuid]
+                    for (write in assembled) {
+                        val handler = writeHandlers[write.charUuid]
                         if (handler == null) {
                             logEvent(
                                 BleLogEvent.ServerRequest(
                                     deviceId,
                                     "execute-write-rejected (no handler)",
-                                    charUuid,
+                                    write.charUuid,
                                     GattStatus.WriteNotPermitted,
                                 ),
                             )
@@ -490,21 +503,13 @@ internal class AndroidGattServer(
                             break
                         }
 
-                        // Assemble chunks by offset into a contiguous byte array
-                        val totalSize = charChunks.maxOf { it.offset + it.value.size }
-                        val assembled = ByteArray(totalSize)
-                        for (chunk in charChunks) {
-                            chunk.value.copyInto(assembled, destinationOffset = chunk.offset)
-                        }
-
                         try {
-                            val bleData = BleData(assembled)
-                            val status = handler(deviceId, bleData, true)
+                            val status = handler(deviceId, BleData(write.data), true)
                             logEvent(
                                 BleLogEvent.ServerRequest(
                                     deviceId,
-                                    "execute-write (${assembled.size}B from ${charChunks.size} chunks)",
-                                    charUuid,
+                                    "execute-write (${write.data.size}B)",
+                                    write.charUuid,
                                     status,
                                 ),
                             )
@@ -512,12 +517,13 @@ internal class AndroidGattServer(
                                 failed = true
                                 break
                             }
-                        } catch (_: Exception) {
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
                             logEvent(
                                 BleLogEvent.ServerRequest(
                                     deviceId,
                                     "execute-write-failed (handler threw)",
-                                    charUuid,
+                                    write.charUuid,
                                     GattStatus.Failure,
                                 ),
                             )
@@ -946,6 +952,7 @@ internal class AndroidGattServer(
         const val DEFAULT_MTU = 23
         const val ATT_HEADER_SIZE = 3
         const val CONNECTION_WARNING_THRESHOLD = 7
+        const val MAX_PREPARED_WRITE_BUFFER_BYTES = 4096
 
         // Global single-instance guard — Android supports one GATT server per app
         private val instanceLock = AtomicBoolean(false)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/PreparedWriteAssembler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/PreparedWriteAssembler.kt
@@ -1,0 +1,38 @@
+package com.atruedev.kmpble.server
+
+import kotlin.uuid.Uuid
+
+/** Single fragment from a BLE Prepared Write (Write Long) request. */
+internal class WriteFragment(
+    val charUuid: Uuid,
+    val offset: Int,
+    val bytes: ByteArray,
+)
+
+/** Assembled result of all fragments for a single characteristic. */
+internal class AssembledWrite(
+    val charUuid: Uuid,
+    val data: ByteArray,
+)
+
+/** BLE spec maximum characteristic value length. */
+internal const val MAX_CHARACTERISTIC_VALUE_SIZE = 512
+
+/**
+ * Assemble Prepared Write fragments into contiguous byte arrays, grouped by characteristic.
+ *
+ * Fragments are sorted by offset before assembly. Overlapping offset ranges use
+ * last-write-wins semantics (per BLE Reliable Write behavior).
+ */
+internal fun assembleWriteFragments(fragments: List<WriteFragment>): List<AssembledWrite> =
+    fragments
+        .groupBy { it.charUuid }
+        .map { (charUuid, charFragments) ->
+            val sorted = charFragments.sortedBy { it.offset }
+            val totalSize = sorted.maxOf { it.offset + it.bytes.size }
+            val assembled = ByteArray(totalSize)
+            for (fragment in sorted) {
+                fragment.bytes.copyInto(assembled, destinationOffset = fragment.offset)
+            }
+            AssembledWrite(charUuid, assembled)
+        }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -374,6 +374,12 @@ internal class IosGattServer(
         }
     }
 
+    private class DeliverableWrite(
+        val request: CBATTRequest,
+        val charUuid: Uuid,
+        val data: BleData,
+    )
+
     private fun handleWriteRequests(
         peripheral: CBPeripheralManager,
         rawRequests: List<*>,
@@ -384,34 +390,32 @@ internal class IosGattServer(
         val firstRequest = requests.first()
 
         scope.launch {
-            // Check if any request has a non-zero offset (Write Long / Prepared Write).
-            // If so, group by characteristic and assemble fragments before delivering.
-            val hasOffsets = requests.any { it.offset.toInt() > 0 }
+            val hasFragments = requests.any { it.offset.toInt() > 0 }
 
-            val deliverableWrites: List<Triple<CBATTRequest, Uuid, BleData>> =
-                if (hasOffsets) {
+            val writes: List<DeliverableWrite> =
+                if (hasFragments) {
                     assembleFragmentedWrites(requests)
                 } else {
                     requests.map { request ->
                         val data =
                             if (request.value != null) bleDataFromNSData(request.value!!) else emptyBleData()
-                        Triple(request, request.charUuid, data)
+                        DeliverableWrite(request, request.charUuid, data)
                     }
                 }
 
             var failed = false
             var failError: Long = CB_ATT_ERROR_UNLIKELY
 
-            for ((request, charUuid, data) in deliverableWrites) {
-                trackCentral(request.central)
+            for (write in writes) {
+                trackCentral(write.request.central)
 
-                val handler = writeHandlers[charUuid]
+                val handler = writeHandlers[write.charUuid]
                 if (handler == null) {
                     logEvent(
                         BleLogEvent.ServerRequest(
-                            request.centralId,
+                            write.request.centralId,
                             "write-rejected (no handler)",
-                            charUuid,
+                            write.charUuid,
                             GattStatus.WriteNotPermitted,
                         ),
                     )
@@ -421,7 +425,7 @@ internal class IosGattServer(
                 }
 
                 try {
-                    val status = handler(request.centralId, data, true)
+                    val status = handler(write.request.centralId, write.data, true)
                     if (status != null && status != GattStatus.Success) {
                         failed = true
                         failError = status.toCBATTError()
@@ -429,9 +433,9 @@ internal class IosGattServer(
                     }
                     logEvent(
                         BleLogEvent.ServerRequest(
-                            request.centralId,
-                            "write (${data.size}B)",
-                            charUuid,
+                            write.request.centralId,
+                            "write (${write.data.size}B)",
+                            write.charUuid,
                             status,
                         ),
                     )
@@ -439,9 +443,9 @@ internal class IosGattServer(
                     if (e is kotlinx.coroutines.CancellationException) throw e
                     logEvent(
                         BleLogEvent.ServerRequest(
-                            request.centralId,
+                            write.request.centralId,
                             "write-failed (handler threw)",
-                            charUuid,
+                            write.charUuid,
                             GattStatus.Failure,
                         ),
                     )
@@ -458,51 +462,22 @@ internal class IosGattServer(
         }
     }
 
-    /**
-     * Assemble Write Long (Prepared Write) fragments into complete writes.
-     *
-     * When a central writes data larger than ATT_MTU, Core Bluetooth delivers
-     * multiple [CBATTRequest] objects with increasing [CBATTRequest.offset] values.
-     * This method groups them by characteristic UUID, sorts by offset, and assembles
-     * the fragments into a single contiguous [BleData] per characteristic.
-     *
-     * Returns a list of (representative request, charUuid, assembled data) triples,
-     * one per characteristic that was written to.
-     */
-    private fun assembleFragmentedWrites(requests: List<CBATTRequest>): List<Triple<CBATTRequest, Uuid, BleData>> {
-        data class Fragment(
-            val offset: Int,
-            val bytes: ByteArray,
-        )
-
-        // Group fragments by characteristic UUID
-        val grouped = mutableMapOf<Uuid, MutableList<Fragment>>()
+    /** Assemble Write Long fragments using the shared assembler, preserving a representative request per characteristic. */
+    private fun assembleFragmentedWrites(requests: List<CBATTRequest>): List<DeliverableWrite> {
         val representativeRequest = mutableMapOf<Uuid, CBATTRequest>()
-
-        for (request in requests) {
-            val charUuid = request.charUuid
-            val bytes =
-                if (request.value != null) {
-                    bleDataFromNSData(request.value!!).toByteArray()
-                } else {
-                    byteArrayOf()
+        val fragments =
+            requests.map { request ->
+                val charUuid = request.charUuid
+                if (charUuid !in representativeRequest) {
+                    representativeRequest[charUuid] = request
                 }
-            grouped
-                .getOrPut(charUuid) { mutableListOf() }
-                .add(Fragment(request.offset.toInt(), bytes))
-            if (charUuid !in representativeRequest) {
-                representativeRequest[charUuid] = request
+                val bytes =
+                    if (request.value != null) bleDataFromNSData(request.value!!).toByteArray() else byteArrayOf()
+                WriteFragment(charUuid, request.offset.toInt(), bytes)
             }
-        }
 
-        return grouped.map { (charUuid, fragments) ->
-            val sorted = fragments.sortedBy { it.offset }
-            val totalSize = sorted.maxOf { it.offset + it.bytes.size }
-            val assembled = ByteArray(totalSize)
-            for (fragment in sorted) {
-                fragment.bytes.copyInto(assembled, destinationOffset = fragment.offset)
-            }
-            Triple(representativeRequest[charUuid]!!, charUuid, BleData(assembled))
+        return assembleWriteFragments(fragments).map { assembled ->
+            DeliverableWrite(representativeRequest[assembled.charUuid]!!, assembled.charUuid, BleData(assembled.data))
         }
     }
 


### PR DESCRIPTION
## Summary

- Extract fragment assembly into `commonMain` `PreparedWriteAssembler` (DRY across Android/iOS)
- Android: clean up `preparedWriteBuffer` on disconnect (memory leak fix)
- Android: reject prepared writes exceeding 4096B per device (DoS prevention)
- Android: rethrow `CancellationException` in `onExecuteWrite` (coroutine correctness)
- iOS: replace `Triple<CBATTRequest, Uuid, BleData>` with typed `DeliverableWrite`
- iOS: delegate to shared `assembleWriteFragments`

## Verification

- `compileDebugKotlin` passes
- `compileKotlinIosSimulatorArm64` passes
- `testAndroidHostTest` passes
- `ktlintCheck` passes