### PR TITLE
fix(ci): strip v prefix from VERSION env var in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish to Maven Central
         run: ./gradlew publishAllPublicationsToMavenCentralRepository
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -47,7 +47,7 @@ jobs:
       - name: Build XCFramework
         run: ./gradlew assembleXCFramework
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Zip XCFramework
         run: |
@@ -117,7 +117,7 @@ jobs:
       - name: Generate API docs (Dokka)
         run: ./gradlew dokkaGenerate
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ needs.publish.outputs.version }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0


### PR DESCRIPTION
## Summary
- The `VERSION` env var passed to Gradle used `github.ref_name` (e.g. `v0.3.12`) instead of the stripped version from the extract step (e.g. `0.3.12`)
- This caused Maven artifacts to be published as `com.atruedev:kmp-ble:v0.3.12` instead of `com.atruedev:kmp-ble:0.3.12`, violating Maven versioning conventions
- Fixed all three occurrences: publish, XCFramework build, and Dokka generation

## Test plan
- [x] Tag a new release and verify the published artifact version on Maven Central has no `v` prefix
- [x] Verify XCFramework build uses correct version
- [x] Verify Dokka docs reflect correct version