### PR TITLE
fix(docs): resolve Dokka unresolved KDoc link warnings

### DIFF
--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/BleCodec.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/BleCodec.kt
@@ -23,7 +23,7 @@ public interface BleCodec<T> : BleEncoder<T>, BleDecoder<T>
 /**
  * Encodes a value of type [T] directly into [BleData].
  *
- * Use for server-side operations ([GattServer.notify], [GattServer.indicate])
+ * Use for server-side operations (`GattServer.notify`, `GattServer.indicate`)
  * where [BleData] is the native currency, avoiding the intermediate
  * `ByteArray` allocation that [BleEncoder] would require.
  */

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 /**
  * Tracks bond state for a single [BluetoothDevice] via broadcast receiver.
  *
- * All mutable state is confined to [peripheralContext.scope] which uses
+ * All mutable state is confined to [PeripheralContext.scope] which uses
  * `limitedParallelism(1)` — no synchronization primitives needed.
  */
 internal class AndroidBondManager(

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -226,7 +226,7 @@ internal class AndroidGattBridge(
      * ```
      *
      * Used as a workaround for OEMs (OnePlus, Xiaomi) that return stale cached services
-     * after bonding. See [BleQuirks.RefreshServicesOnBond].
+     * after bonding. See [com.atruedev.kmpble.quirks.BleQuirks.RefreshServicesOnBond].
      */
     internal fun refreshDeviceCache(): Boolean {
         val g = gatt ?: return false

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPairingRequestHandler.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPairingRequestHandler.kt
@@ -107,7 +107,7 @@ internal class AndroidPairingRequestHandler(
         }
 
     /**
-     * Synchronous teardown for use in [AutoCloseable.close] where
+     * Synchronous teardown for use in `AutoCloseable.close()` where
      * the coroutine scope is about to be cancelled.
      */
     fun closeSync() {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -698,7 +698,7 @@ internal class AndroidGattServer(
     }
 
     /**
-     * Send a notification or indication to a device and await [onNotificationSent].
+     * Send a notification or indication to a device and await `onNotificationSent`.
      *
      * Android's BLE stack requires waiting for onNotificationSent before sending
      * the next notification to the same device. This method serializes per-device

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
@@ -11,9 +11,9 @@ import kotlin.uuid.Uuid
  * Returns a human-readable GATT service/characteristic/descriptor tree.
  *
  * Useful for debugging — answers "what does this device expose?" in one call.
- * Only meaningful after service discovery completes (i.e., in [State.Connected.Ready]).
+ * Only meaningful after service discovery completes (i.e., in [com.atruedev.kmpble.connection.State.Connected.Ready]).
  *
- * Takes a consistent snapshot of [state] and [services] before formatting,
+ * Takes a consistent snapshot of [Peripheral.state] and [Peripheral.services] before formatting,
  * so the output is internally coherent even under concurrent state changes.
  *
  * ```
@@ -93,11 +93,11 @@ private val WELL_KNOWN_DESCRIPTORS: Map<Uuid, String> =
  * ```
  *
  * Behavior:
- * - Delegates state validation to [connect] — if the peripheral is already connected
- *   or connecting, [connect]'s own invariants apply
+ * - Delegates state validation to [Peripheral.connect] — if the peripheral is already connected
+ *   or connecting, [Peripheral.connect]'s own invariants apply
  * - If connection drops mid-block: the block's coroutine is cancelled with
  *   [kotlinx.coroutines.CancellationException], then close() runs in finally
- * - [close] always runs in a [NonCancellable] context, guaranteeing cleanup
+ * - [Peripheral.close] always runs in a [NonCancellable] context, guaranteeing cleanup
  *   even if the coroutine is cancelled mid-block
  *
  * Not thread-safe — callers must ensure exclusive access to this peripheral.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
@@ -26,7 +26,7 @@ public class ScannerConfig internal constructor() {
      * When `true` (default), only legacy advertisements (≤ 31 bytes) are reported.
      * Set to `false` to also receive BLE 5.0 extended advertisements.
      *
-     * On Android, this maps to [android.bluetooth.le.ScanSettings.Builder.setLegacy].
+     * On Android, this maps to `android.bluetooth.le.ScanSettings.Builder.setLegacy`.
      * On iOS, CoreBluetooth receives extended advertisements transparently
      * regardless of this setting.
      */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Collect [advertisements], return the first matching [predicate], or null after [timeout].
+ * Collect [Scanner.advertisements], return the first matching [predicate], or null after [timeout].
  *
  * Since [Scanner.advertisements] is a cold flow, scanning starts when this function
  * begins collecting and stops automatically when a match is found or the timeout expires.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
@@ -13,7 +13,7 @@ import kotlin.uuid.Uuid
  *
  * - **Android**: Full support via `AdvertisingSet` API (API 26+).
  * - **iOS**: CoreBluetooth does not expose extended advertising parameters.
- *   Falls back to legacy advertising via [CBPeripheralManager].
+ *   Falls back to legacy advertising via `CBPeripheralManager`.
  *
  * ## Differences from [Advertiser]
  *


### PR DESCRIPTION
## Summary
- Qualify member references with parent class for extension functions (e.g. `[state]` → `[Peripheral.state]`)
- Use FQN for cross-package references (e.g. `[BleQuirks.RefreshServicesOnBond]` → `[com.atruedev.kmpble.quirks.BleQuirks.RefreshServicesOnBond]`)
- Replace external SDK references with backtick code formatting since Dokka cannot resolve Android/iOS platform APIs (e.g. `[CBPeripheralManager]` → `` `CBPeripheralManager` ``)

## Test plan
- [ ] CI Dokka generation passes with no unresolved link warnings