### PR TITLE
fix(ci): use connectedAndroidDeviceTest to run instrumented tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,14 @@ jobs:
           arch: x86_64
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           emulator-boot-timeout: 300
-          script: ./gradlew androidDeviceCheck
+          script: ./gradlew connectedAndroidDeviceTest
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: instrumented-test-results
-          path: build/reports/androidTests/
+          path: build/reports/androidTests/connected/
 
   docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,7 +26,7 @@ construction, permissions, HandlerThread dispatch, and GATT type construction.
 Requires a connected device or running emulator.
 
 ```bash
-./gradlew androidDeviceCheck
+./gradlew connectedAndroidDeviceTest
 ```
 
 ### JVM Concurrency Tests (Lincheck)


### PR DESCRIPTION
## Summary

- Replace `androidDeviceCheck` with `connectedAndroidDeviceTest` in CI
- Fix artifact upload path to `build/reports/androidTests/connected/`
- Update `TESTING.md` to match

## Context

`androidDeviceCheck` is a lifecycle aggregation task that reports `UP-TO-DATE` without executing any connected tests. `connectedAndroidDeviceTest` is the task that actually installs the test APK and runs instrumented tests on the emulator.

## Test plan

- [x] `android-instrumented` CI job runs tests on emulator instead of skipping
- [x] Test results artifact is uploaded