### PR TITLE
fix(shared): add missing volatile annotation and remove redundant cleanup

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -36,6 +36,7 @@ internal class GattOperationQueue(
 
     fun start(timeout: Duration? = null) {
         drain()
+        drainJob?.cancel()
         if (timeout != null) operationTimeout = timeout
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
         channel = ch

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -27,6 +27,8 @@ internal class GattOperationQueue(
 
     @Volatile
     private var channel = Channel<QueueEntry>(Channel.UNLIMITED)
+
+    @Volatile
     private var drainJob: Job? = null
 
     @Volatile
@@ -34,7 +36,6 @@ internal class GattOperationQueue(
 
     fun start(timeout: Duration? = null) {
         drain()
-        drainJob?.cancel()
         if (timeout != null) operationTimeout = timeout
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
         channel = ch

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
@@ -2,6 +2,8 @@ package com.atruedev.kmpble.internal
 
 import com.atruedev.kmpble.adapter.BluetoothAdapterState
 import com.atruedev.kmpble.interop.KmpBleDelegateProxy
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
 import kotlinx.coroutines.flow.StateFlow
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerOptionRestoreIdentifierKey
@@ -18,7 +20,17 @@ internal object CentralManagerProvider {
     private val delegateProxy =
         KmpBleDelegateProxy(target = delegate).apply {
             onConnectionFailure = { peripheral, error ->
-                val id = peripheral?.identifier?.UUIDString ?: return@apply
+                val id = peripheral?.identifier?.UUIDString
+                if (id == null) {
+                    logEvent(
+                        BleLogEvent.Error(
+                            identifier = null,
+                            message = "didFailToConnectPeripheral fired with null peripheral",
+                            cause = null,
+                        ),
+                    )
+                    return@apply
+                }
                 delegate.handleConnectionFailure(id, error)
             }
         }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
@@ -18,7 +18,7 @@ internal object CentralManagerProvider {
     private val delegateProxy =
         KmpBleDelegateProxy(target = delegate).apply {
             onConnectionFailure = { peripheral, error ->
-                val id = peripheral!!.identifier.UUIDString
+                val id = peripheral?.identifier?.UUIDString ?: return@apply
                 delegate.handleConnectionFailure(id, error)
             }
         }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
@@ -21,7 +21,9 @@ internal object CentralManagerProvider {
         KmpBleDelegateProxy(target = delegate).apply {
             onConnectionFailure = { peripheral, error ->
                 val id = peripheral?.identifier?.UUIDString
-                if (id == null) {
+                if (id != null) {
+                    delegate.handleConnectionFailure(id, error)
+                } else {
                     logEvent(
                         BleLogEvent.Error(
                             identifier = null,
@@ -29,9 +31,7 @@ internal object CentralManagerProvider {
                             cause = null,
                         ),
                     )
-                    return@apply
                 }
-                delegate.handleConnectionFailure(id, error)
             }
         }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -126,7 +126,7 @@ public class IosPeripheral(
             bridge.connect()
 
             // didFailToConnectPeripheral is handled by the ObjC delegate proxy
-            // (KmpBleDelegateProxy) which routes through handleConnectionCallback.
+            // (KmpBleDelegateProxy) which routes through handleConnectionFailure.
             try {
                 withTimeout(options.timeout) {
                     connectionComplete!!.await()

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/GattOperationQueueLifecycleLincheckTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/GattOperationQueueLifecycleLincheckTest.kt
@@ -4,7 +4,6 @@ import com.atruedev.kmpble.gatt.internal.GattOperationQueue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import org.jetbrains.lincheck.datastructures.Operation
 import org.jetbrains.lincheck.datastructures.StressOptions
 import org.jetbrains.lincheck.datastructures.Validate
@@ -41,15 +40,10 @@ class GattOperationQueueLifecycleLincheckTest {
     }
 
     @Test
-    fun stressTest() {
-        try {
-            StressOptions()
-                .iterations(50)
-                .threads(2)
-                .actorsPerThread(3)
-                .check(this::class)
-        } finally {
-            scope.cancel()
-        }
-    }
+    fun stressTest() =
+        StressOptions()
+            .iterations(50)
+            .threads(2)
+            .actorsPerThread(3)
+            .check(this::class)
 }


### PR DESCRIPTION
## Summary
- Add `@Volatile` to `drainJob` in `GattOperationQueue` for cross-thread visibility consistency with `channel` and `operationTimeout`
- Remove redundant `drainJob?.cancel()` in `start()` — `drain()` closes the channel, naturally terminating the `for`-loop consumer
- Replace force unwrap (`!!`) with safe call in `CentralManagerProvider` delegate proxy callback to prevent crash on unexpected null peripheral
- Fix incorrect method name reference in `IosPeripheral` connection comment (`handleConnectionCallback` → `handleConnectionFailure`)
- Remove duplicate scope cancellation in Lincheck stress test — `@Validate` cleanup already cancels the supervisor job

## Test plan
- [ ] Existing common and JVM tests pass (`./gradlew allTests`)
- [ ] Lincheck stress test still passes without the redundant `finally` block
- [ ] iOS build succeeds with delegate proxy changes