### PR TITLE
fix: harden lifecycle safety and fix docs CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
   docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannel.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capChannel.kt
@@ -93,9 +93,6 @@ internal class AndroidL2capChannel(
                             incomingChannel.send(data)
                         }
                     } catch (_: IOException) {
-                        if (!closed.get()) {
-                            break
-                        }
                         break
                     }
                 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -35,8 +35,8 @@ internal class GattOperationQueue(
     private var operationTimeout: Duration = DEFAULT_OPERATION_TIMEOUT
 
     fun start(timeout: Duration? = null) {
-        drain()
         drainJob?.cancel()
+        drain()
         if (timeout != null) operationTimeout = timeout
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
         channel = ch

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -150,10 +150,7 @@ internal class IosL2capChannel(
         dataChannel.close()
     }
 
-    private val streamsClosed = MutableStateFlow(false)
-
     private fun closeStreams() {
-        if (!streamsClosed.compareAndSet(expect = false, update = true)) return
         cbChannel.inputStream?.close()
         cbChannel.outputStream?.close()
     }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -122,14 +122,15 @@ public class IosPeripheral(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            connectionComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            connectionComplete = deferred
             bridge.connect()
 
             // didFailToConnectPeripheral is handled by the ObjC delegate proxy
             // (KmpBleDelegateProxy) which routes through handleConnectionFailure.
             try {
                 withTimeout(options.timeout) {
-                    connectionComplete!!.await()
+                    deferred.await()
                 }
             } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
                 bridge.disconnect()
@@ -148,11 +149,12 @@ public class IosPeripheral(
         withContext(peripheralContext.dispatcher) {
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            disconnectComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            disconnectComplete = deferred
             bridge.disconnect()
 
             try {
-                withTimeout(DISCONNECT_TIMEOUT) { disconnectComplete!!.await() }
+                withTimeout(DISCONNECT_TIMEOUT) { deferred.await() }
             } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
@@ -186,10 +188,11 @@ public class IosPeripheral(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            discoveryComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<List<DiscoveredService>>()
+            discoveryComplete = deferred
             bridge.discoverServices()
             try {
-                withTimeout(DISCOVERY_TIMEOUT) { discoveryComplete!!.await() }
+                withTimeout(DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
                 discoveryComplete = null
             }
@@ -711,12 +714,13 @@ public class IosPeripheral(
                 peripheralContext.gattQueue.start()
                 peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
 
-                connectionComplete = CompletableDeferred()
+                val deferred = CompletableDeferred<Unit>()
+                connectionComplete = deferred
                 bridge.discoverServices()
 
                 try {
                     withTimeout(DISCOVERY_TIMEOUT) {
-                        connectionComplete!!.await()
+                        deferred.await()
                     }
                 } finally {
                     connectionComplete = null


### PR DESCRIPTION
## Summary

- Eliminate TOCTOU window in `IosPeripheral` by capturing `CompletableDeferred` to local val before `await`, removing all `!!` on nullable fields
- Reorder `GattOperationQueue.start()` to cancel the drain job before draining, so suspended operations are interrupted immediately instead of waiting for natural exit
- Remove redundant `streamsClosed` double-guard in `IosL2capChannel` — `_isOpen.compareAndSet` already ensures single-winner close semantics
- Remove dead-code branch in `AndroidL2capChannel` where both `if`/`else` paths execute `break`
- Move docs CI job from `ubuntu-latest` to `macos-26` — Dokka resolves iOS source sets which require `xcrun`

## Test plan

- [x] Existing unit tests pass (`GattOperationQueueTest`, `StateMachineReflectionTest`)
- [x] iOS build succeeds on macOS CI runner
- [ ] Docs job (`dokkaGenerate`) passes on macOS runner
- [x] Android build + tests pass