### PR TITLE
fix(ci): enable cinterop commonization for Dokka docs generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,18 +54,9 @@ kotlin {
 
     compilerOptions {
         freeCompilerArgs.add("-opt-in=kotlin.uuid.ExperimentalUuidApi")
+        freeCompilerArgs.add("-opt-in=kotlinx.cinterop.BetaInteropApi")
+        freeCompilerArgs.add("-opt-in=kotlinx.cinterop.ExperimentalForeignApi")
         freeCompilerArgs.add("-Xexpect-actual-classes")
-    }
-
-    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
-        compilations.all {
-            compileTaskProvider.configure {
-                compilerOptions {
-                    freeCompilerArgs.add("-opt-in=kotlinx.cinterop.BetaInteropApi")
-                    freeCompilerArgs.add("-opt-in=kotlinx.cinterop.ExperimentalForeignApi")
-                }
-            }
-        }
     }
 
     android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx2g
 kotlin.code.style=official
 android.useAndroidX=true
 kotlin.mpp.applyDefaultHierarchyTemplate=true
+kotlin.mpp.enableCInteropCommonization=true

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.atruedev.kmpble.internal
 
 import com.atruedev.kmpble.adapter.BluetoothAdapterState


### PR DESCRIPTION
## Summary

- Enable `kotlin.mpp.enableCInteropCommonization=true` in `gradle.properties` so cinterop declarations (`KmpBleDelegateProxy`) propagate to the shared `iosMain` source set during metadata compilation
- Move `ExperimentalForeignApi`/`BetaInteropApi` opt-in flags from native-target-only scope to top-level `compilerOptions`, covering metadata compilations that Dokka triggers
- Add `@file:OptIn(ExperimentalForeignApi::class)` to `CentralManagerProvider.kt`

Root cause: Dokka runs `:compileIosMainKotlinMetadata` which is a metadata compilation, not a native target compilation. Without cinterop commonization, `iosMain` can't see cinterop types. Without top-level opt-in, the metadata compiler rejects `ExperimentalForeignApi` usages.

## Test plan

Verified locally — all pass:
- [x] `./gradlew :docs:dokkaGenerate`
- [x] `./gradlew compileKotlinIosSimulatorArm64 iosSimulatorArm64Test`
- [x] `./gradlew compileAndroidMain jvmTest`