### PR TITLE
refactor(shared): unify error handling and reduce duplication across peripherals

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -8,12 +8,16 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothProfile
 import android.content.Context
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.connection.internal.ReconnectionHandler
 import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
@@ -32,6 +36,7 @@ import com.atruedev.kmpble.gatt.internal.ENABLE_INDICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.ENABLE_NOTIFICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
+import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOperations
@@ -49,6 +54,7 @@ import com.atruedev.kmpble.quirks.QuirkRegistry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -93,7 +99,7 @@ public class AndroidPeripheral internal constructor(
 
     private val bondManager = AndroidBondManager(device, context, peripheralContext)
 
-    @OptIn(com.atruedev.kmpble.ExperimentalBleApi::class)
+    @OptIn(ExperimentalBleApi::class)
     private val pairingRequestHandler =
         AndroidPairingRequestHandler(device, context, peripheralContext.scope, peripheralContext.dispatcher)
 
@@ -106,11 +112,11 @@ public class AndroidPeripheral internal constructor(
     private var closed = false
     private var currentConnectionOptions: ConnectionOptions? = null
     private val reconnectionHandler =
-        com.atruedev.kmpble.connection.internal.ReconnectionHandler(
+        ReconnectionHandler(
             scope = peripheralContext.scope,
             stateFlow = peripheralContext.state,
             connectAction = { opts ->
-                connect(opts.copy(reconnectionStrategy = com.atruedev.kmpble.connection.ReconnectionStrategy.None))
+                connect(opts.copy(reconnectionStrategy = ReconnectionStrategy.None))
             },
             onMaxAttemptsExhausted = { observationManager.onPermanentDisconnect() },
         )
@@ -127,7 +133,7 @@ public class AndroidPeripheral internal constructor(
         )
     }
 
-    @OptIn(com.atruedev.kmpble.ExperimentalBleApi::class)
+    @OptIn(ExperimentalBleApi::class)
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
         currentConnectionOptions = options
@@ -158,7 +164,7 @@ public class AndroidPeripheral internal constructor(
                 bondManager.createBond()
             }
             logEvent(BleLogEvent.BondEvent(identifier, "Quirk: bond-before-connect succeeded"))
-        } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+        } catch (_: TimeoutCancellationException) {
             logEvent(
                 BleLogEvent.Error(
                     identifier,
@@ -218,7 +224,7 @@ public class AndroidPeripheral internal constructor(
                 withTimeout(timeout) {
                     connectionComplete!!.await()
                 }
-            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
                 bridge.releaseGatt()
                 peripheralContext.processEvent(
@@ -239,7 +245,7 @@ public class AndroidPeripheral internal constructor(
         }
     }
 
-    @OptIn(com.atruedev.kmpble.ExperimentalBleApi::class)
+    @OptIn(ExperimentalBleApi::class)
     override suspend fun disconnect() {
         checkNotClosed()
         reconnectionHandler.stop()
@@ -253,7 +259,7 @@ public class AndroidPeripheral internal constructor(
 
             try {
                 withTimeout(DISCONNECT_TIMEOUT) { disconnectComplete!!.await() }
-            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
                 )
@@ -264,7 +270,7 @@ public class AndroidPeripheral internal constructor(
         }
     }
 
-    @OptIn(com.atruedev.kmpble.ExperimentalBleApi::class)
+    @OptIn(ExperimentalBleApi::class)
     override fun close() {
         if (closed) return
         closed = true
@@ -278,8 +284,8 @@ public class AndroidPeripheral internal constructor(
         PeripheralRegistry.remove(identifier)
     }
 
-    @com.atruedev.kmpble.ExperimentalBleApi
-    override fun removeBond(): com.atruedev.kmpble.bonding.BondRemovalResult {
+    @ExperimentalBleApi
+    override fun removeBond(): BondRemovalResult {
         checkNotClosed()
         return bondManager.removeBond()
     }
@@ -384,7 +390,7 @@ public class AndroidPeripheral internal constructor(
                                 withTimeout(bondTimeout) {
                                     bondManager.createBond()
                                 }
-                            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+                            } catch (_: TimeoutCancellationException) {
                                 logEvent(
                                     BleLogEvent.Error(
                                         identifier,
@@ -566,7 +572,7 @@ public class AndroidPeripheral internal constructor(
         val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
-                val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+                val deferred = CompletableDeferred<GattStatus>()
                 pendingOps.characteristicWrite = deferred
                 if (!bridge.writeCharacteristic(native, chunk, androidWriteType)) {
                     pendingOps.characteristicWrite = null
@@ -634,7 +640,7 @@ public class AndroidPeripheral internal constructor(
         val cccd = native.getDescriptor(java.util.UUID.fromString(CCCD_UUID.toString())) ?: return
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+            val deferred = CompletableDeferred<GattStatus>()
             pendingOps.descriptorWrite = deferred
             bridge.writeDescriptor(cccd, value)
             val status = deferred.await()
@@ -652,7 +658,7 @@ public class AndroidPeripheral internal constructor(
         peripheralContext.scope.launch {
             try {
                 peripheralContext.gattQueue.enqueue {
-                    val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+                    val deferred = CompletableDeferred<GattStatus>()
                     pendingOps.descriptorWrite = deferred
                     bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
                     deferred.await()
@@ -686,7 +692,7 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+            val deferred = CompletableDeferred<GattStatus>()
             pendingOps.descriptorWrite = deferred
             if (!bridge.writeDescriptor(native, data)) {
                 pendingOps.descriptorWrite = null
@@ -863,10 +869,7 @@ public class AndroidPeripheral internal constructor(
         nativeDescMap.clear()
         closeL2capChannels()
         observationManager.onDisconnect()
-        pendingOps.cancelAll(
-            com.atruedev.kmpble.gatt.internal
-                .NotConnectedException(),
-        )
+        pendingOps.cancelAll(NotConnectedException())
     }
 
     private fun checkNotClosed() {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
@@ -92,5 +92,4 @@ public data class OperationFailed(
  */
 public data class BleException(
     public val error: BleError,
-    val errorMessage: String = error.toString(),
-) : Exception(errorMessage)
+) : Exception(error.toString())

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -16,6 +16,10 @@ import kotlin.time.Duration.Companion.seconds
  * Acceptance is controlled by channel lifecycle: [start] opens a new channel,
  * [drain] closes it. [Channel.trySend] on a closed channel fails atomically,
  * eliminating the TOCTOU window that a separate flag would introduce.
+ *
+ * Thread-safety contract: [start], [drain], and [close] must be called from
+ * the owning [PeripheralContext]'s serialized dispatcher (`limitedParallelism(1)`).
+ * [enqueue] may be called from any coroutine context.
  */
 internal class GattOperationQueue(
     private val scope: CoroutineScope,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -1,13 +1,20 @@
 package com.atruedev.kmpble.peripheral
 
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bleDataFromNSData
+import com.atruedev.kmpble.bonding.BondRemovalResult
+import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.connection.internal.ReconnectionHandler
+import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -17,6 +24,7 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
+import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOperations
@@ -33,8 +41,10 @@ import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
@@ -83,7 +93,7 @@ public class IosPeripheral(
     private val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
 
     override val state: StateFlow<State> get() = peripheralContext.state
-    override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = peripheralContext.bondState
+    override val bondState: StateFlow<BondState> get() = peripheralContext.bondState
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
 
@@ -93,11 +103,11 @@ public class IosPeripheral(
     // Safe: all callbacks dispatched to peripheralContext.scope (limitedParallelism(1))
     private var pendingCharacteristicDiscovery = 0
     private val reconnectionHandler =
-        com.atruedev.kmpble.connection.internal.ReconnectionHandler(
+        ReconnectionHandler(
             scope = peripheralContext.scope,
             stateFlow = peripheralContext.state,
             connectAction = { opts ->
-                connect(opts.copy(reconnectionStrategy = com.atruedev.kmpble.connection.ReconnectionStrategy.None))
+                connect(opts.copy(reconnectionStrategy = ReconnectionStrategy.None))
             },
             onMaxAttemptsExhausted = { observationManager.onPermanentDisconnect() },
         )
@@ -132,7 +142,7 @@ public class IosPeripheral(
                 withTimeout(options.timeout) {
                     deferred.await()
                 }
-            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("Connection timeout")),
@@ -155,7 +165,7 @@ public class IosPeripheral(
 
             try {
                 withTimeout(DISCONNECT_TIMEOUT) { deferred.await() }
-            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
                 )
@@ -165,9 +175,9 @@ public class IosPeripheral(
         }
     }
 
-    @com.atruedev.kmpble.ExperimentalBleApi
-    override fun removeBond(): com.atruedev.kmpble.bonding.BondRemovalResult =
-        com.atruedev.kmpble.bonding.BondRemovalResult.NotSupported(
+    @ExperimentalBleApi
+    override fun removeBond(): BondRemovalResult =
+        BondRemovalResult.NotSupported(
             "iOS does not support programmatic bond removal. Remove from Settings > Bluetooth.",
         )
 
@@ -435,7 +445,7 @@ public class IosPeripheral(
             pendingOps.characteristicRead = deferred
             bridge.readCharacteristic(native)
             val result = deferred.await()
-            if (!result.status.isSuccess()) throw Exception("Read failed: ${result.status}")
+            if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
     }
@@ -454,11 +464,11 @@ public class IosPeripheral(
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
                 if (withResponse) {
-                    val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+                    val deferred = CompletableDeferred<GattStatus>()
                     pendingOps.characteristicWrite = deferred
                     bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
                     val status = deferred.await()
-                    if (!status.isSuccess()) throw Exception("Write failed: $status")
+                    if (!status.isSuccess()) throw BleException(GattError("write", status))
                 } else {
                     bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = false)
                 }
@@ -469,61 +479,44 @@ public class IosPeripheral(
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> {
-        checkNotClosed()
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
-        return kotlinx.coroutines.flow
-            .flow {
-                val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-                eventFlow.collect { event ->
-                    when (event) {
-                        is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                        is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                        is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-                    }
-                }
-            }.onStart {
-                if (peripheralContext.state.value is State.Connected.Ready) {
-                    enableNotifications(characteristic)
-                }
-            }.applyBackpressure(backpressure)
-            .onCompletion {
-                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                if (wasLastCollector) {
-                    disableNotifications(characteristic)
-                }
+    ): Flow<Observation> =
+        observeInternal(characteristic, backpressure) { event ->
+            when (event) {
+                is ObservationEvent.Value -> emit(Observation.Value(event.data))
+                is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
+                is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
             }
-    }
+        }
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> {
+    ): Flow<ByteArray> =
+        observeInternal(characteristic, backpressure) { event ->
+            when (event) {
+                is ObservationEvent.Value -> emit(event.data)
+                is ObservationEvent.Disconnected -> Unit
+                is ObservationEvent.PermanentlyDisconnected -> Unit
+            }
+        }
+
+    private fun <T> observeInternal(
+        characteristic: Characteristic,
+        backpressure: BackpressureStrategy,
+        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
+    ): Flow<T> {
         checkNotClosed()
         val serviceUuid = characteristic.serviceUuid
         val charUuid = characteristic.uuid
 
-        return kotlinx.coroutines.flow
-            .flow {
-                val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-                eventFlow.collect { event ->
-                    when (event) {
-                        is ObservationEvent.Value -> emit(event.data)
-                        is ObservationEvent.Disconnected -> {
-                            // Transparent reconnection — no emission during disconnect
-                        }
-                        is ObservationEvent.PermanentlyDisconnected -> {
-                            // Flow completes normally, no emission (transformWhile ends the flow)
-                        }
-                    }
-                }
-            }.onStart {
-                if (peripheralContext.state.value is State.Connected.Ready) {
-                    enableNotifications(characteristic)
-                }
-            }.applyBackpressure(backpressure)
+        return flow {
+            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
+            eventFlow.collect { event -> mapper(event) }
+        }.onStart {
+            if (peripheralContext.state.value is State.Connected.Ready) {
+                enableNotifications(characteristic)
+            }
+        }.applyBackpressure(backpressure)
             .onCompletion {
                 val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
                 if (wasLastCollector) {
@@ -551,7 +544,7 @@ public class IosPeripheral(
             pendingOps.descriptorRead = deferred
             bridge.readDescriptor(native)
             val result = deferred.await()
-            if (!result.status.isSuccess()) throw Exception("Descriptor read failed: ${result.status}")
+            if (!result.status.isSuccess()) throw BleException(GattError("readDescriptor", result.status))
             result.value
         }
     }
@@ -563,11 +556,11 @@ public class IosPeripheral(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
-            val deferred = CompletableDeferred<com.atruedev.kmpble.error.GattStatus>()
+            val deferred = CompletableDeferred<GattStatus>()
             pendingOps.descriptorWrite = deferred
             bridge.writeDescriptor(native, data.toNSData())
             val status = deferred.await()
-            if (!status.isSuccess()) throw Exception("Descriptor write failed: $status")
+            if (!status.isSuccess()) throw BleException(GattError("writeDescriptor", status))
         }
     }
 
@@ -665,10 +658,7 @@ public class IosPeripheral(
         nativeDescMap.clear()
         closeL2capChannels()
         observationManager.onDisconnect()
-        pendingOps.cancelAll(
-            com.atruedev.kmpble.gatt.internal
-                .NotConnectedException(),
-        )
+        pendingOps.cancelAll(NotConnectedException())
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace generic `Exception` throws with `BleException` in iOS GATT operations (`read`, `write`, `readDescriptor`, `writeDescriptor`) to match Android behavior — consumers can now catch `BleException` uniformly across platforms
- Extract `observeInternal()` on iOS to eliminate `observe()`/`observeValues()` code duplication (mirrors existing Android pattern)
- Replace all fully-qualified name references with proper imports in both `IosPeripheral` and `AndroidPeripheral`
- Remove unused `errorMessage` parameter from `BleException` to prevent message/error desync
- Document thread-safety contract on `GattOperationQueue`

## Test plan

- [x] `ktlintCheck` passes
- [x] `jvmTest` passes (includes Lincheck)
- [x] `iosSimulatorArm64Test` passes
- [x] iOS and Android compilation succeeds