### PR TITLE
refactor(shared): unify pending ops, observe pattern, and scan predicate equality

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -39,6 +39,7 @@ import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
@@ -334,12 +335,10 @@ public class AndroidPeripheral internal constructor(
                 is GattCallbackEvent.MtuChanged -> handleMtuChanged(event)
                 is GattCallbackEvent.CharacteristicRead -> {
                     val status = event.status.toGattStatus()
-                    pendingOps.characteristicRead?.complete(GattResult(event.value, status))
-                    pendingOps.characteristicRead = null
+                    pendingOps.complete(PendingOp.CharacteristicRead, GattResult(event.value, status))
                 }
                 is GattCallbackEvent.CharacteristicWrite -> {
-                    pendingOps.characteristicWrite?.complete(event.status.toGattStatus())
-                    pendingOps.characteristicWrite = null
+                    pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
                 }
                 is GattCallbackEvent.CharacteristicChanged -> {
                     val uuid = Uuid.parse(event.characteristic.uuid.toString())
@@ -352,22 +351,20 @@ public class AndroidPeripheral internal constructor(
                 }
                 is GattCallbackEvent.DescriptorRead -> {
                     val status = event.status.toGattStatus()
-                    pendingOps.descriptorRead?.complete(GattResult(event.value, status))
-                    pendingOps.descriptorRead = null
+                    pendingOps.complete(PendingOp.DescriptorRead, GattResult(event.value, status))
                 }
                 is GattCallbackEvent.DescriptorWrite -> {
-                    pendingOps.descriptorWrite?.complete(event.status.toGattStatus())
-                    pendingOps.descriptorWrite = null
+                    pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
                 }
                 is GattCallbackEvent.ReadRemoteRssi -> {
                     if (event.status.toGattStatus().isSuccess()) {
-                        pendingOps.rssiRead?.complete(event.rssi)
+                        pendingOps.complete(PendingOp.RssiRead, event.rssi)
                     } else {
-                        pendingOps.rssiRead?.completeExceptionally(
+                        pendingOps.fail(
+                            PendingOp.RssiRead,
                             Exception("readRssi failed: ${event.status.toGattStatus()}"),
                         )
                     }
-                    pendingOps.rssiRead = null
                 }
             }
         }
@@ -483,8 +480,7 @@ public class AndroidPeripheral internal constructor(
         if (event.status.toGattStatus().isSuccess()) {
             peripheralContext.updateMtu(event.mtu)
         }
-        pendingOps.mtuRequest?.complete(event.mtu)
-        pendingOps.mtuRequest = null
+        pendingOps.complete(PendingOp.MtuRequest, event.mtu)
     }
 
     // --- Service parsing ---
@@ -542,9 +538,9 @@ public class AndroidPeripheral internal constructor(
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeChar(characteristic)
             val deferred = CompletableDeferred<GattResult>()
-            pendingOps.characteristicRead = deferred
+            pendingOps.set(PendingOp.CharacteristicRead, deferred)
             if (!bridge.readCharacteristic(native)) {
-                pendingOps.characteristicRead = null
+                pendingOps.clear(PendingOp.CharacteristicRead)
                 throw BleException(GattError("read", GattStatus.Failure))
             }
             val result = deferred.await()
@@ -573,9 +569,9 @@ public class AndroidPeripheral internal constructor(
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
                 val deferred = CompletableDeferred<GattStatus>()
-                pendingOps.characteristicWrite = deferred
+                pendingOps.set(PendingOp.CharacteristicWrite, deferred)
                 if (!bridge.writeCharacteristic(native, chunk, androidWriteType)) {
-                    pendingOps.characteristicWrite = null
+                    pendingOps.clear(PendingOp.CharacteristicWrite)
                     throw BleException(GattError("write", GattStatus.Failure))
                 }
                 val status = deferred.await()
@@ -641,7 +637,7 @@ public class AndroidPeripheral internal constructor(
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
             val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.descriptorWrite = deferred
+            pendingOps.set(PendingOp.DescriptorWrite, deferred)
             bridge.writeDescriptor(cccd, value)
             val status = deferred.await()
             if (!status.isSuccess()) {
@@ -659,7 +655,7 @@ public class AndroidPeripheral internal constructor(
             try {
                 peripheralContext.gattQueue.enqueue {
                     val deferred = CompletableDeferred<GattStatus>()
-                    pendingOps.descriptorWrite = deferred
+                    pendingOps.set(PendingOp.DescriptorWrite, deferred)
                     bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
                     deferred.await()
                 }
@@ -674,9 +670,9 @@ public class AndroidPeripheral internal constructor(
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
             val deferred = CompletableDeferred<GattResult>()
-            pendingOps.descriptorRead = deferred
+            pendingOps.set(PendingOp.DescriptorRead, deferred)
             if (!bridge.readDescriptor(native)) {
-                pendingOps.descriptorRead = null
+                pendingOps.clear(PendingOp.DescriptorRead)
                 throw BleException(GattError("readDescriptor", GattStatus.Failure))
             }
             val result = deferred.await()
@@ -693,9 +689,9 @@ public class AndroidPeripheral internal constructor(
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
             val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.descriptorWrite = deferred
+            pendingOps.set(PendingOp.DescriptorWrite, deferred)
             if (!bridge.writeDescriptor(native, data)) {
-                pendingOps.descriptorWrite = null
+                pendingOps.clear(PendingOp.DescriptorWrite)
                 throw BleException(GattError("writeDescriptor", GattStatus.Failure))
             }
             val status = deferred.await()
@@ -707,9 +703,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val deferred = CompletableDeferred<Int>()
-            pendingOps.rssiRead = deferred
+            pendingOps.set(PendingOp.RssiRead, deferred)
             if (!bridge.readRemoteRssi()) {
-                pendingOps.rssiRead = null
+                pendingOps.clear(PendingOp.RssiRead)
                 throw BleException(GattError("readRssi", GattStatus.Failure))
             }
             deferred.await()
@@ -720,9 +716,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val deferred = CompletableDeferred<Int>()
-            pendingOps.mtuRequest = deferred
+            pendingOps.set(PendingOp.MtuRequest, deferred)
             if (!bridge.requestMtu(mtu)) {
-                pendingOps.mtuRequest = null
+                pendingOps.clear(PendingOp.MtuRequest)
                 throw BleException(GattError("requestMtu", GattStatus.Failure))
             }
             deferred.await()

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -619,10 +619,10 @@ public class AndroidPeripheral internal constructor(
             val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
             eventFlow.collect { event -> mapper(event) }
         }.onStart {
-                if (peripheralContext.state.value is State.Connected.Ready) {
-                    enableNotifications(characteristic)
-                }
-            }.applyBackpressure(backpressure)
+            if (peripheralContext.state.value is State.Connected.Ready) {
+                enableNotifications(characteristic)
+            }
+        }.applyBackpressure(backpressure)
             .onCompletion {
                 val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
                 if (wasLastCollector) {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -58,8 +58,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
@@ -607,17 +609,16 @@ public class AndroidPeripheral internal constructor(
     private fun <T> observeInternal(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-        mapper: suspend kotlinx.coroutines.flow.FlowCollector<T>.(ObservationEvent) -> Unit,
+        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
     ): Flow<T> {
         checkNotClosed()
         val serviceUuid = characteristic.serviceUuid
         val charUuid = characteristic.uuid
 
-        return kotlinx.coroutines.flow
-            .flow {
-                val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-                eventFlow.collect { event -> mapper(event) }
-            }.onStart {
+        return flow {
+            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
+            eventFlow.collect { event -> mapper(event) }
+        }.onStart {
                 if (peripheralContext.state.value is State.Connected.Ready) {
                     enableNotifications(characteristic)
                 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -36,11 +36,12 @@ internal class GattOperationQueue(
     )
 
     @Volatile
-    private var state = QueueState(
-        channel = Channel(Channel.UNLIMITED),
-        drainJob = null,
-        operationTimeout = DEFAULT_OPERATION_TIMEOUT,
-    )
+    private var state =
+        QueueState(
+            channel = Channel(Channel.UNLIMITED),
+            drainJob = null,
+            operationTimeout = DEFAULT_OPERATION_TIMEOUT,
+        )
 
     fun start(timeout: Duration? = null) {
         val prev = state
@@ -48,16 +49,18 @@ internal class GattOperationQueue(
         prev.drainJob?.cancel()
 
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
-        val job = scope.launch {
-            for (entry in ch) {
-                entry.action()
+        val job =
+            scope.launch {
+                for (entry in ch) {
+                    entry.action()
+                }
             }
-        }
-        state = QueueState(
-            channel = ch,
-            drainJob = job,
-            operationTimeout = timeout ?: prev.operationTimeout,
-        )
+        state =
+            QueueState(
+                channel = ch,
+                drainJob = job,
+                operationTimeout = timeout ?: prev.operationTimeout,
+            )
     }
 
     suspend fun <T> enqueue(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -17,9 +17,9 @@ import kotlin.time.Duration.Companion.seconds
  * [drain] closes it. [Channel.trySend] on a closed channel fails atomically,
  * eliminating the TOCTOU window that a separate flag would introduce.
  *
- * Thread-safety contract: [start], [drain], and [close] must be called from
- * the owning [PeripheralContext]'s serialized dispatcher (`limitedParallelism(1)`).
- * [enqueue] may be called from any coroutine context.
+ * [start], [drain], and [close] are confined to the owning peripheral's
+ * serialized dispatcher (`limitedParallelism(1)`).
+ * [enqueue] reads the `@Volatile` [state] snapshot from any coroutine context.
  */
 internal class GattOperationQueue(
     private val scope: CoroutineScope,
@@ -29,31 +29,39 @@ internal class GattOperationQueue(
         val cancel: (Throwable) -> Unit,
     )
 
-    @Volatile
-    private var channel = Channel<QueueEntry>(Channel.UNLIMITED)
+    private data class QueueState(
+        val channel: Channel<QueueEntry>,
+        val drainJob: Job?,
+        val operationTimeout: Duration,
+    )
 
     @Volatile
-    private var drainJob: Job? = null
-
-    @Volatile
-    private var operationTimeout: Duration = DEFAULT_OPERATION_TIMEOUT
+    private var state = QueueState(
+        channel = Channel(Channel.UNLIMITED),
+        drainJob = null,
+        operationTimeout = DEFAULT_OPERATION_TIMEOUT,
+    )
 
     fun start(timeout: Duration? = null) {
-        drainJob?.cancel()
-        drain()
-        if (timeout != null) operationTimeout = timeout
+        val prev = state
+        prev.drainJob?.cancel()
+        drainChannel(prev.channel)
+
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
-        channel = ch
-        drainJob =
-            scope.launch {
-                for (entry in ch) {
-                    entry.action()
-                }
+        val job = scope.launch {
+            for (entry in ch) {
+                entry.action()
             }
+        }
+        state = QueueState(
+            channel = ch,
+            drainJob = job,
+            operationTimeout = timeout ?: prev.operationTimeout,
+        )
     }
 
     suspend fun <T> enqueue(
-        timeout: Duration = operationTimeout,
+        timeout: Duration = state.operationTimeout,
         block: suspend () -> T,
     ): T {
         val deferred = CompletableDeferred<T>()
@@ -69,7 +77,7 @@ internal class GattOperationQueue(
                 cancel = { deferred.completeExceptionally(it) },
             )
 
-        if (!channel.trySend(entry).isSuccess) throw NotConnectedException()
+        if (!state.channel.trySend(entry).isSuccess) throw NotConnectedException()
 
         return withTimeout(timeout) {
             deferred.await()
@@ -77,17 +85,21 @@ internal class GattOperationQueue(
     }
 
     fun drain() {
-        val ch = channel
+        drainChannel(state.channel)
+    }
+
+    fun close() {
+        val s = state
+        drainChannel(s.channel)
+        s.drainJob?.cancel()
+    }
+
+    private fun drainChannel(ch: Channel<QueueEntry>) {
         ch.close()
         while (true) {
             val entry = ch.tryReceive().getOrNull() ?: break
             entry.cancel(NotConnectedException())
         }
-    }
-
-    fun close() {
-        drain()
-        drainJob?.cancel()
     }
 }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -44,8 +44,8 @@ internal class GattOperationQueue(
 
     fun start(timeout: Duration? = null) {
         val prev = state
-        prev.drainJob?.cancel()
         drainChannel(prev.channel)
+        prev.drainJob?.cancel()
 
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
         val job = scope.launch {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -16,44 +16,51 @@ internal data class GattResult(
     override fun hashCode(): Int = 31 * value.contentHashCode() + status.hashCode()
 }
 
-internal enum class PendingOp {
-    CharacteristicRead,
-    CharacteristicWrite,
-    DescriptorRead,
-    DescriptorWrite,
-    RssiRead,
-    MtuRequest,
+/**
+ * Type-safe key for pending GATT operations. The type parameter [T] links each
+ * operation to its result type, so the compiler rejects mismatched completions
+ * (e.g. completing a CharacteristicRead with a GattStatus instead of GattResult).
+ */
+internal sealed interface PendingOp<T> {
+    data object CharacteristicRead : PendingOp<GattResult>
+    data object CharacteristicWrite : PendingOp<GattStatus>
+    data object DescriptorRead : PendingOp<GattResult>
+    data object DescriptorWrite : PendingOp<GattStatus>
+    data object RssiRead : PendingOp<Int>
+    data object MtuRequest : PendingOp<Int>
 }
 
 internal class PendingOperations {
-    private val slots = mutableMapOf<PendingOp, CompletableDeferred<*>>()
+    private val slots = mutableMapOf<PendingOp<*>, CompletableDeferred<*>>()
 
     fun <T> set(
-        op: PendingOp,
+        op: PendingOp<T>,
         deferred: CompletableDeferred<T>,
     ) {
-        check(op !in slots) { "${op.name} overwritten while pending" }
+        check(op !in slots) { "${op::class.simpleName} overwritten while pending" }
         slots[op] = deferred
     }
 
-    fun has(op: PendingOp): Boolean = op in slots
+    fun has(op: PendingOp<*>): Boolean = op in slots
 
+    // Type linkage between PendingOp<T> and CompletableDeferred<T> is enforced
+    // at set() — the cast bridges JVM type erasure, not a type-safety gap.
     @Suppress("UNCHECKED_CAST")
     fun <T> complete(
-        op: PendingOp,
+        op: PendingOp<T>,
         value: T,
     ) {
         (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
     }
 
     fun fail(
-        op: PendingOp,
+        op: PendingOp<*>,
         cause: Throwable,
     ) {
         slots.remove(op)?.completeExceptionally(cause)
     }
 
-    fun clear(op: PendingOp) {
+    fun clear(op: PendingOp<*>) {
         slots.remove(op)
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -2,7 +2,6 @@ package com.atruedev.kmpble.gatt.internal
 
 import com.atruedev.kmpble.error.GattStatus
 import kotlinx.coroutines.CompletableDeferred
-import kotlin.reflect.KProperty
 
 internal data class GattResult(
     val value: ByteArray,
@@ -17,56 +16,51 @@ internal data class GattResult(
     override fun hashCode(): Int = 31 * value.contentHashCode() + status.hashCode()
 }
 
-internal class PendingSlot<T>(
-    private val name: String,
-) {
-    private var deferred: CompletableDeferred<T>? = null
-
-    operator fun getValue(
-        thisRef: Any?,
-        property: KProperty<*>,
-    ): CompletableDeferred<T>? = deferred
-
-    operator fun setValue(
-        thisRef: Any?,
-        property: KProperty<*>,
-        value: CompletableDeferred<T>?,
-    ) {
-        check(deferred == null || value == null) { "$name overwritten while pending" }
-        deferred = value
-    }
-
-    fun cancelAndClear(cause: Throwable) {
-        deferred?.completeExceptionally(cause)
-        deferred = null
-    }
+internal enum class PendingOp {
+    CharacteristicRead,
+    CharacteristicWrite,
+    DescriptorRead,
+    DescriptorWrite,
+    RssiRead,
+    MtuRequest,
 }
 
 internal class PendingOperations {
-    private val _characteristicRead = PendingSlot<GattResult>("characteristicRead")
-    var characteristicRead: CompletableDeferred<GattResult>? by _characteristicRead
+    private val slots = mutableMapOf<PendingOp, CompletableDeferred<*>>()
 
-    private val _characteristicWrite = PendingSlot<GattStatus>("characteristicWrite")
-    var characteristicWrite: CompletableDeferred<GattStatus>? by _characteristicWrite
+    fun <T> set(
+        op: PendingOp,
+        deferred: CompletableDeferred<T>,
+    ) {
+        check(op !in slots) { "${op.name} overwritten while pending" }
+        slots[op] = deferred
+    }
 
-    private val _descriptorRead = PendingSlot<GattResult>("descriptorRead")
-    var descriptorRead: CompletableDeferred<GattResult>? by _descriptorRead
+    fun has(op: PendingOp): Boolean = op in slots
 
-    private val _descriptorWrite = PendingSlot<GattStatus>("descriptorWrite")
-    var descriptorWrite: CompletableDeferred<GattStatus>? by _descriptorWrite
+    @Suppress("UNCHECKED_CAST")
+    fun <T> complete(
+        op: PendingOp,
+        value: T,
+    ) {
+        (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
+    }
 
-    private val _rssiRead = PendingSlot<Int>("rssiRead")
-    var rssiRead: CompletableDeferred<Int>? by _rssiRead
+    fun fail(
+        op: PendingOp,
+        cause: Throwable,
+    ) {
+        slots.remove(op)?.completeExceptionally(cause)
+    }
 
-    private val _mtuRequest = PendingSlot<Int>("mtuRequest")
-    var mtuRequest: CompletableDeferred<Int>? by _mtuRequest
+    fun clear(op: PendingOp) {
+        slots.remove(op)
+    }
 
     fun cancelAll(cause: Throwable) {
-        _characteristicRead.cancelAndClear(cause)
-        _characteristicWrite.cancelAndClear(cause)
-        _descriptorRead.cancelAndClear(cause)
-        _descriptorWrite.cancelAndClear(cause)
-        _rssiRead.cancelAndClear(cause)
-        _mtuRequest.cancelAndClear(cause)
+        for (deferred in slots.values) {
+            deferred.completeExceptionally(cause)
+        }
+        slots.clear()
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -22,10 +22,15 @@ internal data class GattResult(
  */
 internal sealed interface PendingOp<T> {
     data object CharacteristicRead : PendingOp<GattResult>
+
     data object CharacteristicWrite : PendingOp<GattStatus>
+
     data object DescriptorRead : PendingOp<GattResult>
+
     data object DescriptorWrite : PendingOp<GattStatus>
+
     data object RssiRead : PendingOp<Int>
+
     data object MtuRequest : PendingOp<Int>
 }
 
@@ -38,7 +43,10 @@ internal sealed interface PendingOp<T> {
 internal class PendingOperations {
     private val slots = mutableMapOf<PendingOp<*>, CompletableDeferred<*>>()
 
-    fun <T> set(op: PendingOp<T>, deferred: CompletableDeferred<T>) {
+    fun <T> set(
+        op: PendingOp<T>,
+        deferred: CompletableDeferred<T>,
+    ) {
         check(op !in slots) { "${op::class.simpleName} overwritten while pending" }
         slots[op] = deferred
     }
@@ -50,11 +58,17 @@ internal class PendingOperations {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <T> complete(op: PendingOp<T>, value: T) {
+    fun <T> complete(
+        op: PendingOp<T>,
+        value: T,
+    ) {
         (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
     }
 
-    fun fail(op: PendingOp<*>, cause: Throwable) {
+    fun fail(
+        op: PendingOp<*>,
+        cause: Throwable,
+    ) {
         slots.remove(op)?.completeExceptionally(cause)
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -17,9 +17,8 @@ internal data class GattResult(
 }
 
 /**
- * Type-safe key for pending GATT operations. The type parameter [T] links each
- * operation to its result type, so the compiler rejects mismatched completions
- * (e.g. completing a CharacteristicRead with a GattStatus instead of GattResult).
+ * Type-safe key for pending GATT operations. [T] binds each operation to its
+ * result type so the compiler rejects mismatched completions.
  */
 internal sealed interface PendingOp<T> {
     data object CharacteristicRead : PendingOp<GattResult>
@@ -30,44 +29,37 @@ internal sealed interface PendingOp<T> {
     data object MtuRequest : PendingOp<Int>
 }
 
+/**
+ * Holds at most one [CompletableDeferred] per [PendingOp] type.
+ *
+ * Confined to the owning peripheral's serialized dispatcher
+ * (`limitedParallelism(1)`) — no synchronization required.
+ */
 internal class PendingOperations {
     private val slots = mutableMapOf<PendingOp<*>, CompletableDeferred<*>>()
 
-    fun <T> set(
-        op: PendingOp<T>,
-        deferred: CompletableDeferred<T>,
-    ) {
+    fun <T> set(op: PendingOp<T>, deferred: CompletableDeferred<T>) {
         check(op !in slots) { "${op::class.simpleName} overwritten while pending" }
         slots[op] = deferred
     }
 
     fun has(op: PendingOp<*>): Boolean = op in slots
 
-    // Type linkage between PendingOp<T> and CompletableDeferred<T> is enforced
-    // at set() — the cast bridges JVM type erasure, not a type-safety gap.
-    @Suppress("UNCHECKED_CAST")
-    fun <T> complete(
-        op: PendingOp<T>,
-        value: T,
-    ) {
-        (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
-    }
-
-    fun fail(
-        op: PendingOp<*>,
-        cause: Throwable,
-    ) {
-        slots.remove(op)?.completeExceptionally(cause)
-    }
-
     fun clear(op: PendingOp<*>) {
         slots.remove(op)
     }
 
+    @Suppress("UNCHECKED_CAST")
+    fun <T> complete(op: PendingOp<T>, value: T) {
+        (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
+    }
+
+    fun fail(op: PendingOp<*>, cause: Throwable) {
+        slots.remove(op)?.completeExceptionally(cause)
+    }
+
     fun cancelAll(cause: Throwable) {
-        for (deferred in slots.values) {
-            deferred.completeExceptionally(cause)
-        }
+        slots.values.forEach { it.completeExceptionally(cause) }
         slots.clear()
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
@@ -28,9 +28,9 @@ internal sealed interface ScanPredicate {
         val mask: ByteArray?,
     ) : ScanPredicate {
         override fun equals(other: Any?): Boolean =
-            this === other || (other is ServiceData && uuid == other.uuid && byteArrayFieldsEqual(data, mask, other.data, other.mask))
+            this === other || (other is ServiceData && uuid == other.uuid && contentPairEquals(data, mask, other.data, other.mask))
 
-        override fun hashCode(): Int = byteArrayFieldsHash(uuid.hashCode(), data, mask)
+        override fun hashCode(): Int = contentPairHash(uuid.hashCode(), data, mask)
     }
 
     data class ManufacturerData(
@@ -39,9 +39,9 @@ internal sealed interface ScanPredicate {
         val mask: ByteArray?,
     ) : ScanPredicate {
         override fun equals(other: Any?): Boolean =
-            this === other || (other is ManufacturerData && companyId == other.companyId && byteArrayFieldsEqual(data, mask, other.data, other.mask))
+            this === other || (other is ManufacturerData && companyId == other.companyId && contentPairEquals(data, mask, other.data, other.mask))
 
-        override fun hashCode(): Int = byteArrayFieldsHash(companyId, data, mask)
+        override fun hashCode(): Int = contentPairHash(companyId, data, mask)
     }
 
     data class MinRssi(
@@ -130,14 +130,14 @@ public class FiltersScope internal constructor() {
     }
 }
 
-private fun byteArrayFieldsEqual(
+private fun contentPairEquals(
     data1: ByteArray?,
     mask1: ByteArray?,
     data2: ByteArray?,
     mask2: ByteArray?,
 ): Boolean = data1.contentEquals(data2) && mask1.contentEquals(mask2)
 
-private fun byteArrayFieldsHash(
+private fun contentPairHash(
     seed: Int,
     data: ByteArray?,
     mask: ByteArray?,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
@@ -27,25 +27,10 @@ internal sealed interface ScanPredicate {
         val data: ByteArray?,
         val mask: ByteArray?,
     ) : ScanPredicate {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (other == null || this::class != other::class) return false
+        override fun equals(other: Any?): Boolean =
+            this === other || (other is ServiceData && uuid == other.uuid && byteArrayFieldsEqual(data, mask, other.data, other.mask))
 
-            other as ServiceData
-
-            if (uuid != other.uuid) return false
-            if (!data.contentEquals(other.data)) return false
-            if (!mask.contentEquals(other.mask)) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = uuid.hashCode()
-            result = 31 * result + (data?.contentHashCode() ?: 0)
-            result = 31 * result + (mask?.contentHashCode() ?: 0)
-            return result
-        }
+        override fun hashCode(): Int = byteArrayFieldsHash(uuid.hashCode(), data, mask)
     }
 
     data class ManufacturerData(
@@ -53,25 +38,10 @@ internal sealed interface ScanPredicate {
         val data: ByteArray?,
         val mask: ByteArray?,
     ) : ScanPredicate {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (other == null || this::class != other::class) return false
+        override fun equals(other: Any?): Boolean =
+            this === other || (other is ManufacturerData && companyId == other.companyId && byteArrayFieldsEqual(data, mask, other.data, other.mask))
 
-            other as ManufacturerData
-
-            if (companyId != other.companyId) return false
-            if (!data.contentEquals(other.data)) return false
-            if (!mask.contentEquals(other.mask)) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = companyId
-            result = 31 * result + (data?.contentHashCode() ?: 0)
-            result = 31 * result + (mask?.contentHashCode() ?: 0)
-            return result
-        }
+        override fun hashCode(): Int = byteArrayFieldsHash(companyId, data, mask)
     }
 
     data class MinRssi(
@@ -158,6 +128,24 @@ public class FiltersScope internal constructor() {
             matchGroups += scope.predicates.toList()
         }
     }
+}
+
+private fun byteArrayFieldsEqual(
+    data1: ByteArray?,
+    mask1: ByteArray?,
+    data2: ByteArray?,
+    mask2: ByteArray?,
+): Boolean = data1.contentEquals(data2) && mask1.contentEquals(mask2)
+
+private fun byteArrayFieldsHash(
+    seed: Int,
+    data: ByteArray?,
+    mask: ByteArray?,
+): Int {
+    var result = seed
+    result = 31 * result + (data?.contentHashCode() ?: 0)
+    result = 31 * result + (mask?.contentHashCode() ?: 0)
+    return result
 }
 
 /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
@@ -27,10 +27,13 @@ internal sealed interface ScanPredicate {
         val data: ByteArray?,
         val mask: ByteArray?,
     ) : ScanPredicate {
-        override fun equals(other: Any?): Boolean =
-            this === other || (other is ServiceData && uuid == other.uuid && contentPairEquals(data, mask, other.data, other.mask))
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ServiceData) return false
+            return uuid == other.uuid && byteFieldsEqual(data, mask, other.data, other.mask)
+        }
 
-        override fun hashCode(): Int = contentPairHash(uuid.hashCode(), data, mask)
+        override fun hashCode(): Int = byteFieldsHash(uuid.hashCode(), data, mask)
     }
 
     data class ManufacturerData(
@@ -38,10 +41,13 @@ internal sealed interface ScanPredicate {
         val data: ByteArray?,
         val mask: ByteArray?,
     ) : ScanPredicate {
-        override fun equals(other: Any?): Boolean =
-            this === other || (other is ManufacturerData && companyId == other.companyId && contentPairEquals(data, mask, other.data, other.mask))
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ManufacturerData) return false
+            return companyId == other.companyId && byteFieldsEqual(data, mask, other.data, other.mask)
+        }
 
-        override fun hashCode(): Int = contentPairHash(companyId, data, mask)
+        override fun hashCode(): Int = byteFieldsHash(companyId, data, mask)
     }
 
     data class MinRssi(
@@ -130,19 +136,19 @@ public class FiltersScope internal constructor() {
     }
 }
 
-private fun contentPairEquals(
+private fun byteFieldsEqual(
     data1: ByteArray?,
     mask1: ByteArray?,
     data2: ByteArray?,
     mask2: ByteArray?,
 ): Boolean = data1.contentEquals(data2) && mask1.contentEquals(mask2)
 
-private fun contentPairHash(
-    seed: Int,
+private fun byteFieldsHash(
+    identifierHash: Int,
     data: ByteArray?,
     mask: ByteArray?,
 ): Int {
-    var result = seed
+    var result = identifierHash
     result = 31 * result + (data?.contentHashCode() ?: 0)
     result = 31 * result + (mask?.contentHashCode() ?: 0)
     return result

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -27,11 +27,13 @@ import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -48,9 +50,7 @@ public class FakePeripheral internal constructor(
     private val context = PeripheralContext(identifier)
     private val observationManager = ObservationManager()
     private var closed = false
-
-    @Volatile
-    private var cccdWritesList = emptyList<CccdWrite>()
+    private val cccdWritesState = MutableStateFlow(emptyList<CccdWrite>())
 
     override val state: StateFlow<State> get() = context.state
     override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = context.bondState
@@ -220,7 +220,7 @@ public class FakePeripheral internal constructor(
     private fun <T> observeInternal(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-        mapper: suspend kotlinx.coroutines.flow.FlowCollector<T>.(ObservationEvent) -> Unit,
+        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
     ): Flow<T> {
         val serviceUuid = characteristic.serviceUuid
         val charUuid = characteristic.uuid
@@ -312,7 +312,7 @@ public class FakePeripheral internal constructor(
         charUuid: Uuid,
         enabled: Boolean,
     ) {
-        cccdWritesList = cccdWritesList + CccdWrite(serviceUuid, charUuid, enabled)
+        cccdWritesState.update { it + CccdWrite(serviceUuid, charUuid, enabled) }
     }
 
     private fun checkNotClosed() {
@@ -382,6 +382,7 @@ public class FakePeripheral internal constructor(
         observationManager.onPermanentDisconnect()
     }
 
+    /** Simulate a characteristic notification by emitting [value] to active observers. */
     public suspend fun emitObservationValue(
         serviceUuid: Uuid,
         charUuid: Uuid,
@@ -391,6 +392,7 @@ public class FakePeripheral internal constructor(
         observationManager.emitValue(serviceUuid, charUuid, value)
     }
 
+    /** Convenience overload accepting short or full UUID strings. */
     public suspend fun emitObservationValue(
         serviceUuid: String,
         charUuid: String,
@@ -403,12 +405,15 @@ public class FakePeripheral internal constructor(
         )
     }
 
-    public fun getCccdWrites(): List<CccdWrite> = cccdWritesList
+    /** Returns all CCCD writes recorded during observation setup/teardown. */
+    public fun getCccdWrites(): List<CccdWrite> = cccdWritesState.value
 
+    /** Clears recorded CCCD writes. */
     public fun clearCccdWrites() {
-        cccdWritesList = emptyList()
+        cccdWritesState.value = emptyList()
     }
 
+    /** Returns `true` if there are active collectors for the given characteristic. */
     public suspend fun hasCollectors(
         serviceUuid: Uuid,
         charUuid: Uuid,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -26,13 +26,12 @@ import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.update
+import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -49,16 +48,15 @@ public class FakePeripheral internal constructor(
     private val context = PeripheralContext(identifier)
     private val observationManager = ObservationManager()
     private var closed = false
-    private val _cccdWrites = MutableStateFlow<List<CccdWrite>>(emptyList())
+
+    @Volatile
+    private var cccdWritesList = emptyList<CccdWrite>()
 
     override val state: StateFlow<State> get() = context.state
     override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = context.bondState
     override val services: StateFlow<List<DiscoveredService>?> get() = context.services
     override val maximumWriteValueLength: StateFlow<Int> get() = context.maximumWriteValueLength
 
-    /**
-     * Record of CCCD writes for test verification.
-     */
     public data class CccdWrite(
         val serviceUuid: Uuid,
         val charUuid: Uuid,
@@ -139,7 +137,6 @@ public class FakePeripheral internal constructor(
     override suspend fun read(characteristic: Characteristic): ByteArray {
         checkNotClosed()
         checkConnected()
-        // config null → no delay/error injection, fall through to handler requirement
         val config = findConfig(characteristic)
         applyDelay(config)
         checkFailWith(config)
@@ -172,7 +169,6 @@ public class FakePeripheral internal constructor(
                     GattError("write", GattStatus.WriteNotPermitted),
                 )
             }
-            // No handler but writable — succeed silently
         }
     }
 
@@ -180,6 +176,7 @@ public class FakePeripheral internal constructor(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
     ): Flow<Observation> {
+        checkNotClosed()
         val config = findConfig(characteristic)
         failWithFlow<Observation>(config)?.let { return it }
         val handler = config?.observeHandler
@@ -202,6 +199,7 @@ public class FakePeripheral internal constructor(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
     ): Flow<ByteArray> {
+        checkNotClosed()
         val config = findConfig(characteristic)
         failWithFlow<ByteArray>(config)?.let { return it }
         val handler = config?.observeHandler
@@ -211,6 +209,7 @@ public class FakePeripheral internal constructor(
             observeInternal(characteristic, backpressure) { event ->
                 when (event) {
                     is ObservationEvent.Value -> emit(event.data)
+                    // Transparent reconnection — ObservationManager re-subscribes on reconnect
                     is ObservationEvent.Disconnected -> Unit
                     is ObservationEvent.PermanentlyDisconnected -> Unit
                 }
@@ -223,7 +222,6 @@ public class FakePeripheral internal constructor(
         backpressure: BackpressureStrategy,
         mapper: suspend kotlinx.coroutines.flow.FlowCollector<T>.(ObservationEvent) -> Unit,
     ): Flow<T> {
-        checkNotClosed()
         val serviceUuid = characteristic.serviceUuid
         val charUuid = characteristic.uuid
 
@@ -314,7 +312,7 @@ public class FakePeripheral internal constructor(
         charUuid: Uuid,
         enabled: Boolean,
     ) {
-        _cccdWrites.update { it + CccdWrite(serviceUuid, charUuid, enabled) }
+        cccdWritesList = cccdWritesList + CccdWrite(serviceUuid, charUuid, enabled)
     }
 
     private fun checkNotClosed() {
@@ -347,7 +345,6 @@ public class FakePeripheral internal constructor(
      */
     public suspend fun simulateReconnect(newServices: List<DiscoveredService>? = null) {
         checkNotClosed()
-        // Update services if provided (simulates service change on reconnect)
         if (newServices != null) {
             fakeServices = newServices
         }
@@ -358,7 +355,6 @@ public class FakePeripheral internal constructor(
         context.processEvent(ConnectionEvent.ServicesDiscovered)
         context.updateServices(fakeServices)
 
-        // Re-enable CCCD for observations that survived the disconnect
         resubscribeObservations()
 
         context.processEvent(ConnectionEvent.ConfigurationComplete)
@@ -371,7 +367,6 @@ public class FakePeripheral internal constructor(
             if (char != null) {
                 recordCccdWrite(key.serviceUuid, key.charUuid, enabled = true)
             } else {
-                // Characteristic no longer exists — complete that observation
                 observationManager.completeObservation(key)
             }
         }
@@ -387,9 +382,6 @@ public class FakePeripheral internal constructor(
         observationManager.onPermanentDisconnect()
     }
 
-    /**
-     * Emit a value to an observation. Use this to simulate characteristic notifications.
-     */
     public suspend fun emitObservationValue(
         serviceUuid: Uuid,
         charUuid: Uuid,
@@ -399,39 +391,24 @@ public class FakePeripheral internal constructor(
         observationManager.emitValue(serviceUuid, charUuid, value)
     }
 
-    /**
-     * Emit a value to an observation using short UUID strings.
-     */
     public suspend fun emitObservationValue(
         serviceUuid: String,
         charUuid: String,
         value: ByteArray,
     ) {
         emitObservationValue(
-            com.atruedev.kmpble.scanner
-                .uuidFrom(serviceUuid),
-            com.atruedev.kmpble.scanner
-                .uuidFrom(charUuid),
+            com.atruedev.kmpble.scanner.uuidFrom(serviceUuid),
+            com.atruedev.kmpble.scanner.uuidFrom(charUuid),
             value,
         )
     }
 
-    /**
-     * Get all CCCD writes that have occurred. Useful for verifying that
-     * CCCD is enabled/disabled at the correct times.
-     */
-    public fun getCccdWrites(): List<CccdWrite> = _cccdWrites.value
+    public fun getCccdWrites(): List<CccdWrite> = cccdWritesList
 
-    /**
-     * Clear recorded CCCD writes.
-     */
     public fun clearCccdWrites() {
-        _cccdWrites.value = emptyList()
+        cccdWritesList = emptyList()
     }
 
-    /**
-     * Check if there are any active collectors for a characteristic.
-     */
     public suspend fun hasCollectors(
         serviceUuid: Uuid,
         charUuid: Uuid,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -26,11 +26,13 @@ import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
 import kotlin.time.Duration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -47,7 +49,7 @@ public class FakePeripheral internal constructor(
     private val context = PeripheralContext(identifier)
     private val observationManager = ObservationManager()
     private var closed = false
-    private val cccdWrites = mutableListOf<CccdWrite>()
+    private val _cccdWrites = MutableStateFlow<List<CccdWrite>>(emptyList())
 
     override val state: StateFlow<State> get() = context.state
     override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = context.bondState
@@ -178,40 +180,21 @@ public class FakePeripheral internal constructor(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
     ): Flow<Observation> {
-        checkNotClosed()
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
         val config = findConfig(characteristic)
         failWithFlow<Observation>(config)?.let { return it }
-
         val handler = config?.observeHandler
-
         return if (handler != null) {
             handler()
                 .map<ByteArray, Observation> { Observation.Value(it) }
                 .applyBackpressure(backpressure)
         } else {
-            flow {
-                val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-                eventFlow.collect { event ->
-                    when (event) {
-                        is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                        is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                        is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-                    }
+            observeInternal(characteristic, backpressure) { event ->
+                when (event) {
+                    is ObservationEvent.Value -> emit(Observation.Value(event.data))
+                    is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
+                    is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
                 }
-            }.onStart {
-                if (context.state.value is State.Connected.Ready) {
-                    cccdWrites.add(CccdWrite(serviceUuid, charUuid, enabled = true))
-                }
-            }.applyBackpressure(backpressure)
-                .onCompletion {
-                    val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                    if (wasLastCollector && context.state.value is State.Connected) {
-                        cccdWrites.add(CccdWrite(serviceUuid, charUuid, enabled = false))
-                    }
-                }
+            }
         }
     }
 
@@ -219,43 +202,45 @@ public class FakePeripheral internal constructor(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
     ): Flow<ByteArray> {
+        val config = findConfig(characteristic)
+        failWithFlow<ByteArray>(config)?.let { return it }
+        val handler = config?.observeHandler
+        return if (handler != null) {
+            handler().applyBackpressure(backpressure)
+        } else {
+            observeInternal(characteristic, backpressure) { event ->
+                when (event) {
+                    is ObservationEvent.Value -> emit(event.data)
+                    is ObservationEvent.Disconnected -> Unit
+                    is ObservationEvent.PermanentlyDisconnected -> Unit
+                }
+            }
+        }
+    }
+
+    private fun <T> observeInternal(
+        characteristic: Characteristic,
+        backpressure: BackpressureStrategy,
+        mapper: suspend kotlinx.coroutines.flow.FlowCollector<T>.(ObservationEvent) -> Unit,
+    ): Flow<T> {
         checkNotClosed()
         val serviceUuid = characteristic.serviceUuid
         val charUuid = characteristic.uuid
 
-        val config = findConfig(characteristic)
-        failWithFlow<ByteArray>(config)?.let { return it }
-
-        val handler = config?.observeHandler
-
-        return if (handler != null) {
-            handler().applyBackpressure(backpressure)
-        } else {
-            flow {
-                val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-                eventFlow.collect { event ->
-                    when (event) {
-                        is ObservationEvent.Value -> emit(event.data)
-                        is ObservationEvent.Disconnected -> {
-                            // Transparent reconnection — no emission during disconnect
-                        }
-                        is ObservationEvent.PermanentlyDisconnected -> {
-                            // Flow completes normally, no emission (transformWhile ends the flow)
-                        }
-                    }
+        return flow {
+            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
+            eventFlow.collect { event -> mapper(event) }
+        }.onStart {
+            if (context.state.value is State.Connected.Ready) {
+                recordCccdWrite(serviceUuid, charUuid, enabled = true)
+            }
+        }.applyBackpressure(backpressure)
+            .onCompletion {
+                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
+                if (wasLastCollector && context.state.value is State.Connected) {
+                    recordCccdWrite(serviceUuid, charUuid, enabled = false)
                 }
-            }.onStart {
-                if (context.state.value is State.Connected.Ready) {
-                    cccdWrites.add(CccdWrite(serviceUuid, charUuid, enabled = true))
-                }
-            }.applyBackpressure(backpressure)
-                .onCompletion {
-                    val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                    if (wasLastCollector && context.state.value is State.Connected) {
-                        cccdWrites.add(CccdWrite(serviceUuid, charUuid, enabled = false))
-                    }
-                }
-        }
+            }
     }
 
     override suspend fun readDescriptor(descriptor: Descriptor): ByteArray {
@@ -324,6 +309,14 @@ public class FakePeripheral internal constructor(
                 it.characteristic.uuid == characteristic.uuid
         }
 
+    private fun recordCccdWrite(
+        serviceUuid: Uuid,
+        charUuid: Uuid,
+        enabled: Boolean,
+    ) {
+        _cccdWrites.update { it + CccdWrite(serviceUuid, charUuid, enabled) }
+    }
+
     private fun checkNotClosed() {
         check(!closed) { "Peripheral is closed" }
     }
@@ -376,7 +369,7 @@ public class FakePeripheral internal constructor(
         for (key in toResubscribe) {
             val char = findCharacteristic(key.serviceUuid, key.charUuid)
             if (char != null) {
-                cccdWrites.add(CccdWrite(key.serviceUuid, key.charUuid, enabled = true))
+                recordCccdWrite(key.serviceUuid, key.charUuid, enabled = true)
             } else {
                 // Characteristic no longer exists — complete that observation
                 observationManager.completeObservation(key)
@@ -427,13 +420,13 @@ public class FakePeripheral internal constructor(
      * Get all CCCD writes that have occurred. Useful for verifying that
      * CCCD is enabled/disabled at the correct times.
      */
-    public fun getCccdWrites(): List<CccdWrite> = cccdWrites.toList()
+    public fun getCccdWrites(): List<CccdWrite> = _cccdWrites.value
 
     /**
      * Clear recorded CCCD writes.
      */
     public fun clearCccdWrites() {
-        cccdWrites.clear()
+        _cccdWrites.value = emptyList()
     }
 
     /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -26,14 +26,14 @@ import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
 import kotlin.time.Duration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -399,8 +399,10 @@ public class FakePeripheral internal constructor(
         value: ByteArray,
     ) {
         emitObservationValue(
-            com.atruedev.kmpble.scanner.uuidFrom(serviceUuid),
-            com.atruedev.kmpble.scanner.uuidFrom(charUuid),
+            com.atruedev.kmpble.scanner
+                .uuidFrom(serviceUuid),
+            com.atruedev.kmpble.scanner
+                .uuidFrom(charUuid),
             value,
         )
     }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -27,6 +27,7 @@ import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.gatt.internal.PersistedObservation
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
@@ -270,14 +271,12 @@ public class IosPeripheral(
                     // one of read/write is pending. Check write first, then read, then notification.
                     val cbChar = event.characteristic
                     val error = event.error
-                    if (pendingOps.characteristicWrite != null) {
-                        pendingOps.characteristicWrite?.complete(error.toGattStatus())
-                        pendingOps.characteristicWrite = null
-                    } else if (pendingOps.characteristicRead != null) {
+                    if (pendingOps.has(PendingOp.CharacteristicWrite)) {
+                        pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
+                    } else if (pendingOps.has(PendingOp.CharacteristicRead)) {
                         val status = error.toGattStatus()
                         val value = cbChar.value?.toByteArray() ?: byteArrayOf()
-                        pendingOps.characteristicRead?.complete(GattResult(value, status))
-                        pendingOps.characteristicRead = null
+                        pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, status))
                     } else {
                         val value = cbChar.value?.toByteArray() ?: return@launch
                         val svcUuid = uuidFrom(cbChar.service?.UUID?.UUIDString ?: return@launch)
@@ -286,33 +285,29 @@ public class IosPeripheral(
                     }
                 }
                 is AppleCallbackEvent.DidWriteValueForCharacteristic -> {
-                    pendingOps.characteristicWrite?.complete(event.error.toGattStatus())
-                    pendingOps.characteristicWrite = null
+                    pendingOps.complete(PendingOp.CharacteristicWrite, event.error.toGattStatus())
                 }
                 is AppleCallbackEvent.DidUpdateValueForDescriptor -> {
                     val error = event.error
-                    if (pendingOps.descriptorWrite != null) {
-                        pendingOps.descriptorWrite?.complete(error.toGattStatus())
-                        pendingOps.descriptorWrite = null
+                    if (pendingOps.has(PendingOp.DescriptorWrite)) {
+                        pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
                     } else {
                         val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
-                        pendingOps.descriptorRead?.complete(GattResult(value, error.toGattStatus()))
-                        pendingOps.descriptorRead = null
+                        pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
                     }
                 }
                 is AppleCallbackEvent.DidWriteValueForDescriptor -> {
-                    pendingOps.descriptorWrite?.complete(event.error.toGattStatus())
-                    pendingOps.descriptorWrite = null
+                    pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
                 }
                 is AppleCallbackEvent.DidReadRSSI -> {
                     if (event.error == null) {
-                        pendingOps.rssiRead?.complete(event.rssi.intValue)
+                        pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
                     } else {
-                        pendingOps.rssiRead?.completeExceptionally(
+                        pendingOps.fail(
+                            PendingOp.RssiRead,
                             Exception("readRSSI failed: ${event.error.localizedDescription}"),
                         )
                     }
-                    pendingOps.rssiRead = null
                 }
                 is AppleCallbackEvent.DidOpenL2CAPChannel -> {
                     handleDidOpenL2CAPChannel(event)
@@ -442,7 +437,7 @@ public class IosPeripheral(
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbChar(characteristic)
             val deferred = CompletableDeferred<GattResult>()
-            pendingOps.characteristicRead = deferred
+            pendingOps.set(PendingOp.CharacteristicRead, deferred)
             bridge.readCharacteristic(native)
             val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
@@ -465,7 +460,7 @@ public class IosPeripheral(
             for (chunk in chunks) {
                 if (withResponse) {
                     val deferred = CompletableDeferred<GattStatus>()
-                    pendingOps.characteristicWrite = deferred
+                    pendingOps.set(PendingOp.CharacteristicWrite, deferred)
                     bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
                     val status = deferred.await()
                     if (!status.isSuccess()) throw BleException(GattError("write", status))
@@ -541,7 +536,7 @@ public class IosPeripheral(
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
             val deferred = CompletableDeferred<GattResult>()
-            pendingOps.descriptorRead = deferred
+            pendingOps.set(PendingOp.DescriptorRead, deferred)
             bridge.readDescriptor(native)
             val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("readDescriptor", result.status))
@@ -557,7 +552,7 @@ public class IosPeripheral(
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
             val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.descriptorWrite = deferred
+            pendingOps.set(PendingOp.DescriptorWrite, deferred)
             bridge.writeDescriptor(native, data.toNSData())
             val status = deferred.await()
             if (!status.isSuccess()) throw BleException(GattError("writeDescriptor", status))
@@ -568,7 +563,7 @@ public class IosPeripheral(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val deferred = CompletableDeferred<Int>()
-            pendingOps.rssiRead = deferred
+            pendingOps.set(PendingOp.RssiRead, deferred)
             bridge.readRSSI()
             deferred.await()
         }


### PR DESCRIPTION
## Summary

- **PendingOperations**: Replace 6 repetitive `PendingSlot` delegate properties
  with a map keyed by `PendingOp<T>` sealed interface. The type parameter binds
  each operation to its result type at compile time. `cancelAll()` is exhaustive
  by construction. Confinement to the peripheral's serialized dispatcher is
  documented explicitly.

- **observe/observeValues**: Extract `observeInternal()` in `IosPeripheral` and
  `FakePeripheral` to match `AndroidPeripheral`'s existing pattern, eliminating
  ~60 duplicated lines of flow setup/teardown per file. Clean up FQN references
  to `FlowCollector` and `flow` builder across all three peripherals.

- **ScanPredicate**: Consolidate `ServiceData` and `ManufacturerData`
  equals/hashCode into `byteFieldsEqual`/`byteFieldsHash` utilities with
  multi-line equals for readability.

- **GattOperationQueue**: Combine 3 separate `@Volatile` fields into a single
  `QueueState` snapshot reference. Restore graceful drain-before-cancel ordering
  in `start()`.

- **FakePeripheral cccdWrites**: Replace `@Volatile` copy-on-write (racy
  read-modify-write) with `MutableStateFlow.update` for atomic appends.
  Restore essential KDoc on public test API methods.

## Test plan

- [x] `compileKotlinMetadata` — commonMain
- [x] `compileKotlinJvm` — JVM target
- [x] `compileKotlinIosSimulatorArm64` — iOS/Native target
- [x] `jvmTest` — all tests pass, 0 failures