### PR TITLE
fix(shared): harden thread safety and unify error types across peripherals

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.IOException
+import java.util.UUID
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -91,8 +92,13 @@ public class AndroidPeripheral internal constructor(
     private val peripheralContext = PeripheralContext(identifier)
     private val bridge = AndroidGattBridge(device, context)
 
+    @Volatile
     private var connectionComplete: CompletableDeferred<Unit>? = null
+
+    @Volatile
     private var discoveryComplete: CompletableDeferred<List<DiscoveredService>>? = null
+
+    @Volatile
     private var disconnectComplete: CompletableDeferred<Unit>? = null
     private val pendingOps = PendingOperations()
     private val observationManager = ObservationManager()
@@ -113,6 +119,8 @@ public class AndroidPeripheral internal constructor(
 
     @Volatile
     private var closed = false
+
+    @Volatile
     private var currentConnectionOptions: ConnectionOptions? = null
     private val reconnectionHandler =
         ReconnectionHandler(
@@ -359,12 +367,13 @@ public class AndroidPeripheral internal constructor(
                     pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
                 }
                 is GattCallbackEvent.ReadRemoteRssi -> {
-                    if (event.status.toGattStatus().isSuccess()) {
+                    val status = event.status.toGattStatus()
+                    if (status.isSuccess()) {
                         pendingOps.complete(PendingOp.RssiRead, event.rssi)
                     } else {
                         pendingOps.fail(
                             PendingOp.RssiRead,
-                            Exception("readRssi failed: ${event.status.toGattStatus()}"),
+                            BleException(GattError("readRssi", status)),
                         )
                     }
                 }
@@ -461,7 +470,7 @@ public class AndroidPeripheral internal constructor(
             )
             connectionComplete?.complete(Unit)
             discoveryComplete?.completeExceptionally(
-                IllegalStateException("Service discovery failed: $status"),
+                BleException(GattError("discoverServices", status)),
             )
         }
     }
@@ -634,7 +643,7 @@ public class AndroidPeripheral internal constructor(
     private suspend fun enableNotifications(characteristic: Characteristic) {
         val native = requireNativeChar(characteristic)
         bridge.setCharacteristicNotification(native, true)
-        val cccd = native.getDescriptor(java.util.UUID.fromString(CCCD_UUID.toString())) ?: return
+        val cccd = native.getDescriptor(UUID.fromString(CCCD_UUID.toString())) ?: return
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
             val deferred = CompletableDeferred<GattStatus>()
@@ -651,7 +660,7 @@ public class AndroidPeripheral internal constructor(
         if (peripheralContext.state.value !is State.Connected) return
         val native = nativeCharMap[characteristic] ?: return
         bridge.setCharacteristicNotification(native, false)
-        val cccd = native.getDescriptor(java.util.UUID.fromString(CCCD_UUID.toString())) ?: return
+        val cccd = native.getDescriptor(UUID.fromString(CCCD_UUID.toString())) ?: return
         peripheralContext.scope.launch {
             try {
                 peripheralContext.gattQueue.enqueue {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.peripheral
 
+import com.atruedev.kmpble.BleData
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bleDataFromNSData
@@ -60,11 +61,14 @@ import platform.CoreBluetooth.CBCharacteristicPropertyNotify
 import platform.CoreBluetooth.CBCharacteristicPropertyRead
 import platform.CoreBluetooth.CBCharacteristicPropertyWrite
 import platform.CoreBluetooth.CBCharacteristicPropertyWriteWithoutResponse
+import platform.CoreBluetooth.CBCharacteristicWriteWithResponse
 import platform.CoreBluetooth.CBDescriptor
 import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreBluetooth.CBPeripheral
+import platform.CoreBluetooth.CBPeripheralStateConnected
 import platform.CoreBluetooth.CBService
 import platform.Foundation.NSData
+import platform.Foundation.NSError
 import kotlin.concurrent.Volatile
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
@@ -79,8 +83,13 @@ public class IosPeripheral(
     private val bridge = ApplePeripheralBridge(cbPeripheral)
     private val centralDelegate = CentralManagerProvider.scanDelegate
 
+    @Volatile
     private var connectionComplete: CompletableDeferred<Unit>? = null
+
+    @Volatile
     private var discoveryComplete: CompletableDeferred<List<DiscoveredService>>? = null
+
+    @Volatile
     private var disconnectComplete: CompletableDeferred<Unit>? = null
     private val pendingOps = PendingOperations()
     private val observationManager = ObservationManager()
@@ -90,6 +99,7 @@ public class IosPeripheral(
     private val nativeDescMap = mutableMapOf<Descriptor, CBDescriptor>()
 
     // L2CAP state
+    @Volatile
     private var pendingL2capChannel: CompletableDeferred<CBL2CAPChannel>? = null
     private val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
 
@@ -232,7 +242,7 @@ public class IosPeripheral(
 
     private fun handleConnectionCallback(
         connected: Boolean,
-        error: platform.Foundation.NSError?,
+        error: NSError?,
     ) {
         peripheralContext.scope.launch {
             if (connected) {
@@ -305,7 +315,7 @@ public class IosPeripheral(
                     } else {
                         pendingOps.fail(
                             PendingOp.RssiRead,
-                            Exception("readRSSI failed: ${event.error.localizedDescription}"),
+                            BleException(GattError("readRssi", event.error.toGattStatus())),
                         )
                     }
                 }
@@ -325,7 +335,7 @@ public class IosPeripheral(
             )
             connectionComplete?.complete(Unit)
             discoveryComplete?.completeExceptionally(
-                IllegalStateException("Service discovery failed: ${event.error.localizedDescription}"),
+                BleException(GattError("discoverServices", event.error.toGattStatus())),
             )
             return
         }
@@ -425,10 +435,7 @@ public class IosPeripheral(
         nativeDescMap[descriptor]
             ?: throw IllegalArgumentException("Descriptor not found.")
 
-    private fun ByteArray.toNSData(): NSData =
-        com.atruedev.kmpble
-            .BleData(this)
-            .nsData
+    private fun ByteArray.toNSData(): NSData = BleData(this).nsData
 
     private fun NSData.toByteArray(): ByteArray = bleDataFromNSData(this).toByteArray()
 
@@ -576,7 +583,7 @@ public class IosPeripheral(
         val actualMtu =
             cbPeripheral
                 .maximumWriteValueLengthForType(
-                    platform.CoreBluetooth.CBCharacteristicWriteWithResponse,
+                    CBCharacteristicWriteWithResponse,
                 ).toInt() + ATT_HEADER_SIZE
         peripheralContext.updateMtu(actualMtu)
         return actualMtu
@@ -694,7 +701,7 @@ public class IosPeripheral(
             // If the peripheral is already connected (iOS maintained the connection),
             // trigger service discovery to rebuild the native char/desc maps and
             // re-enable notifications.
-            if (cbPeripheral.state == platform.CoreBluetooth.CBPeripheralStateConnected) {
+            if (cbPeripheral.state == CBPeripheralStateConnected) {
                 peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
                 peripheralContext.gattQueue.start()
                 peripheralContext.processEvent(ConnectionEvent.LinkEstablished)


### PR DESCRIPTION
## Summary

- Add missing `@Volatile` annotations to `CompletableDeferred` vars (`connectionComplete`, `discoveryComplete`, `disconnectComplete`, `pendingL2capChannel`, `currentConnectionOptions`) ensuring cross-thread visibility
- Replace generic `Exception`/`IllegalStateException` with structured `BleException(GattError(...))` for `readRssi` callback failures and service discovery failures on both platforms
- Clean remaining FQN references (`FlowCollector`, `flow`, `java.util.UUID`, `NSError`, `CBCharacteristicWriteWithResponse`, `CBPeripheralStateConnected`, `BleData`)

## Stacking

Rebased on top of #133 — merge #133 first, then this PR merges cleanly into main.

## Test plan

- [x] `compileKotlinJvm` passes
- [x] `compileKotlinIosArm64` passes
- [ ] Android compilation (CI will validate)