### PR TITLE
fix(ci): use macos runner for Dokka API docs generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
 
   deploy-api-docs:
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- The `deploy-api-docs` job in the publish workflow runs on `ubuntu-latest`, but Dokka triggers iOS target compilation (`:compileObjcIosArm64`) which requires `xcrun` — a macOS-only tool
- Changed the runner to `macos-latest` so `xcrun` is available

Fixes: https://github.com/gary-quinn/kmp-ble/actions/runs/24339724303/job/71066838517

## Test plan
- [ ] Verify the next publish workflow run completes the `deploy-api-docs` job successfully