### PR TITLE
fix: eliminate non-null assertions and make iOS L2CAP MTU configurable

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
@@ -50,7 +50,8 @@ internal class AndroidBondManager(
             return true
         }
 
-        bondComplete = CompletableDeferred()
+        val deferred = CompletableDeferred<Boolean>()
+        bondComplete = deferred
         val initiated = device.createBond()
         if (!initiated) {
             bondComplete = null
@@ -58,7 +59,7 @@ internal class AndroidBondManager(
         }
 
         return try {
-            bondComplete!!.await()
+            deferred.await()
         } finally {
             bondComplete = null
         }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -217,7 +217,8 @@ public class AndroidPeripheral internal constructor(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            connectionComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            connectionComplete = deferred
 
             val gatt = bridge.connect(options)
             if (gatt == null) {
@@ -233,7 +234,7 @@ public class AndroidPeripheral internal constructor(
 
             try {
                 withTimeout(timeout) {
-                    connectionComplete!!.await()
+                    deferred.await()
                 }
             } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
@@ -265,11 +266,12 @@ public class AndroidPeripheral internal constructor(
             pairingRequestHandler.stop()
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            disconnectComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            disconnectComplete = deferred
             bridge.disconnect()
 
             try {
-                withTimeout(DISCONNECT_TIMEOUT) { disconnectComplete!!.await() }
+                withTimeout(DISCONNECT_TIMEOUT) { deferred.await() }
             } catch (_: TimeoutCancellationException) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
@@ -304,13 +306,14 @@ public class AndroidPeripheral internal constructor(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            discoveryComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<List<DiscoveredService>>()
+            discoveryComplete = deferred
             if (!bridge.discoverServices()) {
                 discoveryComplete = null
                 throw BleException(OperationFailed("discoverServices initiation failed"))
             }
             try {
-                withTimeout(SERVICE_DISCOVERY_TIMEOUT) { discoveryComplete!!.await() }
+                withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
                 discoveryComplete = null
             }
@@ -755,6 +758,7 @@ public class AndroidPeripheral internal constructor(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -56,7 +56,7 @@ internal class AndroidExtendedAdvertiser(
         val data = config.toAdvertiseData()
 
         val setId = withContext(serialDispatcher) { ++nextSetId }
-        var callbackRef: AdvertisingSetCallback? = null
+        lateinit var callbackRef: AdvertisingSetCallback
 
         val callback =
             object : AdvertisingSetCallback() {
@@ -67,7 +67,7 @@ internal class AndroidExtendedAdvertiser(
                 ) {
                     scope.launch {
                         if (status == ADVERTISE_SUCCESS && advertisingSet != null) {
-                            advertisingSets[setId] = AdvertisingSetHandle(advertisingSet, callbackRef!!)
+                            advertisingSets[setId] = AdvertisingSetHandle(advertisingSet, callbackRef)
                             _activeSets.update { it + setId }
                             logEvent(BleLogEvent.ServerLifecycle("extended advertising set $setId started"))
                             deferred.complete(setId)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
@@ -42,10 +42,13 @@ public interface L2capChannel : AutoCloseable {
      * Writes larger than this are segmented automatically by the OS.
      * Typical values: 2KB–64KB depending on peripheral and connection.
      *
-     * **Note:** iOS does not expose the negotiated L2CAP MTU directly via
-     * `CBL2CAPChannel`. The value returned is a conservative default (2048 bytes).
-     * Callers performing chunked transfers (e.g., firmware updates) should treat
-     * this as an upper-bound hint, not a precise negotiated value.
+     * **Platform behavior:**
+     * - **Android:** Queried from the socket via `maxTransmitPacketSize`, floored
+     *   at 672 bytes. Reflects the actual negotiated value.
+     * - **iOS:** CoreBluetooth does not expose the negotiated L2CAP MTU.
+     *   Defaults to 2048 bytes. Pass an explicit `mtu` to
+     *   [com.atruedev.kmpble.peripheral.Peripheral.openL2capChannel] to override
+     *   when the peripheral's MTU is known (e.g., from a device specification).
      */
     public val mtu: Int
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -168,6 +168,11 @@ public interface Peripheral : AutoCloseable {
      *                 channels inherit the connection's security level.
      *               - **Android:** When true, uses `createL2capChannel()` (encrypted);
      *                 when false, uses `createInsecureL2capChannel()`.
+     * @param mtu Optional MTU hint for the channel. **Platform behavior varies:**
+     *            - **iOS:** CoreBluetooth does not expose the negotiated L2CAP MTU.
+     *              When provided, the channel uses this value instead of the
+     *              conservative 2048-byte default.
+     *            - **Android:** Ignored. The MTU is queried from the socket directly.
      * @return Open L2CAP channel ready for communication
      * @throws com.atruedev.kmpble.l2cap.L2capException.NotConnected if peripheral is not connected
      * @throws com.atruedev.kmpble.l2cap.L2capException.OpenFailed if channel cannot be opened
@@ -176,5 +181,6 @@ public interface Peripheral : AutoCloseable {
     public suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean = true,
+        mtu: Int? = null,
     ): L2capChannel
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -258,6 +258,7 @@ public class FakePeripheral internal constructor(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
         if (context.state.value !is State.Connected) {

--- a/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/L2capChannelTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/L2capChannelTest.kt
@@ -199,6 +199,20 @@ class L2capChannelTest {
             assertEquals(0x42, receivedPsm)
         }
 
+    @Test
+    fun openL2capChannelPassesMtuToChannel() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    onOpenL2capChannel { psm -> FakeL2capChannel(psm, mtu = 4096) }
+                }
+
+            peripheral.connect()
+            val channel = peripheral.openL2capChannel(psm = 0x25, mtu = 4096)
+
+            assertEquals(4096, channel.mtu)
+        }
+
     // --- L2capException hierarchy ---
 
     @Test

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -27,10 +27,9 @@ import kotlin.coroutines.coroutineContext
 internal class IosL2capChannel(
     private val cbChannel: CBL2CAPChannel,
     private val scope: CoroutineScope,
+    override val mtu: Int = DEFAULT_MTU,
 ) : L2capChannel {
     override val psm: Int = cbChannel.PSM.toInt()
-
-    override val mtu: Int = DEFAULT_MTU
 
     private val _isOpen = MutableStateFlow(true)
     override val isOpen: Boolean get() = _isOpen.value

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -594,6 +594,7 @@ public class IosPeripheral(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
         if (peripheralContext.state.value !is State.Connected) {
@@ -614,7 +615,12 @@ public class IosPeripheral(
                     withTimeout(L2CAP_OPEN_TIMEOUT) {
                         deferred.await()
                     }
-                val channel = IosL2capChannel(cbChannel, peripheralContext.scope)
+                val channel =
+                    if (mtu != null) {
+                        IosL2capChannel(cbChannel, peripheralContext.scope, mtu)
+                    } else {
+                        IosL2capChannel(cbChannel, peripheralContext.scope)
+                    }
                 activeL2capChannels.update { it + channel }
                 channel
             } catch (_: TimeoutCancellationException) {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -409,7 +409,7 @@ internal class IosGattServer(
                     assembled
                 } else {
                     requests.map { request ->
-                        val data = if (request.value != null) bleDataFromNSData(request.value!!) else emptyBleData()
+                        val data = request.value?.let(::bleDataFromNSData) ?: emptyBleData()
                         request.charUuid to data
                     }
                 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -87,6 +87,7 @@ internal class StubPeripheral(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel = unsupported()
 
     private fun unsupported(): Nothing = throw UnsupportedOperationException("StubPeripheral")


### PR DESCRIPTION
## Summary

- Replace `!!` with idiomatic Kotlin alternatives in production code (local-val capture, `lateinit`, `?.let`)
- Add optional `mtu: Int?` parameter to `Peripheral.openL2capChannel()` for iOS MTU override

## Changes

**Non-null assertion removal (5 sites across 4 files):**

| File | Before | After |
|------|--------|-------|
| `AndroidPeripheral` | `connectionComplete!!.await()` (×3 deferreds) | Local val captures the deferred; field stays for GATT callbacks |
| `AndroidBondManager` | `bondComplete!!.await()` | Same local-val pattern |
| `AndroidExtendedAdvertiser` | `callbackRef!!` | `lateinit var` — idiomatic for deferred init |
| `IosGattServer` | `if (x != null) f(x!!)` | `?.let(::f) ?: default` |

`BleData.ios.kt:23` (`nsData.bytes!!`) intentionally kept — ObjC interop hot path where the bounds check already guards zero-length access.

**iOS L2CAP MTU:**

CoreBluetooth does not expose the negotiated L2CAP MTU. The previous hardcode (2048) gave callers no override path. Now `openL2capChannel(psm, secure, mtu)` accepts an optional hint that iOS forwards to the channel constructor. Android ignores the parameter (it queries `socket.maxTransmitPacketSize` directly).

## Test plan

- [x] `testAndroidHostTest` — all pass
- [x] `iosSimulatorArm64Test` — all pass
- [x] `jvmTest` (Lincheck) — all pass
- [x] `ktlintCheck` — clean
- [x] New test: `openL2capChannelPassesMtuToChannel`