### PR TITLE
refactor: replace non-null assertions; feat(l2cap): configurable iOS MTU

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
@@ -50,7 +50,8 @@ internal class AndroidBondManager(
             return true
         }
 
-        bondComplete = CompletableDeferred()
+        val deferred = CompletableDeferred<Boolean>()
+        bondComplete = deferred
         val initiated = device.createBond()
         if (!initiated) {
             bondComplete = null
@@ -58,7 +59,7 @@ internal class AndroidBondManager(
         }
 
         return try {
-            bondComplete!!.await()
+            deferred.await()
         } finally {
             bondComplete = null
         }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -758,8 +758,10 @@ public class AndroidPeripheral internal constructor(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
+        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
 
         val currentState = state.value
         if (currentState !is State.Connected.Ready) {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -217,7 +217,8 @@ public class AndroidPeripheral internal constructor(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            connectionComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            connectionComplete = deferred
 
             val gatt = bridge.connect(options)
             if (gatt == null) {
@@ -233,7 +234,7 @@ public class AndroidPeripheral internal constructor(
 
             try {
                 withTimeout(timeout) {
-                    connectionComplete!!.await()
+                    deferred.await()
                 }
             } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
@@ -265,11 +266,12 @@ public class AndroidPeripheral internal constructor(
             pairingRequestHandler.stop()
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            disconnectComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<Unit>()
+            disconnectComplete = deferred
             bridge.disconnect()
 
             try {
-                withTimeout(DISCONNECT_TIMEOUT) { disconnectComplete!!.await() }
+                withTimeout(DISCONNECT_TIMEOUT) { deferred.await() }
             } catch (_: TimeoutCancellationException) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
@@ -304,13 +306,14 @@ public class AndroidPeripheral internal constructor(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            discoveryComplete = CompletableDeferred()
+            val deferred = CompletableDeferred<List<DiscoveredService>>()
+            discoveryComplete = deferred
             if (!bridge.discoverServices()) {
                 discoveryComplete = null
                 throw BleException(OperationFailed("discoverServices initiation failed"))
             }
             try {
-                withTimeout(SERVICE_DISCOVERY_TIMEOUT) { discoveryComplete!!.await() }
+                withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
                 discoveryComplete = null
             }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -56,7 +56,7 @@ internal class AndroidExtendedAdvertiser(
         val data = config.toAdvertiseData()
 
         val setId = withContext(serialDispatcher) { ++nextSetId }
-        var callbackRef: AdvertisingSetCallback? = null
+        lateinit var callbackRef: AdvertisingSetCallback
 
         val callback =
             object : AdvertisingSetCallback() {
@@ -67,7 +67,7 @@ internal class AndroidExtendedAdvertiser(
                 ) {
                     scope.launch {
                         if (status == ADVERTISE_SUCCESS && advertisingSet != null) {
-                            advertisingSets[setId] = AdvertisingSetHandle(advertisingSet, callbackRef!!)
+                            advertisingSets[setId] = AdvertisingSetHandle(advertisingSet, callbackRef)
                             _activeSets.update { it + setId }
                             logEvent(BleLogEvent.ServerLifecycle("extended advertising set $setId started"))
                             deferred.complete(setId)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
@@ -42,10 +42,13 @@ public interface L2capChannel : AutoCloseable {
      * Writes larger than this are segmented automatically by the OS.
      * Typical values: 2KB–64KB depending on peripheral and connection.
      *
-     * **Note:** iOS does not expose the negotiated L2CAP MTU directly via
-     * `CBL2CAPChannel`. The value returned is a conservative default (2048 bytes).
-     * Callers performing chunked transfers (e.g., firmware updates) should treat
-     * this as an upper-bound hint, not a precise negotiated value.
+     * **Platform behavior:**
+     * - **Android:** Queried from the socket via `maxTransmitPacketSize`, floored
+     *   at 672 bytes. Reflects the actual negotiated value.
+     * - **iOS:** CoreBluetooth does not expose the negotiated L2CAP MTU.
+     *   Defaults to 2048 bytes. Pass an explicit `mtu` to
+     *   [com.atruedev.kmpble.peripheral.Peripheral.openL2capChannel] to override
+     *   when the peripheral's MTU is known (e.g., from a device specification).
      */
     public val mtu: Int
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -168,7 +168,14 @@ public interface Peripheral : AutoCloseable {
      *                 channels inherit the connection's security level.
      *               - **Android:** When true, uses `createL2capChannel()` (encrypted);
      *                 when false, uses `createInsecureL2capChannel()`.
+     * @param mtu Optional MTU hint for the channel (must be positive if provided).
+     *            **Platform behavior varies:**
+     *            - **iOS:** CoreBluetooth does not expose the negotiated L2CAP MTU.
+     *              When provided, the channel uses this value instead of the
+     *              conservative 2048-byte default.
+     *            - **Android:** Ignored. The MTU is queried from the socket directly.
      * @return Open L2CAP channel ready for communication
+     * @throws IllegalArgumentException if [mtu] is not positive
      * @throws com.atruedev.kmpble.l2cap.L2capException.NotConnected if peripheral is not connected
      * @throws com.atruedev.kmpble.l2cap.L2capException.OpenFailed if channel cannot be opened
      * @throws com.atruedev.kmpble.l2cap.L2capException.NotSupported if L2CAP is not available
@@ -176,5 +183,6 @@ public interface Peripheral : AutoCloseable {
     public suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean = true,
+        mtu: Int? = null,
     ): L2capChannel
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -258,15 +258,17 @@ public class FakePeripheral internal constructor(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
+        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
         if (context.state.value !is State.Connected) {
             throw L2capException.NotConnected("Peripheral is not connected (state: ${context.state.value})")
         }
         val handler =
             onL2capHandler
                 ?: throw L2capException.NotSupported("No onOpenL2capChannel handler configured")
-        return handler(psm)
+        return handler(psm, mtu)
     }
 
     override suspend fun readRssi(): Int {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
@@ -15,7 +15,7 @@ import kotlin.uuid.Uuid
 public typealias ReadHandler = suspend () -> ByteArray
 public typealias WriteHandler = suspend (data: ByteArray, writeType: WriteType) -> Unit
 public typealias ObserveHandler = () -> Flow<ByteArray>
-public typealias L2capHandler = suspend (psm: Int) -> L2capChannel
+public typealias L2capHandler = suspend (psm: Int, mtu: Int?) -> L2capChannel
 
 @OptIn(ExperimentalUuidApi::class)
 internal data class FakeCharacteristicConfig(
@@ -63,7 +63,7 @@ public class FakePeripheralBuilder {
 
     /**
      * Configure L2CAP channel opening behavior.
-     * The handler receives the PSM and returns an [L2capChannel] (typically [FakeL2capChannel]).
+     * The handler receives the PSM and optional MTU hint, returning an [L2capChannel].
      */
     public fun onOpenL2capChannel(handler: L2capHandler) {
         l2capHandler = handler

--- a/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/L2capChannelTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/L2capChannelTest.kt
@@ -147,7 +147,7 @@ class L2capChannelTest {
         runTest {
             val peripheral =
                 FakePeripheral {
-                    onOpenL2capChannel { psm -> FakeL2capChannel(psm) }
+                    onOpenL2capChannel { psm, _ -> FakeL2capChannel(psm) }
                 }
 
             assertFailsWith<L2capException.NotConnected> {
@@ -160,7 +160,7 @@ class L2capChannelTest {
         runTest {
             val peripheral =
                 FakePeripheral {
-                    onOpenL2capChannel { psm -> FakeL2capChannel(psm) }
+                    onOpenL2capChannel { psm, _ -> FakeL2capChannel(psm) }
                 }
 
             peripheral.connect()
@@ -187,7 +187,7 @@ class L2capChannelTest {
             var receivedPsm = -1
             val peripheral =
                 FakePeripheral {
-                    onOpenL2capChannel { psm ->
+                    onOpenL2capChannel { psm, _ ->
                         receivedPsm = psm
                         FakeL2capChannel(psm)
                     }
@@ -197,6 +197,43 @@ class L2capChannelTest {
             peripheral.openL2capChannel(psm = 0x42)
 
             assertEquals(0x42, receivedPsm)
+        }
+
+    @Test
+    fun openL2capChannelForwardsMtuToHandler() =
+        runTest {
+            var receivedMtu: Int? = null
+            val peripheral =
+                FakePeripheral {
+                    onOpenL2capChannel { psm, mtu ->
+                        receivedMtu = mtu
+                        FakeL2capChannel(psm, mtu = mtu ?: 2048)
+                    }
+                }
+
+            peripheral.connect()
+            val channel = peripheral.openL2capChannel(psm = 0x25, mtu = 4096)
+
+            assertEquals(4096, receivedMtu)
+            assertEquals(4096, channel.mtu)
+        }
+
+    @Test
+    fun openL2capChannelDefaultsMtuToNull() =
+        runTest {
+            var receivedMtu: Int? = -1
+            val peripheral =
+                FakePeripheral {
+                    onOpenL2capChannel { psm, mtu ->
+                        receivedMtu = mtu
+                        FakeL2capChannel(psm)
+                    }
+                }
+
+            peripheral.connect()
+            peripheral.openL2capChannel(psm = 0x25)
+
+            assertEquals(null, receivedMtu)
         }
 
     // --- L2capException hierarchy ---

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -24,13 +24,14 @@ import platform.Foundation.NSStreamStatusError
 import platform.Foundation.NSStreamStatusOpen
 import kotlin.coroutines.coroutineContext
 
+internal const val DEFAULT_L2CAP_MTU = 2048
+
 internal class IosL2capChannel(
     private val cbChannel: CBL2CAPChannel,
     private val scope: CoroutineScope,
+    override val mtu: Int,
 ) : L2capChannel {
     override val psm: Int = cbChannel.PSM.toInt()
-
-    override val mtu: Int = DEFAULT_MTU
 
     private val _isOpen = MutableStateFlow(true)
     override val isOpen: Boolean get() = _isOpen.value
@@ -156,7 +157,6 @@ internal class IosL2capChannel(
     }
 
     private companion object {
-        const val DEFAULT_MTU = 2048
         const val READ_BUFFER_SIZE = 4096
         const val MIN_POLL_INTERVAL_MS = 10L
         const val MAX_POLL_INTERVAL_MS = 100L

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -34,6 +34,7 @@ import com.atruedev.kmpble.gatt.internal.PersistedObservation
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import com.atruedev.kmpble.internal.StateRestorationHandler
+import com.atruedev.kmpble.l2cap.DEFAULT_L2CAP_MTU
 import com.atruedev.kmpble.l2cap.IosL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
@@ -594,8 +595,10 @@ public class IosPeripheral(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel {
         checkNotClosed()
+        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
         if (peripheralContext.state.value !is State.Connected) {
             throw L2capException.NotConnected("Peripheral is not connected (state: ${peripheralContext.state.value})")
         }
@@ -614,7 +617,7 @@ public class IosPeripheral(
                     withTimeout(L2CAP_OPEN_TIMEOUT) {
                         deferred.await()
                     }
-                val channel = IosL2capChannel(cbChannel, peripheralContext.scope)
+                val channel = IosL2capChannel(cbChannel, peripheralContext.scope, mtu ?: DEFAULT_L2CAP_MTU)
                 activeL2capChannels.update { it + channel }
                 channel
             } catch (_: TimeoutCancellationException) {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -409,7 +409,7 @@ internal class IosGattServer(
                     assembled
                 } else {
                     requests.map { request ->
-                        val data = if (request.value != null) bleDataFromNSData(request.value!!) else emptyBleData()
+                        val data = request.value?.let(::bleDataFromNSData) ?: emptyBleData()
                         request.charUuid to data
                     }
                 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -87,6 +87,7 @@ internal class StubPeripheral(
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
+        mtu: Int?,
     ): L2capChannel = unsupported()
 
     private fun unsupported(): Nothing = throw UnsupportedOperationException("StubPeripheral")


### PR DESCRIPTION
Two independent changes, split into separate commits.

## Commit 1: `refactor: replace non-null assertions with idiomatic Kotlin alternatives`

Eliminate `!!` from production code without behavior change:

| File | Before | After |
|------|--------|-------|
| `AndroidPeripheral` | `connectionComplete!!.await()` (×3) | Local val captures the `CompletableDeferred`; field kept for GATT callbacks |
| `AndroidBondManager` | `bondComplete!!.await()` | Same local-val pattern |
| `AndroidExtendedAdvertiser` | `callbackRef!!` | `lateinit var` |
| `IosGattServer` | `if (x != null) f(x!!)` | `?.let(::f) ?: default` |

`BleData.ios.kt:23` (`nsData.bytes!!`) kept — ObjC interop hot path, bounds check guards zero-length access.

## Commit 2: `feat(l2cap): add configurable MTU for iOS L2CAP channels`

CoreBluetooth does not expose the negotiated L2CAP MTU. Add `mtu: Int? = null` to `Peripheral.openL2capChannel()` so callers can provide a known value instead of the 2048-byte default.

- `IosPeripheral` forwards `mtu` to `IosL2capChannel` constructor
- `AndroidPeripheral` ignores the hint (queries `socket.maxTransmitPacketSize`)
- Input validated: `require(mtu > 0)` in all implementations
- `L2capHandler` typealias updated to `(psm, mtu) -> L2capChannel` so `FakePeripheral` forwards the parameter
- `IosL2capChannel.DEFAULT_MTU` promoted to `internal` visibility

## Test plan

- [x] `testAndroidHostTest` — pass
- [x] `iosSimulatorArm64Test` — pass
- [x] `jvmTest` (Lincheck) — pass
- [x] `ktlintCheck` — clean
- [x] `openL2capChannelForwardsMtuToHandler` — verifies mtu pass-through
- [x] `openL2capChannelDefaultsMtuToNull` — verifies null default