### PR TITLE
style: replace em-dashes with hyphens across repo

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -62,14 +62,14 @@ jobs:
             // Extract the type prefix from the PR title
             const match = title.match(/^(\w+)(?:\(.+\))?!?:/);
             if (!match) {
-              core.info('PR title does not match conventional commit format — skipping label');
+              core.info('PR title does not match conventional commit format - skipping label');
               return;
             }
 
             const type = match[1].toLowerCase();
             const label = labelMap[type];
             if (!label) {
-              core.info(`No changelog label mapped for type "${type}" — skipping`);
+              core.info(`No changelog label mapped for type "${type}" - skipping`);
               return;
             }
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,9 +207,9 @@ jobs:
             Automated PR to update project docs with the new release version.
 
             **Updated files:**
-            - `README.md` — dependency version
-            - `CHANGELOG.md` — auto-generated entries from merged PRs
-            - `llms.txt` — dependency version
+            - `README.md` - dependency version
+            - `CHANGELOG.md` - auto-generated entries from merged PRs
+            - `llms.txt` - dependency version
 
             Release: ${{ needs.publish.outputs.release_url }}
           branch: update-docs-${{ needs.publish.outputs.version }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,34 +21,34 @@ The connection state machine is the core of the library. It tracks every periphe
 ```
 State
 ├── Connecting
-│   ├── Transport          — Physical link establishing
-│   ├── Authenticating     — Bonding/pairing in progress
-│   ├── Discovering        — GATT service discovery
-│   └── Configuring        — MTU negotiation, CCCD setup
+│   ├── Transport          - Physical link establishing
+│   ├── Authenticating     - Bonding/pairing in progress
+│   ├── Discovering        - GATT service discovery
+│   └── Configuring        - MTU negotiation, CCCD setup
 ├── Connected
-│   ├── Ready              — Normal operation
-│   ├── BondingChange      — Bond state changed mid-connection
-│   └── ServiceChanged     — Service list changed, rediscovering
+│   ├── Ready              - Normal operation
+│   ├── BondingChange      - Bond state changed mid-connection
+│   └── ServiceChanged     - Service list changed, rediscovering
 ├── Disconnecting
-│   ├── Requested          — Local disconnect initiated
-│   └── Error              — Connection lost during operation
+│   ├── Requested          - Local disconnect initiated
+│   └── Error              - Connection lost during operation
 └── Disconnected
-    ├── ByRequest          — Clean local disconnect completed
-    ├── ByRemote           — Remote device disconnected
-    ├── ByError(error)     — Connection error with details
-    ├── ByTimeout          — Supervision timeout
-    └── BySystemEvent      — Adapter off, airplane mode
+    ├── ByRequest          - Clean local disconnect completed
+    ├── ByRemote           - Remote device disconnected
+    ├── ByError(error)     - Connection error with details
+    ├── ByTimeout          - Supervision timeout
+    └── BySystemEvent      - Adapter off, airplane mode
 ```
 
 ### Transition Table
 
-The state machine uses a **declarative transition table** — a `Map` from `(State, Event)` pairs to transition functions. Two resolution mechanisms:
+The state machine uses a **declarative transition table** - a `Map` from `(State, Event)` pairs to transition functions. Two resolution mechanisms:
 
 1. **Wildcard transitions** (checked first): `AdapterOff` and `RemoteDisconnected` can fire from any non-Disconnected state, always winning over specific transitions.
 
 2. **Hierarchy-aware lookup**: If no exact match for `(Disconnected.ByError, SomeEvent)`, the resolver walks up to `(Disconnected, SomeEvent)`, then `(State, SomeEvent)`. This avoids duplicating transitions for every Disconnected subtype.
 
-Illegal transitions throw `IllegalStateException` — caught in tests, never silent in production.
+Illegal transitions throw `IllegalStateException` - caught in tests, never silent in production.
 
 ### Why 14 States?
 
@@ -78,7 +78,7 @@ Layer 2: Serialized processing (commonMain)
 Layer 3: Consumer API (caller's coroutine context)
 ```
 
-**Layer 2** uses `Dispatchers.Default.limitedParallelism(1)` — a serial execution view that works on all KMP targets without `expect/actual`. At most one coroutine runs at a time per peripheral. No locks, no mutexes.
+**Layer 2** uses `Dispatchers.Default.limitedParallelism(1)` - a serial execution view that works on all KMP targets without `expect/actual`. At most one coroutine runs at a time per peripheral. No locks, no mutexes.
 
 **Layer 1** is platform-specific:
 - **Android**: `HandlerThread` receives `BluetoothGattCallback` callbacks, completes `CompletableDeferred` values
@@ -120,9 +120,9 @@ A drain job consumes entries one at a time. Each entry's `block` runs, the resul
 
 ### Key Behaviors
 
-- **10-second timeout** per operation — Android will silently drop operations without a callback. The watchdog catches these.
-- **Drain on disconnect** — all pending operations complete with `NotConnectedException`.
-- **Cancellation** — cancelling the caller's coroutine cancels the *wait*, not the hardware operation. The in-flight GATT op completes silently, the result is discarded, and the queue advances. This prevents leaving the GATT in an inconsistent state.
+- **10-second timeout** per operation - Android will silently drop operations without a callback. The watchdog catches these.
+- **Drain on disconnect** - all pending operations complete with `NotConnectedException`.
+- **Cancellation** - cancelling the caller's coroutine cancels the *wait*, not the hardware operation. The in-flight GATT op completes silently, the result is discarded, and the queue advances. This prevents leaving the GATT in an inconsistent state.
 
 ---
 
@@ -132,9 +132,9 @@ A drain job consumes entries one at a time. Each entry's `block` runs, the resul
 
 ### How It Works
 
-1. **On subscribe**: `ObservationManager` creates a tracked observation keyed by `(serviceUuid, characteristicUuid)` — UUID-based, not object-reference-based. A `MutableSharedFlow` is returned to the consumer.
+1. **On subscribe**: `ObservationManager` creates a tracked observation keyed by `(serviceUuid, characteristicUuid)` - UUID-based, not object-reference-based. A `MutableSharedFlow` is returned to the consumer.
 
-2. **On disconnect**: All tracked observations receive an `Observation.Disconnected` event. Observations are **not cleared** — they remain tracked.
+2. **On disconnect**: All tracked observations receive an `Observation.Disconnected` event. Observations are **not cleared** - they remain tracked.
 
 3. **On reconnect**: `ObservationManager.getObservationsToResubscribe()` returns all tracked observations. The peripheral re-enables CCCD (Client Characteristic Configuration Descriptor) for each one using the *new* native characteristic objects from the fresh GATT session.
 
@@ -142,8 +142,8 @@ A drain job consumes entries one at a time. Each entry's `block` runs, the resul
 
 ### Two Consumer APIs
 
-- **`observe()`** — emits `Observation` sealed type: `Value(data)` during connection, `Disconnected` during gaps. Consumer handles both.
-- **`observeValues()`** — emits raw `ByteArray`. Suspends during disconnection gaps, transparently resumes on reconnect. Consumer doesn't see disconnects.
+- **`observe()`** - emits `Observation` sealed type: `Value(data)` during connection, `Disconnected` during gaps. Consumer handles both.
+- **`observeValues()`** - emits raw `ByteArray`. Suspends during disconnection gaps, transparently resumes on reconnect. Consumer doesn't see disconnects.
 
 ### Thread Safety
 
@@ -164,8 +164,8 @@ BleError
 │   └── ConnectionLost(reason, platformCode?)
 ├── GattOperationError
 │   ├── GattError(operation, status: GattStatus)
-│   ├── AuthenticationFailed — also implements AuthError
-│   └── EncryptionFailed    — also implements AuthError
+│   ├── AuthenticationFailed - also implements AuthError
+│   └── EncryptionFailed    - also implements AuthError
 ├── AuthError (composable interface)
 ├── OperationConstraintError
 │   └── MtuExceeded(attempted, maximum)
@@ -192,10 +192,10 @@ Android OEMs ship BLE stacks with device-specific bugs. The quirk registry appli
 
 ### Matching Priority
 
-1. `manufacturer:model:display` — exact firmware match
-2. `manufacturer:model` — any firmware
-3. `manufacturer:model-prefix` — 6-char prefix for device series (e.g., all Pixel 7 variants)
-4. `manufacturer` — any model from that OEM
+1. `manufacturer:model:display` - exact firmware match
+2. `manufacturer:model` - any firmware
+3. `manufacturer:model-prefix` - 6-char prefix for device series (e.g., all Pixel 7 variants)
+4. `manufacturer` - any model from that OEM
 
 ### Active Quirks
 
@@ -208,13 +208,13 @@ Android OEMs ship BLE stacks with device-specific bugs. The quirk registry appli
 | Bond state timeout | Xiaomi/Redmi/Poco (15s), Huawei/Honor (10s) | Extended timeout for slow bond callbacks |
 | Connection timeout | Samsung (30s), Huawei/Honor (35s) | Extended timeout for slow connections |
 
-The registry is internal — consumers don't interact with it.
+The registry is internal - consumers don't interact with it.
 
 ---
 
 ## GATT Server
 
-The server module lets the phone act as a BLE peripheral — advertising and serving GATT characteristics.
+The server module lets the phone act as a BLE peripheral - advertising and serving GATT characteristics.
 
 ### Architecture
 
@@ -269,7 +269,7 @@ interface L2capChannel : AutoCloseable {
 }
 ```
 
-L2CAP channels are independent of the GATT queue — they're a separate transport with their own read/write coroutines.
+L2CAP channels are independent of the GATT queue - they're a separate transport with their own read/write coroutines.
 
 | Platform | Implementation |
 |----------|---------------|
@@ -291,18 +291,18 @@ Every major component has a Fake* counterpart for unit testing without hardware:
 | Platform L2capChannel | `FakeL2capChannel` | Simulate streaming |
 
 `FakePeripheral` supports the full observation resilience lifecycle:
-- `simulateDisconnect()` — emits `Observation.Disconnected` without clearing observations
-- `simulateReconnect()` — transitions through connect states, re-enables CCCD
-- `simulatePermanentDisconnect()` — clears observations, completes Flows
-- `emitObservationValue()` — simulate characteristic notifications
+- `simulateDisconnect()` - emits `Observation.Disconnected` without clearing observations
+- `simulateReconnect()` - transitions through connect states, re-enables CCCD
+- `simulatePermanentDisconnect()` - clears observations, completes Flows
+- `emitObservationValue()` - simulate characteristic notifications
 
 ---
 
 ## Scanner
 
-`Scanner.advertisements` is a **cold Flow**. Creating a `Scanner` starts nothing — no OS resources, no scanning. Scanning starts on first `collect()`, stops when the collector's coroutine is cancelled.
+`Scanner.advertisements` is a **cold Flow**. Creating a `Scanner` starts nothing - no OS resources, no scanning. Scanning starts on first `collect()`, stops when the collector's coroutine is cancelled.
 
-Multiple concurrent collectors share one underlying OS scan. This is standard structured concurrency — no `scanner.stop()` needed.
+Multiple concurrent collectors share one underlying OS scan. This is standard structured concurrency - no `scanner.stop()` needed.
 
 ### Filters
 
@@ -329,8 +329,8 @@ Some filters are OS-level (hardware-offloaded, power-efficient), others are post
 
 ### Emission Policy
 
-- **`All`** — every advertisement packet (for RSSI tracking, indoor positioning)
-- **`FirstThenChanges(rssiThreshold)`** — deduplicate by device identifier, re-emit on data or RSSI change. Default. Prevents 200+ emissions/sec from 20 devices advertising at 100ms.
+- **`All`** - every advertisement packet (for RSSI tracking, indoor positioning)
+- **`FirstThenChanges(rssiThreshold)`** - deduplicate by device identifier, re-emit on data or RSSI change. Default. Prevents 200+ emissions/sec from 20 devices advertising at 100ms.
 
 ---
 
@@ -341,7 +341,7 @@ The `expect/actual` boundary is kept minimal. Platform code does two things:
 1. **Receive OS callbacks** on a platform-appropriate thread/queue
 2. **Complete `CompletableDeferred` values** to bridge into the common coroutine layer
 
-Everything else — state transitions, queue management, observation tracking, error normalization — lives in `commonMain`.
+Everything else - state transitions, queue management, observation tracking, error normalization - lives in `commonMain`.
 
 ```
 Android: BluetoothGattCallback.onCharacteristicRead()
@@ -361,7 +361,7 @@ iOS: CBPeripheralDelegate.peripheral(_:didUpdateValueFor:error:)
 | Decision | Rationale |
 |----------|-----------|
 | `limitedParallelism(1)` over dedicated threads | Compiles on all KMP targets. No thread lifecycle management. Same serial guarantee. |
-| Sealed interfaces over sealed classes for errors | Composability — `AuthenticationFailed` is both `GattOperationError` and `AuthError` |
+| Sealed interfaces over sealed classes for errors | Composability - `AuthenticationFailed` is both `GattOperationError` and `AuthError` |
 | UUID-based observation tracking over object reference | After reconnect, native characteristic objects are new. UUID is the stable identity. |
 | Cold Flows over hot streams for scanning | No OS resources until collection starts. Structured concurrency handles cleanup. |
 | 10s GATT operation timeout | Android silently drops operations. The watchdog prevents indefinite hangs. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,15 +324,15 @@ _No notable changes._
 ## [0.1.6] - 2026-03-19
 
 ### Changed
-- Repository-wide code review cleanup — improved consistency, removed dead code, tightened access modifiers
+- Repository-wide code review cleanup - improved consistency, removed dead code, tightened access modifiers
 
 ---
 
 ## [0.1.5] - 2026-03-18
 
 ### Added
-- **GATT Server (iOS)** — peripheral role using `CBPeripheralManager`. Define services, handle read/write requests, send notifications and indications
-- **Advertiser (iOS)** — BLE advertising via `CBPeripheralManager` with configurable name, service UUIDs, and manufacturer data
+- **GATT Server (iOS)** - peripheral role using `CBPeripheralManager`. Define services, handle read/write requests, send notifications and indications
+- **Advertiser (iOS)** - BLE advertising via `CBPeripheralManager` with configurable name, service UUIDs, and manufacturer data
 
 ### Changed
 - Use `BleData.slice` for zero-copy offset reads in server handlers
@@ -349,9 +349,9 @@ _No notable changes._
 ## [0.1.4] - 2026-03-18
 
 ### Added
-- **GATT Server (Android)** — peripheral role using `BluetoothGattServer`. DSL builder for defining services, characteristics, and descriptors with read/write/notify support
-- **Advertiser (Android)** — BLE advertising with configurable mode (LowPower, Balanced, LowLatency), TX power levels, service UUIDs, and manufacturer data
-- **FakeGattServer** and **FakeAdvertiser** — test doubles for server and advertiser code
+- **GATT Server (Android)** - peripheral role using `BluetoothGattServer`. DSL builder for defining services, characteristics, and descriptors with read/write/notify support
+- **Advertiser (Android)** - BLE advertising with configurable mode (LowPower, Balanced, LowLatency), TX power levels, service UUIDs, and manufacturer data
+- **FakeGattServer** and **FakeAdvertiser** - test doubles for server and advertiser code
 
 ### Changed
 - Configurable advertise mode and TX power included in `AdvertiseConfig` equals/hashCode/toString
@@ -367,8 +367,8 @@ _No notable changes._
 ## [0.1.3] - 2026-03-18
 
 ### Added
-- **L2CAP Channels (Android)** — high-throughput streaming via `BluetoothSocket`, bypassing GATT for bulk data and DFU transfers
-- **FakeL2capChannel** — test double for L2CAP channel code with socket abstraction
+- **L2CAP Channels (Android)** - high-throughput streaming via `BluetoothSocket`, bypassing GATT for bulk data and DFU transfers
+- **FakeL2capChannel** - test double for L2CAP channel code with socket abstraction
 
 ### Fixed
 - Removed dead partial-write loop in L2CAP channel implementation
@@ -378,7 +378,7 @@ _No notable changes._
 ## [0.1.2] - 2026-03-18
 
 ### Added
-- **L2CAP Channels (iOS)** — high-throughput streaming via `CBL2CAPChannel`, bypassing GATT for bulk data and DFU transfers
+- **L2CAP Channels (iOS)** - high-throughput streaming via `CBL2CAPChannel`, bypassing GATT for bulk data and DFU transfers
 
 ### Changed
 - Repository URLs migrated from `gary-quinn` to `atruedeveloper`
@@ -388,7 +388,7 @@ _No notable changes._
 ## [0.1.1] - 2026-03-17
 
 ### Added
-- **Device Quirk Registry** — internal registry for Android OEM-specific BLE workarounds (Samsung, Pixel, Xiaomi, OnePlus)
+- **Device Quirk Registry** - internal registry for Android OEM-specific BLE workarounds (Samsung, Pixel, Xiaomi, OnePlus)
 - Consumer ProGuard rules bundled in the AAR
 - CI: test suite runs on every push
 - CI: workflow to auto-update README on release
@@ -401,16 +401,16 @@ _No notable changes._
 ## [0.1.0] - 2026-03-17
 
 ### Added
-- **Scanning & Discovery** — filters (service UUID, name, manufacturer data, RSSI), emission policy (dedup/all), cold Flow API
-- **GATT Client** — read, write (with/without response), observe (notifications/indications), descriptors, MTU negotiation
-- **14-State State Machine** — exhaustive transition table with no invalid states, covering transport, authentication, discovery, service changes, and bonding changes
-- **Bonding & Pairing** — Just Works + Passkey Entry. Proactive or implicit bonding with bond state tracking
-- **Reconnection Strategies** — built-in `ExponentialBackoff` and `LinearBackoff`, configurable per-peripheral
-- **Observation Resilience** — `observe()` / `observeValues()` survive disconnects and auto-resubscribe to CCCD on reconnect
-- **Testing Infrastructure** — `FakePeripheral`, `FakeScanner` for full BLE simulation in unit tests without hardware
-- **Permissions** — cross-platform BLE permission checking API
-- **Logging** — structured BLE event logging with pluggable backends
-- **Distribution** — Maven Central (`com.atruedev:kmp-ble`) + Swift Package Manager (XCFramework)
+- **Scanning & Discovery** - filters (service UUID, name, manufacturer data, RSSI), emission policy (dedup/all), cold Flow API
+- **GATT Client** - read, write (with/without response), observe (notifications/indications), descriptors, MTU negotiation
+- **14-State State Machine** - exhaustive transition table with no invalid states, covering transport, authentication, discovery, service changes, and bonding changes
+- **Bonding & Pairing** - Just Works + Passkey Entry. Proactive or implicit bonding with bond state tracking
+- **Reconnection Strategies** - built-in `ExponentialBackoff` and `LinearBackoff`, configurable per-peripheral
+- **Observation Resilience** - `observe()` / `observeValues()` survive disconnects and auto-resubscribe to CCCD on reconnect
+- **Testing Infrastructure** - `FakePeripheral`, `FakeScanner` for full BLE simulation in unit tests without hardware
+- **Permissions** - cross-platform BLE permission checking API
+- **Logging** - structured BLE event logging with pluggable backends
+- **Distribution** - Maven Central (`com.atruedev:kmp-ble`) + Swift Package Manager (XCFramework)
 
 ### Changed
 - Renamed package to `com.atruedev.kmpble`, group to `com.atruedev`
@@ -430,12 +430,12 @@ _No notable changes._
 ## [0.1.0-alpha06] - 2026-03-17
 
 ### Added
-- Bonding — Just Works + Passkey Entry
+- Bonding - Just Works + Passkey Entry
 - `FakeScanner` + property-based state machine tests
 - Logging infrastructure + error model refinement
 - BLE permissions check API
 - Sample app with auto-init
-- Migration guide — API mapping and key differences from other BLE libraries
+- Migration guide - API mapping and key differences from other BLE libraries
 
 ### Fixed
 - iOS scanner initialization issue
@@ -445,7 +445,7 @@ _No notable changes._
 ## [0.1.0-alpha01] - 2026-03-15
 
 ### Added
-- Initial release — BLE scanning, connecting, GATT read/write/observe
+- Initial release - BLE scanning, connecting, GATT read/write/observe
 - Android and iOS platform support
 - CI/CD with GitHub Actions and Dependabot
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -82,9 +82,9 @@ No initialization needed. Add via SPM or use the XCFramework directly.
 |---------|---------|
 | Bond state | `peripheral.bondState: StateFlow<BondState>` |
 | Proactive bonding | `ConnectionOptions(bondingPreference = BondingPreference.Required)` |
-| Implicit bonding | Default — OS triggers when device requires encryption |
+| Implicit bonding | Default - OS triggers when device requires encryption |
 | Remove bond (Android) | `@OptIn(ExperimentalBleApi::class) peripheral.removeBond()` |
-| Remove bond (iOS) | Returns `BondRemovalResult.NotSupported` — use Settings |
+| Remove bond (iOS) | Returns `BondRemovalResult.NotSupported` - use Settings |
 
 ### Adapter State
 
@@ -146,16 +146,16 @@ val peripheral = FakePeripheral {
 
 ### Explicit WriteType
 
-kmp-ble requires an explicit `WriteType` on every write — no default. This prevents the common mistake of accidentally using fire-and-forget writes when acknowledged writes are needed.
+kmp-ble requires an explicit `WriteType` on every write - no default. This prevents the common mistake of accidentally using fire-and-forget writes when acknowledged writes are needed.
 
 ### Object Identity for Characteristics
 
-`Characteristic` and `Descriptor` use reference equality, not structural equality. Always get them from `peripheral.services` or `findCharacteristic()` after connecting — don't construct them manually.
+`Characteristic` and `Descriptor` use reference equality, not structural equality. Always get them from `peripheral.services` or `findCharacteristic()` after connecting - don't construct them manually.
 
 ### Close vs Disconnect
 
-- `disconnect()` — graceful, peripheral can reconnect
-- `close()` — terminal, releases all native resources, peripheral is unusable after
+- `disconnect()` - graceful, peripheral can reconnect
+- `close()` - terminal, releases all native resources, peripheral is unusable after
 
 Always call `close()` when done (e.g., `ViewModel.onCleared()`, `deinit`).
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Kotlin Multiplatform BLE library for Android and iOS.
 
 | Module | Artifact | Description |
 |--------|----------|-------------|
-| **kmp-ble** | `com.atruedev:kmp-ble` | Core BLE — scanning, connecting, GATT read/write/observe, server, advertising |
+| **kmp-ble** | `com.atruedev:kmp-ble` | Core BLE - scanning, connecting, GATT read/write/observe, server, advertising |
 | **kmp-ble-profiles** | `com.atruedev:kmp-ble-profiles` | Type-safe GATT profile parsing (Heart Rate, Battery, Device Info, Blood Pressure, Glucose, CSC) |
-| **kmp-ble-dfu** | `com.atruedev:kmp-ble-dfu` | Firmware updates — Nordic Secure DFU, MCUboot SMP, Espressif ESP OTA — with auto-detection and progress tracking |
+| **kmp-ble-dfu** | `com.atruedev:kmp-ble-dfu` | Firmware updates - Nordic Secure DFU, MCUboot SMP, Espressif ESP OTA - with auto-detection and progress tracking |
 | **kmp-ble-codec** | `com.atruedev:kmp-ble-codec` | Format-agnostic typed read/write via composable `BleEncoder`/`BleDecoder` |
 
 ## Setup
@@ -71,7 +71,7 @@ services, use the UUID from your device's documentation or GATT profile.
 See: [Bluetooth SIG Service UUIDs](https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/uuids/service_uuids.yaml)
 
 ```kotlin
-// Common code — works on both Android and iOS
+// Common code - works on both Android and iOS
 val scanner = Scanner {
     timeout = 30.seconds
     emission = EmissionPolicy.FirstThenChanges(rssiThreshold = 10)
@@ -359,23 +359,23 @@ Production-grade BLE utility app (Android + iOS) with tab-based navigation, comp
 - **Scanner** with RSSI/name filtering, sorting, device categorization, manufacturer name resolution
 - **Device Detail** with GATT service browser, value display in HEX/UTF-8/Decimal/Binary, connection recipes, bonding
 - **Multi-protocol DFU** with auto-detection (Nordic Secure DFU, MCUboot SMP, Espressif ESP OTA)
-- **Profile monitoring** — Heart Rate, Battery, Device Information with auto-detection
+- **Profile monitoring** - Heart Rate, Battery, Device Information with auto-detection
 - **L2CAP channels** with message history and directional logging
 - **Codec** typed read/write with decoder composition
 - **GATT Server** with service builder presets and advanced advertising controls
 
 ### Quickstart (`sample-quickstart/`)
 
-Minimal ~150-line single-screen app: scan, tap, connect, read first characteristic, display value. No ViewModel, no navigation — the "Getting Started in 5 Minutes" reference.
+Minimal ~150-line single-screen app: scan, tap, connect, read first characteristic, display value. No ViewModel, no navigation - the "Getting Started in 5 Minutes" reference.
 
 ## Architecture
 
-- **State machine:** 14 states with declarative transition table — no invalid states in production
+- **State machine:** 14 states with declarative transition table - no invalid states in production
 - **Per-peripheral concurrency:** `limitedParallelism(1)` serialization, no locks
 - **GATT queue:** FIFO with timeout watchdog
 - **Zero-copy:** `BleData` wraps `NSData` on iOS, `ByteArray` on Android
 - **Object identity:** `Characteristic` and `Descriptor` use reference equality, matching native API behavior
-- **Composable errors:** Sealed interfaces — `AuthError`, `GattOperationError`, `ConnectionError`
+- **Composable errors:** Sealed interfaces - `AuthError`, `GattOperationError`, `ConnectionError`
 
 ## Requirements
 
@@ -386,4 +386,4 @@ Minimal ~150-line single-screen app: scan, tap, connect, read first characterist
 
 ## License
 
-[Apache 2.0](LICENSE) — Copyright (C) 2026 Gary Quinn
+[Apache 2.0](LICENSE) - Copyright (C) 2026 Gary Quinn

--- a/buildSrc/src/main/kotlin/ObjcCinterop.kt
+++ b/buildSrc/src/main/kotlin/ObjcCinterop.kt
@@ -12,7 +12,7 @@ private val iosTargetPlatform = mapOf(
  * Compiles an ObjC source file into a static library and registers Gradle tasks
  * so that the K/N compilation depends on the archive.
  *
- * Call this alongside `cinterops.create(...)` — cinterop generates Kotlin bindings
+ * Call this alongside `cinterops.create(...)` - cinterop generates Kotlin bindings
  * from the header; this function bridges the `.m` implementation.
  *
  * @param targetName K/N target name (e.g. "iosArm64")

--- a/kmp-ble-dfu/build.gradle.kts
+++ b/kmp-ble-dfu/build.gradle.kts
@@ -63,7 +63,7 @@ mavenPublishing {
 
     pom {
         name.set("kmp-ble-dfu")
-        description.set("DFU/OTA firmware update support for kmp-ble — Nordic DFU, L2CAP OTA, observable progress, resume")
+        description.set("DFU/OTA firmware update support for kmp-ble - Nordic DFU, L2CAP OTA, observable progress, resume")
         url.set("https://github.com/gary-quinn/kmp-ble")
         licenses {
             license {

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuController.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuController.kt
@@ -35,14 +35,14 @@ public class DfuController(
 ) {
 
     // Abort signal shared between performDfu and abort(). CompletableDeferred
-    // is a coroutine primitive with thread-safe complete/isCompleted — no
+    // is a coroutine primitive with thread-safe complete/isCompleted - no
     // @Volatile or Mutex needed. A fresh signal is created per DFU invocation.
     private var abortSignal = CompletableDeferred<Unit>()
 
     /**
      * Start a firmware update and observe its progress.
      *
-     * Returns a **cold** [Flow] — the DFU begins when you call `collect`.
+     * Returns a **cold** [Flow] - the DFU begins when you call `collect`.
      *
      * @param firmware the firmware package to install
      * @param options DFU configuration

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuOptions.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/DfuOptions.kt
@@ -11,12 +11,12 @@ import kotlin.uuid.Uuid
  * Defaults are tuned for Nordic nRF5 SDK Secure DFU over GATT.
  *
  * @property prnInterval how many data packets to send before waiting for a
- *   receipt confirmation (Packet Receipt Notification). `0` disables PRNs —
+ *   receipt confirmation (Packet Receipt Notification). `0` disables PRNs -
  *   faster but removes flow control. Default `10`.
  * @property retryCount maximum attempts per DFU object before giving up
  * @property retryDelay pause between retry attempts
  * @property commandTimeout how long to wait for a response to a DFU command
- * @property transport BLE transport to use — [GATT][DfuTransportConfig.Gatt]
+ * @property transport BLE transport to use - [GATT][DfuTransportConfig.Gatt]
  *   (default) or [L2CAP][DfuTransportConfig.L2cap] for higher throughput
  */
 public data class DfuOptions(

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/firmware/FirmwarePackage.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/firmware/FirmwarePackage.kt
@@ -20,7 +20,7 @@ public sealed interface FirmwarePackage {
      * Contains the init packet (metadata + signature) and the raw firmware binary,
      * parsed from a Nordic DFU .zip distribution package.
      *
-     * @property initPacket DFU init packet (.dat) — firmware metadata and signature
+     * @property initPacket DFU init packet (.dat) - firmware metadata and signature
      * @property firmware raw firmware binary (.bin) to flash onto the peripheral
      */
     public class Nordic(

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/firmware/NordicDfuZipParser.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/firmware/NordicDfuZipParser.kt
@@ -30,7 +30,7 @@ internal object NordicDfuZipParser {
      * Extract all `"key": "value"` pairs from a JSON string.
      *
      * Handles escaped quotes within values (`\"`). Does not attempt to parse
-     * nested objects, arrays, or non-string values — only flat string fields.
+     * nested objects, arrays, or non-string values - only flat string fields.
      * Sufficient for Nordic DFU manifest.json which contains only string
      * filenames in a shallow structure.
      */
@@ -48,7 +48,7 @@ internal object NordicDfuZipParser {
             i = skipWhitespaceAndColon(json, i)
 
             if (i >= json.length || json[i] != '"') {
-                // non-string value — advance past it; next iteration finds the next key
+                // non-string value - advance past it; next iteration finds the next key
                 i++
                 continue
             }

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Cbor.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Cbor.kt
@@ -198,7 +198,7 @@ internal object Cbor {
 
 /**
  * Writes CBOR-encoded values directly into a pre-allocated ByteArray.
- * No intermediate buffers — every byte goes straight to the target.
+ * No intermediate buffers - every byte goes straight to the target.
  */
 private class CborWriter(private val target: ByteArray) {
     private var pos = 0

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/ObjectTransfer.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/ObjectTransfer.kt
@@ -114,7 +114,7 @@ internal class ObjectTransfer(
             val message = if (resultCode == DfuResultCode.EXTENDED_ERROR && response.size >= 4) {
                 val extCode = response[3].toInt() and 0xFF
                 "DFU command 0x${expectedOpcode.toString(16)} failed: " +
-                    "${DfuResultCode.describe(resultCode)} — ${DfuExtendedError.describe(extCode)}"
+                    "${DfuResultCode.describe(resultCode)} - ${DfuExtendedError.describe(extCode)}"
             } else {
                 "DFU command 0x${expectedOpcode.toString(16)} failed: " +
                     DfuResultCode.describe(resultCode)

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
@@ -3,14 +3,14 @@ package com.atruedev.kmpble.dfu.internal
 /**
  * Pure Kotlin SHA-256 implementation for MCUboot image verification.
  *
- * Follows FIPS 180-4. No platform dependencies — runs identically on all KMP targets.
+ * Follows FIPS 180-4. No platform dependencies - runs identically on all KMP targets.
  * Trade-off: slower than platform-native crypto (MessageDigest / CC_SHA256) but avoids
  * an expect/actual boundary. Acceptable because the hash is computed once per DFU
  * transfer. Consider an expect/actual with platform crypto if profiling shows a bottleneck.
  *
  * Allocation strategy: complete 64-byte blocks are processed directly from the source
  * array. Only the 1–2 padding tail blocks (max 128 bytes) are materialized in a
- * temporary buffer — no full-image copy regardless of firmware size.
+ * temporary buffer - no full-image copy regardless of firmware size.
  */
 @OptIn(ExperimentalUnsignedTypes::class)
 internal object Sha256 {
@@ -35,7 +35,7 @@ internal object Sha256 {
         val h = H0.copyOf()
         val w = UIntArray(64)
 
-        // Process all complete 64-byte blocks directly from the source — no copy.
+        // Process all complete 64-byte blocks directly from the source - no copy.
         val completeBlocks = data.size / 64
         for (b in 0 until completeBlocks) {
             processBlock(h, w, data, b * 64)

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/EspOtaDfuProtocol.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/EspOtaDfuProtocol.kt
@@ -56,7 +56,7 @@ public class EspOtaDfuProtocol : DfuProtocol {
         // Only the final (potentially shorter) chunk allocates a fresh array.
         val chunkBuffer = ByteArray(chunkSize)
 
-        // ESP OTA does not support resume — a fresh OTA Begin is required on
+        // ESP OTA does not support resume - a fresh OTA Begin is required on
         // each attempt because the device resets its OTA state on error.
         // The OTA End exchange (hash verification) is inside retry scope so
         // that a disconnect mid-verify retries the entire transfer from scratch.

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/NordicDfuProtocol.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/NordicDfuProtocol.kt
@@ -20,7 +20,7 @@ import kotlin.math.min
  * Transfers firmware in two phases: first the init packet (command object),
  * then the firmware binary split into data objects whose size is negotiated
  * with the peripheral. Each object is CRC32-verified before execution.
- * Supports partial resume — if the peripheral already has a valid prefix of
+ * Supports partial resume - if the peripheral already has a valid prefix of
  * an object, only the remaining bytes are sent.
  *
  * This is the default [DfuProtocol] used by [DfuController][com.atruedev.kmpble.dfu.DfuController].

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeader.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/protocol/smp/SmpHeader.kt
@@ -1,7 +1,7 @@
 package com.atruedev.kmpble.dfu.protocol.smp
 
 /**
- * SMP (Simple Management Protocol) header — 8 bytes, big-endian.
+ * SMP (Simple Management Protocol) header - 8 bytes, big-endian.
  *
  * Layout:
  * ```

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransport.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.flow.Flow
  * Abstraction over the BLE link used to send DFU commands and data.
  *
  * Built-in implementations:
- * - [GattDfuTransport] — uses DFU Control Point and DFU Packet characteristics
- * - [L2capDfuTransport] — L2CAP CoC channel for higher throughput (commands via GATT)
- * - [SmpTransport] — single SMP characteristic with response reassembly (MCUboot)
- * - [EspOtaTransport] — dual-characteristic OTA control/data (Espressif ESP-IDF)
+ * - [GattDfuTransport] - uses DFU Control Point and DFU Packet characteristics
+ * - [L2capDfuTransport] - L2CAP CoC channel for higher throughput (commands via GATT)
+ * - [SmpTransport] - single SMP characteristic with response reassembly (MCUboot)
+ * - [EspOtaTransport] - dual-characteristic OTA control/data (Espressif ESP-IDF)
  *
  * Implement this interface to support custom transport mechanisms.
  *

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/deviceinfo/DeviceInformation.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/deviceinfo/DeviceInformation.kt
@@ -5,7 +5,7 @@ import com.atruedev.kmpble.profiles.parsing.BleByteReader
 /**
  * Aggregated data from the Device Information Service (0x180A).
  *
- * All fields are optional — only characteristics present on the peripheral are populated.
+ * All fields are optional - only characteristics present on the peripheral are populated.
  */
 public data class DeviceInformation(
     val manufacturerName: String? = null,
@@ -18,13 +18,13 @@ public data class DeviceInformation(
     val pnpId: PnpId? = null,
 )
 
-/** IEEE 11073 System ID (0x2A23) — manufacturer identifier and OUI. */
+/** IEEE 11073 System ID (0x2A23) - manufacturer identifier and OUI. */
 public data class SystemId(
     val manufacturerIdentifier: Long,
     val organizationallyUniqueIdentifier: Int,
 )
 
-/** PnP ID (0x2A50) — vendor, product, and version identifiers. */
+/** PnP ID (0x2A50) - vendor, product, and version identifiers. */
 public data class PnpId(
     val vendorIdSource: Int,
     val vendorId: Int,

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteReader.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteReader.kt
@@ -4,7 +4,7 @@ package com.atruedev.kmpble.profiles.parsing
  * Little-endian byte cursor for parsing BLE characteristic payloads.
  *
  * Designed to be created, consumed linearly, and discarded within a single
- * pure parse function. Not thread-safe — not intended to be shared.
+ * pure parse function. Not thread-safe - not intended to be shared.
  */
 public class BleByteReader(private val data: ByteArray) {
 

--- a/kmp-ble-quirks/src/androidMain/kotlin/com/atruedev/kmpble/quirks/oem/OemQuirkProvider.kt
+++ b/kmp-ble-quirks/src/androidMain/kotlin/com/atruedev/kmpble/quirks/oem/OemQuirkProvider.kt
@@ -50,7 +50,7 @@ public class OemQuirkProvider : QuirkProvider {
                 "samsung:sm-a53",
             )
 
-        // Pixel devices often return GATT 133 on first attempt — retry after delay.
+        // Pixel devices often return GATT 133 on first attempt - retry after delay.
         val GATT_RETRY_DELAY: Map<String, Duration> =
             mapOf(
                 "google" to 1.seconds,

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # kmp-ble
 
-> The complete BLE toolkit for Kotlin Multiplatform — Android & iOS from one codebase.
+> The complete BLE toolkit for Kotlin Multiplatform - Android & iOS from one codebase.
 
 ## What is kmp-ble?
 
@@ -17,7 +17,7 @@ Maven Central group: `com.atruedev`
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            // Core — scan, connect, GATT client/server, advertise, L2CAP
+            // Core - scan, connect, GATT client/server, advertise, L2CAP
             implementation("com.atruedev:kmp-ble:0.4.2")
 
             // Optional modules
@@ -201,7 +201,7 @@ Built-in workarounds for BLE bugs on Samsung, Pixel, Xiaomi, OnePlus devices via
 ## Architecture
 
 - 14-state connection state machine with exhaustive transition table
-- Per-peripheral serial execution via limitedParallelism(1) — no locks
+- Per-peripheral serial execution via limitedParallelism(1) - no locks
 - Flow-based reactive APIs throughout
 - Zero-copy BleData on iOS (wraps NSData)
 - 460+ tests, CI on every push

--- a/sample-quickstart/src/commonMain/kotlin/com/atruedev/kmpble/quickstart/QuickstartApp.kt
+++ b/sample-quickstart/src/commonMain/kotlin/com/atruedev/kmpble/quickstart/QuickstartApp.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Minimal BLE quickstart — scan, connect, read the first characteristic.
+ * Minimal BLE quickstart - scan, connect, read the first characteristic.
  *
  * This is intentionally simple. For production patterns (reconnection,
  * error handling, profiles, DFU), see the full `sample/` module.
@@ -76,7 +76,7 @@ private fun ScanScreen(onDeviceSelected: (Advertisement) -> Unit) {
         Column(
             modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp),
         ) {
-            // Guard relies on recomposition timing — a rapid double-tap could
+            // Guard relies on recomposition timing - a rapid double-tap could
             // theoretically create two scanners. Acceptable for quickstart simplicity.
             Button(
                 onClick = {
@@ -153,7 +153,7 @@ private fun DeviceScreen(
     LaunchedEffect(peripheral) {
         try {
             peripheral.connect()
-            status = "Connected — discovering services..."
+            status = "Connected - discovering services..."
 
             val discoveredServices = peripheral.services.filterNotNull().first()
             val firstReadable: Characteristic? =

--- a/sample/src/iosMain/kotlin/com/atruedev/kmpble/sample/permission/BlePermissionLauncher.ios.kt
+++ b/sample/src/iosMain/kotlin/com/atruedev/kmpble/sample/permission/BlePermissionLauncher.ios.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 @Composable
 actual fun rememberBlePermissionLauncher(onResult: (PermissionResult) -> Unit): () -> Unit {
     // iOS triggers Bluetooth permission automatically on first CBCentralManager usage.
-    // No explicit permission request needed — the system prompt appears when kmp-ble
+    // No explicit permission request needed - the system prompt appears when kmp-ble
     // creates its first CBCentralManager instance.
     return { onResult(PermissionResult.Granted) }
 }

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpble/peripheral/BondManagerBroadcastTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpble/peripheral/BondManagerBroadcastTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertFailsWith
  *
  * Tests the receiver registration/unregistration lifecycle and intent
  * processing on a real Android runtime. Does NOT test with real Bluetooth
- * devices — validates the framework integration only.
+ * devices - validates the framework integration only.
  */
 @RunWith(AndroidJUnit4::class)
 class BondManagerBroadcastTest {
@@ -59,7 +59,7 @@ class BondManagerBroadcastTest {
             }
 
         val filter = IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED)
-        // This should not throw — validates RECEIVER_NOT_EXPORTED works
+        // This should not throw - validates RECEIVER_NOT_EXPORTED works
         ContextCompat.registerReceiver(
             context,
             receiver!!,
@@ -180,6 +180,6 @@ class BondManagerBroadcastTest {
             filter,
             ContextCompat.RECEIVER_NOT_EXPORTED,
         )
-        // Registration succeeds — the broadcast itself requires real adapter state change
+        // Registration succeeds - the broadcast itself requires real adapter state change
     }
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/BluetoothL2capSocket.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/BluetoothL2capSocket.kt
@@ -7,7 +7,7 @@ import java.io.OutputStream
 
 /**
  * Adapts [BluetoothSocket] to the [L2capSocket] interface used by
- * [AndroidL2capChannel]. Thin delegation — no added logic.
+ * [AndroidL2capChannel]. Thin delegation - no added logic.
  */
 @SuppressLint("NewApi")
 internal class BluetoothL2capSocket(

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
  * Tracks bond state for a single [BluetoothDevice] via broadcast receiver.
  *
  * All mutable state is confined to [PeripheralContext.scope] which uses
- * `limitedParallelism(1)` — no synchronization primitives needed.
+ * `limitedParallelism(1)` - no synchronization primitives needed.
  */
 internal class AndroidBondManager(
     private val device: BluetoothDevice,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -255,7 +255,7 @@ internal class AndroidGattBridge(
         gatt = null
     }
 
-    /** Terminal — release all resources including the callback thread. */
+    /** Terminal - release all resources including the callback thread. */
     internal fun close() {
         gatt?.close()
         gatt = null

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -189,7 +189,7 @@ public class AndroidPeripheral internal constructor(
     /**
      * Attempts GATT connection with device-specific retry behavior.
      *
-     * Pixel devices commonly return GATT error 133 on the first attempt — a retry with
+     * Pixel devices commonly return GATT error 133 on the first attempt - a retry with
      * a short delay (1–1.5s) typically succeeds. The retry count and delay are sourced
      * from [QuirkRegistry] so each OEM gets appropriate handling.
      *
@@ -673,7 +673,7 @@ public class AndroidPeripheral internal constructor(
                     deferred.await()
                 }
             } catch (_: Throwable) {
-                // Best-effort — don't fail the flow completion
+                // Best-effort - don't fail the flow completion
             }
         }
     }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.android.kt
@@ -8,8 +8,8 @@ import com.atruedev.kmpble.KmpBle
  * Android BLE permission check.
  *
  * On API 33+ (minSdk), the required permissions are:
- * - `BLUETOOTH_SCAN` — for scanning
- * - `BLUETOOTH_CONNECT` — for connecting, reading, writing
+ * - `BLUETOOTH_SCAN` - for scanning
+ * - `BLUETOOTH_CONNECT` - for connecting, reading, writing
  *
  * `ACCESS_FINE_LOCATION` is NOT required on API 31+ unless scanning
  * with physical location intent (`ScanSettings.SCAN_TYPE_CLASSIC`).

--- a/src/androidMain/kotlin/com/atruedev/kmpble/quirks/BleQuirks.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/quirks/BleQuirks.kt
@@ -10,7 +10,7 @@ public object BleQuirks {
     public val BondBeforeConnect: QuirkKey<Boolean> =
         QuirkKey("bondBeforeConnect", false) { v, _ -> if (v) "bond-before-connect" else null }
 
-    /** Pixel: GATT 133 on first attempt — retry after this delay. */
+    /** Pixel: GATT 133 on first attempt - retry after this delay. */
     public val GattRetryDelay: QuirkKey<Duration> =
         QuirkKey("gattRetryDelay", 300.milliseconds) { v, d -> if (v != d) "retry-delay=$v" else null }
 
@@ -18,7 +18,7 @@ public object BleQuirks {
     public val GattRetryCount: QuirkKey<Int> =
         QuirkKey("gattRetryCount", 1) { v, _ -> if (v > 1) "retry=${v}x" else null }
 
-    /** OnePlus/Xiaomi: cache stale services after bonding — refresh required. */
+    /** OnePlus/Xiaomi: cache stale services after bonding - refresh required. */
     public val RefreshServicesOnBond: QuirkKey<Boolean> =
         QuirkKey("refreshServicesOnBond", false) { v, _ -> if (v) "refresh-services-on-bond" else null }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/quirks/QuirkRegistry.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/quirks/QuirkRegistry.kt
@@ -7,10 +7,10 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 /**
  * Immutable registry that resolves device-specific BLE quirks.
  *
- * All values are pre-resolved at build time — [resolve] is O(1).
+ * All values are pre-resolved at build time - [resolve] is O(1).
  * Resolution priority: user overrides > providers > [QuirkKey.default].
  *
- * The registry is frozen after construction — all mutation happens through [Builder].
+ * The registry is frozen after construction - all mutation happens through [Builder].
  */
 public class QuirkRegistry private constructor(
     @PublishedApi internal val resolved: Map<QuirkKey<*>, Any>,
@@ -76,7 +76,7 @@ public class QuirkRegistry private constructor(
                     }
                 }
             val suffix = if (active.isEmpty()) "no device-specific quirks" else active.joinToString()
-            val description = "${device.manufacturer}/${device.model} — $suffix"
+            val description = "${device.manufacturer}/${device.model} - $suffix"
             return QuirkRegistry(resolved, description)
         }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidAdvertisementParser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidAdvertisementParser.kt
@@ -54,7 +54,7 @@ private fun Int.toPhyOrNull(): Phy? =
         else -> null
     }
 
-/** Wraps ByteArray from ScanRecord — zero-copy (BleData wraps the reference). */
+/** Wraps ByteArray from ScanRecord - zero-copy (BleData wraps the reference). */
 private fun parseManufacturerData(record: android.bluetooth.le.ScanRecord?): Map<Int, BleData> {
     val sparse = record?.manufacturerSpecificData ?: return emptyMap()
     val result = mutableMapOf<Int, BleData>()

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -67,7 +67,7 @@ import kotlin.uuid.toKotlinUuid
  *
  * [close] follows the AndroidPeripheral pattern: set the closed flag,
  * close native resources synchronously (BluetoothGattServer.close() is
- * thread-safe), then cancel the scope. No runBlocking — safe to call
+ * thread-safe), then cancel the scope. No runBlocking - safe to call
  * from any context including handler callbacks.
  *
  * Thread-safe fields accessed from Binder threads:
@@ -161,7 +161,7 @@ internal class AndroidGattServer(
     // O(1) lookup cache: characteristic UUID -> native characteristic (built during open)
     private val characteristicCache = mutableMapOf<Uuid, BluetoothGattCharacteristic>()
 
-    // Per-device pending onNotificationSent — ConcurrentHashMap because
+    // Per-device pending onNotificationSent - ConcurrentHashMap because
     // onNotificationSent fires on a Binder thread and completes the deferred,
     // while notify/indicate write the entry from the serialized dispatcher.
     // Used for BOTH notifications and indications because Android's
@@ -169,14 +169,14 @@ internal class AndroidGattServer(
     // sending the next to the same device.
     private val pendingNotifySent = ConcurrentHashMap<String, CompletableDeferred<Int>>()
 
-    // Pending service addition — @Volatile because written on dispatcher, read on Binder thread
+    // Pending service addition - @Volatile because written on dispatcher, read on Binder thread
     @Volatile
     private var pendingServiceAdd: CompletableDeferred<Int>? = null
 
     // AtomicBoolean for atomic close (prevents double-close waste)
     private val isOpen = AtomicBoolean(false)
 
-    // Tracks whether close() has been called — prevents reopen after close
+    // Tracks whether close() has been called - prevents reopen after close
     private val isClosed = AtomicBoolean(false)
 
     private val callback =
@@ -457,7 +457,7 @@ internal class AndroidGattServer(
                 device: BluetoothDevice,
                 status: Int,
             ) {
-                // Called on Binder thread — ConcurrentHashMap + CompletableDeferred are both thread-safe
+                // Called on Binder thread - ConcurrentHashMap + CompletableDeferred are both thread-safe
                 pendingNotifySent.remove(device.address)?.complete(status)
             }
 
@@ -465,7 +465,7 @@ internal class AndroidGattServer(
                 status: Int,
                 service: BluetoothGattService,
             ) {
-                // Called on Binder thread — @Volatile + CompletableDeferred.complete is thread-safe
+                // Called on Binder thread - @Volatile + CompletableDeferred.complete is thread-safe
                 pendingServiceAdd?.complete(status)
             }
 
@@ -585,7 +585,7 @@ internal class AndroidGattServer(
 
             val targets =
                 if (device != null) {
-                    // Specific device — verify connected and subscribed
+                    // Specific device - verify connected and subscribed
                     val connected =
                         connectedDevices[device]
                             ?: throw ServerException.DeviceNotConnected("Device $device not connected")
@@ -596,7 +596,7 @@ internal class AndroidGattServer(
                     }
                     listOf(connected)
                 } else {
-                    // All subscribed devices for this characteristic — O(1) lookup via secondary index
+                    // All subscribed devices for this characteristic - O(1) lookup via secondary index
                     val subscribed = subscribersByChar[characteristicUuid] ?: emptySet()
                     subscribed.mapNotNull { connectedDevices[it] }
                 }
@@ -738,7 +738,7 @@ internal class AndroidGattServer(
      *
      * Follows the AndroidPeripheral pattern: set closed flag, release native
      * resources synchronously (BluetoothGattServer.close() is thread-safe),
-     * then cancel the scope. No runBlocking — no deadlock risk.
+     * then cancel the scope. No runBlocking - no deadlock risk.
      *
      * Uses [AtomicBoolean.compareAndSet] to ensure exactly one close executes
      * even under concurrent calls.
@@ -748,7 +748,7 @@ internal class AndroidGattServer(
         isClosed.set(true)
         logEvent(BleLogEvent.ServerLifecycle("closing"))
 
-        // Close native server first — stops all Binder callbacks
+        // Close native server first - stops all Binder callbacks
         try {
             nativeServer?.close()
         } catch (_: SecurityException) {
@@ -762,7 +762,7 @@ internal class AndroidGattServer(
         }
         pendingNotifySent.clear()
 
-        // Don't clear collections here — races with in-flight coroutines before cancellation.
+        // Don't clear collections here - races with in-flight coroutines before cancellation.
         scope.cancel()
         _connections.value = emptyList()
 
@@ -957,7 +957,7 @@ internal class AndroidGattServer(
         try {
             nativeServer?.sendResponse(device, requestId, status, offset, value)
         } catch (_: SecurityException) {
-            // Ignore — device disconnected or permission lost
+            // Ignore - device disconnected or permission lost
         }
     }
 
@@ -972,7 +972,7 @@ internal class AndroidGattServer(
         const val ATT_HEADER_SIZE = 3
         const val CONNECTION_WARNING_THRESHOLD = 7
 
-        // Global single-instance guard — Android supports one GATT server per app
+        // Global single-instance guard - Android supports one GATT server per app
         private val instanceLock = AtomicBoolean(false)
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/BleData.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/BleData.kt
@@ -4,7 +4,7 @@ package com.atruedev.kmpble
  * Zero-copy wrapper around platform-native byte buffers.
  *
  * - Android: wraps `ByteArray` directly (already native representation)
- * - iOS: wraps `NSData` — no memcpy on construction
+ * - iOS: wraps `NSData` - no memcpy on construction
  *
  * Provides indexed read access and slicing without copying. Call [toByteArray]
  * only when you need a mutable copy (e.g., for protocol parsing in consumer code).
@@ -16,7 +16,7 @@ public expect class BleData {
     /** Read a single byte at [index]. */
     public operator fun get(index: Int): Byte
 
-    /** Copy contents into a new ByteArray. Use sparingly — this allocates. */
+    /** Copy contents into a new ByteArray. Use sparingly - this allocates. */
     public fun toByteArray(): ByteArray
 
     /** Zero-copy slice from [fromIndex] (inclusive) to [toIndex] (exclusive). */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/ServiceUuid.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/ServiceUuid.kt
@@ -99,7 +99,7 @@ public object ServiceUuid {
     public val GENERIC_TELEPHONE_BEARER: Uuid = sig("184c")
     public val MICROPHONE_CONTROL: Uuid = sig("184d")
 
-    /** Nordic UART Service — defacto standard for serial-over-BLE. */
+    /** Nordic UART Service - defacto standard for serial-over-BLE. */
     public val NORDIC_UART: Uuid = vendor("6e400001-b5a3-f393-e0a9-e50e24dcca9e")
 
     /** All UUIDs defined in this object, auto-populated via [sig] and [vendor]. */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Observes the system Bluetooth adapter state.
  *
- * Standalone — not coupled to the connection API. When the adapter transitions to
+ * Standalone - not coupled to the connection API. When the adapter transitions to
  * [BluetoothAdapterState.Off] or [BluetoothAdapterState.Unavailable], downstream
  * peripherals (P2+) will transition to Disconnected.BySystemEvent.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/LatencyTracker.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/LatencyTracker.kt
@@ -6,7 +6,7 @@ import kotlin.time.TimeSource
 
 /**
  * Collects latency samples and computes percentile statistics.
- * Not thread-safe — confine to a single coroutine or use external serialization.
+ * Not thread-safe - confine to a single coroutine or use external serialization.
  *
  * ```kotlin
  * val tracker = LatencyTracker()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/ThroughputMeter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/ThroughputMeter.kt
@@ -9,7 +9,7 @@ import kotlin.time.TimeSource
  * Measures data throughput for BLE transfer operations.
  *
  * Accumulates byte counts and computes throughput over the measurement window.
- * Not thread-safe — confine to a single coroutine or use external serialization.
+ * Not thread-safe - confine to a single coroutine or use external serialization.
  *
  * ```kotlin
  * val meter = ThroughputMeter()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/bonding/BondRemovalResult.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/bonding/BondRemovalResult.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.bonding
 /**
  * Result of a [com.atruedev.kmpble.peripheral.Peripheral.removeBond] operation.
  *
- * Bond removal is an Android-only capability — iOS will always return [NotSupported].
+ * Bond removal is an Android-only capability - iOS will always return [NotSupported].
  */
 public sealed interface BondRemovalResult {
     /** The bond was successfully removed. */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/bonding/BondState.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/bonding/BondState.kt
@@ -13,9 +13,9 @@ public sealed interface BondState {
     /** A bonding procedure is in progress. */
     public data object Bonding : BondState
 
-    /** The peripheral is bonded — encryption keys are stored. */
+    /** The peripheral is bonded - encryption keys are stored. */
     public data object Bonded : BondState
 
-    /** iOS default — CoreBluetooth does not expose bond state directly. */
+    /** iOS default - CoreBluetooth does not expose bond state directly. */
     public data object Unknown : BondState
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/bonding/PairingHandler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/bonding/PairingHandler.kt
@@ -65,7 +65,7 @@ public sealed interface PairingEvent {
     ) : PairingEvent
 
     /**
-     * Just Works pairing — no user verification needed but handler is notified.
+     * Just Works pairing - no user verification needed but handler is notified.
      * Respond with [PairingResponse.Confirm] (typically `true`).
      */
     public data class JustWorksConfirmation(
@@ -82,7 +82,7 @@ public sealed interface PairingEvent {
 
     /**
      * Passkey displayed on the remote device. Informational only.
-     * No response required — respond with [PairingResponse.Confirm].
+     * No response required - respond with [PairingResponse.Confirm].
      */
     public data class PasskeyNotification(
         override val deviceIdentifier: Identifier,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
@@ -81,12 +81,12 @@ public enum class TransportType {
 public enum class PhyMask(
     public val value: Int,
 ) {
-    /** 1 Mbps PHY — universally supported. */
+    /** 1 Mbps PHY - universally supported. */
     LE_1M(1),
 
-    /** 2 Mbps PHY — double throughput, shorter range. */
+    /** 2 Mbps PHY - double throughput, shorter range. */
     LE_2M(2),
 
-    /** Coded PHY (Long Range) — lower throughput, extended range. */
+    /** Coded PHY (Long Range) - lower throughput, extended range. */
     LE_CODED(4),
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionRecipe.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionRecipe.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
  * Pre-built [ConnectionOptions] for common BLE device categories.
  *
  * Each preset provides optimized MTU, reconnection strategy, and timeout
- * for its target use case. Use these as starting points — override individual
+ * for its target use case. Use these as starting points - override individual
  * fields with [ConnectionOptions.copy] if needed.
  *
  * ```
@@ -15,7 +15,7 @@ import kotlin.time.Duration.Companion.seconds
  * ```
  */
 public object ConnectionRecipe {
-    /** BLE 4.2 maximum ATT MTU — 251 bytes minus 4 bytes L2CAP header. */
+    /** BLE 4.2 maximum ATT MTU - 251 bytes minus 4 bytes L2CAP header. */
     private const val BLE_4_2_MAX_ATT_MTU = 247
 
     /**
@@ -24,8 +24,8 @@ public object ConnectionRecipe {
      *
      * Optimized for continuous background monitoring:
      * - High MTU for efficient data transfer
-     * - Aggressive reconnection (10 attempts) — data gaps are unacceptable
-     * - Long timeout — medical devices can be slow to respond (bonding, encryption)
+     * - Aggressive reconnection (10 attempts) - data gaps are unacceptable
+     * - Long timeout - medical devices can be slow to respond (bonding, encryption)
      */
     public val MEDICAL: ConnectionOptions =
         ConnectionOptions(
@@ -46,8 +46,8 @@ public object ConnectionRecipe {
      *
      * Optimized for workout sessions:
      * - High MTU for sensor data throughput
-     * - Fast reconnection — workout interruptions should be brief
-     * - Moderate timeout — fitness devices respond reasonably fast
+     * - Fast reconnection - workout interruptions should be brief
+     * - Moderate timeout - fitness devices respond reasonably fast
      */
     public val FITNESS: ConnectionOptions =
         ConnectionOptions(
@@ -67,9 +67,9 @@ public object ConnectionRecipe {
      * environmental monitors).
      *
      * Optimized for low-power constrained devices:
-     * - Default MTU — many IoT devices don't support MTU negotiation
-     * - Conservative reconnection — battery-constrained, don't hammer
-     * - Short timeout — if it doesn't connect quickly, it's probably off
+     * - Default MTU - many IoT devices don't support MTU negotiation
+     * - Conservative reconnection - battery-constrained, don't hammer
+     * - Short timeout - if it doesn't connect quickly, it's probably off
      */
     public val IOT: ConnectionOptions =
         ConnectionOptions(
@@ -89,8 +89,8 @@ public object ConnectionRecipe {
      *
      * Optimized for responsive first connection:
      * - High MTU for audio/HID data
-     * - Moderate reconnection — users will retry manually if needed
-     * - Short timeout — consumer devices should connect quickly
+     * - Moderate reconnection - users will retry manually if needed
+     * - Short timeout - consumer devices should connect quickly
      */
     public val CONSUMER: ConnectionOptions =
         ConnectionOptions(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ReconnectionStrategy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ReconnectionStrategy.kt
@@ -7,7 +7,7 @@ import kotlin.time.Duration.Companion.seconds
  * Strategy applied when a peripheral disconnects unexpectedly.
  *
  * Set via [ConnectionOptions.reconnectionStrategy]. The strategy only activates on
- * unintentional disconnects — calling [com.atruedev.kmpble.peripheral.Peripheral.disconnect]
+ * unintentional disconnects - calling [com.atruedev.kmpble.peripheral.Peripheral.disconnect]
  * explicitly will not trigger reconnection.
  */
 public sealed class ReconnectionStrategy {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/State.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/State.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.connection
 import com.atruedev.kmpble.error.BleError
 
 /**
- * Peripheral connection state machine — 14 states organized into four phases.
+ * Peripheral connection state machine - 14 states organized into four phases.
  *
  * Observe via [com.atruedev.kmpble.peripheral.Peripheral.state]. The state machine uses a
  * declarative transition table with no invalid transitions possible at compile time.
@@ -29,13 +29,13 @@ public sealed interface State {
 
     /** The peripheral is connected and operational. */
     public sealed interface Connected : State {
-        /** Fully connected — GATT operations may be performed. */
+        /** Fully connected - GATT operations may be performed. */
         public data object Ready : Connected
 
         /** The bond state changed while connected (e.g. bond lost or re-paired). */
         public data object BondingChange : Connected
 
-        /** The remote GATT database changed — services need re-discovery. */
+        /** The remote GATT database changed - services need re-discovery. */
         public data object ServiceChanged : Connected
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.kt
@@ -9,7 +9,7 @@ import com.atruedev.kmpble.ExperimentalBleApi
  * On iOS, this configures the CBCentralManager with a restoration identifier so
  * iOS can restore BLE connections after app termination.
  *
- * On Android, this is a no-op — Android handles BLE background differently
+ * On Android, this is a no-op - Android handles BLE background differently
  * (via foreground services).
  *
  * @param config Configuration specifying the restoration identifier.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationConfig.kt
@@ -14,7 +14,7 @@ import com.atruedev.kmpble.ExperimentalBleApi
  * - The `bluetooth-central` background mode in your app's Info.plist
  * - The `UIBackgroundModes` key must include `bluetooth-central`
  *
- * On Android, this configuration is ignored — Android handles BLE background differently.
+ * On Android, this configuration is ignored - Android handles BLE background differently.
  *
  * Usage:
  * ```kotlin

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
@@ -83,7 +83,7 @@ internal class ReconnectionHandler(
                         } else {
                             min(baseMs * multiplier, maxMs)
                         }
-                    // ±20% jitter. At sub-5ms delays, truncation to Long zeros out the jitter —
+                    // ±20% jitter. At sub-5ms delays, truncation to Long zeros out the jitter -
                     // acceptable since sub-5ms backoff is not a thundering-herd risk.
                     val jitter = (delayMs * 0.2 * (2.0 * random.nextDouble() - 1.0)).toLong()
                     (delayMs + jitter).coerceAtLeast(1).milliseconds

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/StateMachine.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/StateMachine.kt
@@ -108,7 +108,7 @@ internal object StateMachine {
         }
 
     /**
-     * Wildcard transitions — apply from any non-Disconnected state.
+     * Wildcard transitions - apply from any non-Disconnected state.
      * Checked before the table. Order matters: AdapterOff and RemoteDisconnected
      * take precedence over state-specific transitions.
      */
@@ -139,13 +139,13 @@ internal object StateMachine {
             }
         }
 
-        // Look up in transition table — walk the state class hierarchy
+        // Look up in transition table - walk the state class hierarchy
         val resolver = findResolver(current, event)
         if (resolver != null) {
             return TransitionResult(resolver(current, event), valid = true)
         }
 
-        // No valid transition found — return current state, flag as invalid
+        // No valid transition found - return current state, flag as invalid
         return TransitionResult(current, valid = false)
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
@@ -4,7 +4,7 @@ package com.atruedev.kmpble.error
  * Root of the composable BLE error hierarchy.
  *
  * Errors are organized into sealed sub-interfaces ([ConnectionError], [GattOperationError],
- * [AuthError], [OperationConstraintError]) that can be composed — e.g. [AuthenticationFailed]
+ * [AuthError], [OperationConstraintError]) that can be composed - e.g. [AuthenticationFailed]
  * implements both [AuthError] and [GattOperationError], allowing callers to pattern-match at
  * the granularity they need.
  */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/error/GattStatus.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/error/GattStatus.kt
@@ -34,7 +34,7 @@ public sealed interface GattStatus {
     /** The peripheral does not support the requested ATT operation. */
     public data object RequestNotSupported : GattStatus
 
-    /** The connection is congested — retry the operation after a delay. */
+    /** The connection is congested - retry the operation after a delay. */
     public data object ConnectionCongested : GattStatus
 
     /** A generic GATT failure with no specific cause. */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/BackpressureStrategy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/BackpressureStrategy.kt
@@ -13,6 +13,6 @@ public sealed class BackpressureStrategy {
         val capacity: Int,
     ) : BackpressureStrategy()
 
-    /** Unlimited buffering — use with caution on high-throughput characteristics. */
+    /** Unlimited buffering - use with caution on high-throughput characteristics. */
     public data object Unbounded : BackpressureStrategy()
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/Characteristic.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/Characteristic.kt
@@ -10,7 +10,7 @@ import kotlin.uuid.Uuid
  * completes. Use [properties] to determine which operations (read, write, notify, etc.) the
  * characteristic supports before performing GATT operations.
  *
- * **Identity:** This is a `class`, not a `data class` — it uses reference equality intentionally,
+ * **Identity:** This is a `class`, not a `data class` - it uses reference equality intentionally,
  * matching native platform behavior where each discovered characteristic is a unique handle even
  * if two share the same UUID.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/Observation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/Observation.kt
@@ -4,7 +4,7 @@ package com.atruedev.kmpble.gatt
  * An event emitted by [com.atruedev.kmpble.peripheral.Peripheral.observe] for a characteristic
  * notification or indication subscription.
  *
- * Observations survive disconnection — a [Disconnected] event is emitted on disconnect, and
+ * Observations survive disconnection - a [Disconnected] event is emitted on disconnect, and
  * [Value] events resume automatically when the peripheral reconnects and resubscribes.
  */
 public sealed interface Observation {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationManager.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationManager.kt
@@ -88,7 +88,7 @@ internal class ObservationManager(
      * Serial dispatcher for mutable state access. Defaults to [Dispatchers.Unconfined]
      * because ObservationManager is always owned by a Peripheral that already provides
      * serialization via its own `limitedParallelism(1)` dispatcher. The Unconfined
-     * dispatcher runs inline — no thread hop, no test dispatcher conflict.
+     * dispatcher runs inline - no thread hop, no test dispatcher conflict.
      */
     private val serialDispatcher: CoroutineDispatcher = dispatcher
     private val observations = mutableMapOf<ObservationKey, TrackedObservation>()
@@ -219,7 +219,7 @@ internal class ObservationManager(
 
     /**
      * Called on disconnect. Emits [ObservationEvent.Disconnected] to all active observations.
-     * Does NOT clear observations — they persist for reconnection.
+     * Does NOT clear observations - they persist for reconnection.
      *
      * Thread-safety: Reads from an immutable @Volatile snapshot.
      */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -38,7 +38,7 @@ internal sealed interface PendingOp<T> {
  * Holds at most one [CompletableDeferred] per [PendingOp] type.
  *
  * Confined to the owning peripheral's serialized dispatcher
- * (`limitedParallelism(1)`) — no synchronization required.
+ * (`limitedParallelism(1)`) - no synchronization required.
  */
 internal class PendingOperations {
     private val slots = mutableMapOf<PendingOp<*>, CompletableDeferred<*>>()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogEvent.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogEvent.kt
@@ -9,10 +9,10 @@ import kotlin.uuid.Uuid
 public sealed interface BleLogEvent {
     /**
      * Human-readable log line for this event. Loggers can use this instead of
-     * exhaustive `when` blocks — new event subtypes get a sensible format
+     * exhaustive `when` blocks - new event subtypes get a sensible format
      * automatically (OCP: loggers don't break when events are added).
      *
-     * Computed on each access — log events are typically format-once-discard,
+     * Computed on each access - log events are typically format-once-discard,
      * so a plain `get()` avoids the synchronization overhead of `lazy`.
      */
     public val formatted: String

--- a/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogger.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogger.kt
@@ -4,10 +4,10 @@ package com.atruedev.kmpble.logging
  * Pluggable logging interface for BLE events.
  *
  * Set on [BleLogConfig] at library initialization. All peripherals and scanners
- * emit structured [BleLogEvent]s — consumers forward to Timber, OSLog, Kermit,
+ * emit structured [BleLogEvent]s - consumers forward to Timber, OSLog, Kermit,
  * or any logging framework.
  *
- * Data payloads are logged by byte count only by default — no accidental PHI/PII in logs.
+ * Data payloads are logged by byte count only by default - no accidental PHI/PII in logs.
  */
 public fun interface BleLogger {
     public fun log(event: BleLogEvent)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -69,7 +69,7 @@ public interface Peripheral : AutoCloseable {
      * - Resumes emitting [Observation.Value] when reconnected
      * - Completes normally when reconnection exhausts max attempts
      *
-     * May be called before connecting — CCCD will be enabled when connection is established.
+     * May be called before connecting - CCCD will be enabled when connection is established.
      *
      * @param characteristic The characteristic to observe (must support notify or indicate)
      * @param backpressure Strategy for handling backpressure when values arrive faster than consumed.
@@ -86,7 +86,7 @@ public interface Peripheral : AutoCloseable {
     /**
      * Observe raw notification/indication values from a characteristic.
      *
-     * Similar to [observe], but provides transparent reconnection — the flow suspends during
+     * Similar to [observe], but provides transparent reconnection - the flow suspends during
      * disconnects and resumes when reconnected, without emitting disconnect events.
      *
      * The returned flow survives disconnects and auto-resubscribes on reconnect:
@@ -98,7 +98,7 @@ public interface Peripheral : AutoCloseable {
      * Use this when you want to process values without handling connection state changes.
      * Consumers will see a gap in data during disconnects but no error handling is required.
      *
-     * May be called before connecting — CCCD will be enabled when connection is established.
+     * May be called before connecting - CCCD will be enabled when connection is established.
      *
      * @param characteristic The characteristic to observe (must support notify or indicate)
      * @param backpressure Strategy for handling backpressure when values arrive faster than consumed.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
@@ -10,7 +10,7 @@ import kotlin.uuid.Uuid
 /**
  * Returns a human-readable GATT service/characteristic/descriptor tree.
  *
- * Useful for debugging — answers "what does this device expose?" in one call.
+ * Useful for debugging - answers "what does this device expose?" in one call.
  * Only meaningful after service discovery completes (i.e., in [com.atruedev.kmpble.connection.State.Connected.Ready]).
  *
  * Takes a consistent snapshot of [Peripheral.state] and [Peripheral.services] before formatting,
@@ -93,14 +93,14 @@ private val WELL_KNOWN_DESCRIPTORS: Map<Uuid, String> =
  * ```
  *
  * Behavior:
- * - Delegates state validation to [Peripheral.connect] — if the peripheral is already connected
+ * - Delegates state validation to [Peripheral.connect] - if the peripheral is already connected
  *   or connecting, [Peripheral.connect]'s own invariants apply
  * - If connection drops mid-block: the block's coroutine is cancelled with
  *   [kotlinx.coroutines.CancellationException], then close() runs in finally
  * - [Peripheral.close] always runs in a [NonCancellable] context, guaranteeing cleanup
  *   even if the coroutine is cancelled mid-block
  *
- * Not thread-safe — callers must ensure exclusive access to this peripheral.
+ * Not thread-safe - callers must ensure exclusive access to this peripheral.
  */
 @OptIn(ExperimentalUuidApi::class)
 public suspend fun Peripheral.whenReady(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
@@ -52,7 +52,7 @@ internal class PeripheralContext(
 
     /**
      * Tracks when the current state was entered, for connection timeline logging.
-     * Confined to [dispatcher] — only read/written inside [processEvent].
+     * Confined to [dispatcher] - only read/written inside [processEvent].
      */
     private var stateEnteredAt: TimeSource.Monotonic.ValueTimeMark? = null
 
@@ -115,7 +115,7 @@ internal class PeripheralContext(
             _maximumWriteValueLength.value = (mtu - ATT_HEADER_SIZE).coerceAtLeast(DEFAULT_ATT_MTU - ATT_HEADER_SIZE)
         }
 
-    /** Terminal — non-suspend for ViewModel.onCleared() / deinit. Idempotent. */
+    /** Terminal - non-suspend for ViewModel.onCleared() / deinit. Idempotent. */
     fun close() {
         if (closed) return
         closed = true

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
@@ -7,7 +7,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Prevents duplicate [Peripheral] instances for the same physical device.
- * Lock-free via [AtomicReference] CAS — no blocking, no suspend, no TOCTOU.
+ * Lock-free via [AtomicReference] CAS - no blocking, no suspend, no TOCTOU.
  */
 @OptIn(ExperimentalAtomicApi::class)
 internal object PeripheralRegistry {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.permissions
 /**
  * Check whether the required BLE permissions are granted.
  *
- * This does NOT request permissions — it only checks the current state.
+ * This does NOT request permissions - it only checks the current state.
  * Use platform-specific APIs (ActivityResultContracts on Android, Info.plist
  * on iOS) to request permissions before calling this.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/permissions/PermissionResult.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/permissions/PermissionResult.kt
@@ -6,7 +6,7 @@ package com.atruedev.kmpble.permissions
  * Check this before starting a scan or connection to provide appropriate UI guidance.
  */
 public sealed interface PermissionResult {
-    /** All required BLE permissions are granted — scanning and connection are allowed. */
+    /** All required BLE permissions are granted - scanning and connection are allowed. */
     public data object Granted : PermissionResult
 
     /** One or more [permissions] were denied but can still be requested again. */
@@ -14,7 +14,7 @@ public sealed interface PermissionResult {
         val permissions: List<String>,
     ) : PermissionResult
 
-    /** One or more [permissions] were permanently denied — direct the user to system settings. */
+    /** One or more [permissions] were permanently denied - direct the user to system settings. */
     public data class PermanentlyDenied(
         val permissions: List<String>,
     ) : PermissionResult

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Advertisement.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Advertisement.kt
@@ -9,7 +9,7 @@ import kotlin.uuid.Uuid
 /**
  * Parsed BLE advertisement data from a single scan result.
  *
- * [manufacturerData] and [serviceData] values are [BleData] — zero-copy on iOS
+ * [manufacturerData] and [serviceData] values are [BleData] - zero-copy on iOS
  * (wraps NSData), lightweight on Android (wraps ByteArray). Call [BleData.toByteArray]
  * only when you need a mutable copy for protocol parsing.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/EmissionPolicy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/EmissionPolicy.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.scanner
 /**
  * Controls how scan results are deduplicated before emission.
  *
- * Default: [FirstThenChanges] — emits the first advertisement per device, then
+ * Default: [FirstThenChanges] - emits the first advertisement per device, then
  * re-emits only when data or RSSI changes significantly. This prevents flooding
  * the collector with 10+ identical advertisements per second per device.
  */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanFilter.kt
@@ -112,7 +112,7 @@ public class MatchScope internal constructor() {
 
     /**
      * Match devices with this MAC address. **Android only.**
-     * Apple does not expose MAC addresses — this filter has no effect on iOS.
+     * Apple does not expose MAC addresses - this filter has no effect on iOS.
      */
     @AndroidOnly
     public fun address(mac: String) {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Scanner.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Scanner.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * BLE scanner that discovers nearby advertising devices.
  *
- * [advertisements] is a **cold Flow**. Creating a Scanner starts nothing — no OS
+ * [advertisements] is a **cold Flow**. Creating a Scanner starts nothing - no OS
  * resources allocated. Scanning starts on first `collect()`, stops when the collector's
  * coroutine is cancelled. Multiple concurrent collectors share one underlying OS scan.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/EmissionPolicyFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/EmissionPolicyFilter.kt
@@ -32,7 +32,7 @@ private fun Flow<Advertisement>.firstThenChanges(rssiThreshold: Int): Flow<Adver
 
 /**
  * Lightweight snapshot for change detection. Uses BleData.hashCode() which is
- * content-based — no ByteArray allocation needed for comparison.
+ * content-based - no ByteArray allocation needed for comparison.
  */
 @OptIn(ExperimentalUuidApi::class)
 private data class AdvertisementSnapshot(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/Advertiser.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/Advertiser.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlin.uuid.Uuid
 
 /**
- * BLE advertiser — broadcasts the device's presence so centrals can discover it.
+ * BLE advertiser - broadcasts the device's presence so centrals can discover it.
  *
  * ## Usage
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlin.uuid.Uuid
 
 /**
- * BLE 5.0 extended advertiser — supports larger payloads, PHY selection,
+ * BLE 5.0 extended advertiser - supports larger payloads, PHY selection,
  * and multiple concurrent advertising sets.
  *
  * ## Platform Support

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/GattServer.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/GattServer.kt
@@ -9,7 +9,7 @@ import kotlin.uuid.Uuid
 /**
  * A GATT server that hosts BLE services on the local device.
  *
- * The phone acts as a BLE peripheral — remote devices (centrals) can
+ * The phone acts as a BLE peripheral - remote devices (centrals) can
  * connect and read/write characteristics, subscribe to notifications.
  *
  * ## Usage
@@ -47,7 +47,7 @@ import kotlin.uuid.Uuid
  * - Created via [GattServer] factory function (no OS resources allocated)
  * - [open] allocates OS resources and starts accepting connections
  * - [close] disconnects all clients, releases OS resources
- * - Use independently from [Advertiser] — a server can accept connections
+ * - Use independently from [Advertiser] - a server can accept connections
  *   without advertising (if client already knows the address)
  */
 public interface GattServer : AutoCloseable {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/IdleTracker.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/IdleTracker.kt
@@ -8,7 +8,7 @@ import kotlin.time.TimeSource
  * Tracks entries with monotonic last-activity timestamps and evicts those
  * idle beyond [idleTimeout].
  *
- * Not thread-safe — callers must confine access to a single dispatcher
+ * Not thread-safe - callers must confine access to a single dispatcher
  * (e.g. `limitedParallelism(1)`).
  */
 internal class IdleTracker<T>(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -209,7 +209,7 @@ public class FakePeripheral internal constructor(
             observeInternal(characteristic, backpressure) { event ->
                 when (event) {
                     is ObservationEvent.Value -> emit(event.data)
-                    // Transparent reconnection — ObservationManager re-subscribes on reconnect
+                    // Transparent reconnection - ObservationManager re-subscribes on reconnect
                     is ObservationEvent.Disconnected -> Unit
                     is ObservationEvent.PermanentlyDisconnected -> Unit
                 }
@@ -331,7 +331,7 @@ public class FakePeripheral internal constructor(
 
     /**
      * Simulate a disconnect event. This will emit [Observation.Disconnected] to all active
-     * observations but NOT complete them — they persist for reconnection.
+     * observations but NOT complete them - they persist for reconnection.
      */
     public suspend fun simulateDisconnect(error: BleError = ConnectionLost("Simulated disconnect")) {
         checkNotClosed()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
@@ -155,7 +155,7 @@ public class FakeCharacteristicBuilder(
 
     /**
      * Add a delay before executing read/write handlers on this characteristic.
-     * The delay is cancellable — if the coroutine is cancelled during the delay,
+     * The delay is cancellable - if the coroutine is cancelled during the delay,
      * the operation cancels cleanly without invoking the handler.
      * Does not affect [onObserve] (notifications have their own timing via Flow).
      */
@@ -165,7 +165,7 @@ public class FakeCharacteristicBuilder(
 
     /**
      * Cause all operations (read, write, observe) on this characteristic to throw
-     * the specified [BleError]. Takes precedence over [onRead]/[onWrite]/[onObserve] —
+     * the specified [BleError]. Takes precedence over [onRead]/[onWrite]/[onObserve] -
      * if both are set, the error is thrown and handlers are never invoked.
      * Can be combined with [respondAfter] to delay before failing.
      */

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/GattOperationQueueTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/GattOperationQueueTest.kt
@@ -133,7 +133,7 @@ class GattOperationQueueTest {
             }
             yield()
 
-            // drain() closes the channel — victim gets NotConnectedException.
+            // drain() closes the channel - victim gets NotConnectedException.
             queue.drain()
             gate.complete(Unit)
 

--- a/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceCallbackTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceCallbackTest.kt
@@ -91,7 +91,7 @@ class ObservationPersistenceCallbackTest {
     fun `no callback when callback is null`() =
         runTest {
             val manager = ObservationManager()
-            // Should not throw — callback is null by default
+            // Should not throw - callback is null by default
             manager.subscribe(serviceUuid, charUuid, BackpressureStrategy.Latest)
             manager.unsubscribe(serviceUuid, charUuid)
         }
@@ -105,7 +105,7 @@ class ObservationPersistenceCallbackTest {
             val received = mutableListOf<Set<PersistedObservation>>()
             manager.onObservationsChanged = { obs -> received.add(obs) }
 
-            // Second subscribe for same key — collector count goes up, but key set unchanged
+            // Second subscribe for same key - collector count goes up, but key set unchanged
             manager.subscribe(serviceUuid, charUuid, BackpressureStrategy.Latest)
 
             assertTrue(received.isEmpty(), "Callback should not fire when key set is unchanged")

--- a/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionTest.kt
@@ -78,7 +78,7 @@ class ObservationReconnectionTest {
                 assertContentEquals(byteArrayOf(0x01), awaitItem())
 
                 peripheral.simulateDisconnect()
-                // observeValues does not emit during disconnect — no awaitItem here
+                // observeValues does not emit during disconnect - no awaitItem here
 
                 peripheral.simulateReconnect()
                 peripheral.emitObservationValue(testServiceUuid, testCharUuid, byteArrayOf(0x02))
@@ -193,7 +193,7 @@ class ObservationReconnectionTest {
                     )
                 peripheral.simulateReconnect(newServices)
 
-                // Characteristic removed — emits final Disconnected then completes
+                // Characteristic removed - emits final Disconnected then completes
                 assertIs<Observation.Disconnected>(awaitItem())
                 awaitComplete()
             }
@@ -288,7 +288,7 @@ class ObservationReconnectionTest {
                 assertEquals(1, cccdBeforeValue.size)
                 assertTrue(cccdBeforeValue[0].enabled)
 
-                // Now emit — only possible after CCCD enable completed
+                // Now emit - only possible after CCCD enable completed
                 peripheral.emitObservationValue(testServiceUuid, testCharUuid, byteArrayOf(0x42))
                 val v = awaitItem()
                 assertIs<Observation.Value>(v)

--- a/src/commonTest/kotlin/com/atruedev/kmpble/server/IdleTrackerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/server/IdleTrackerTest.kt
@@ -44,7 +44,7 @@ class IdleTrackerTest {
     fun trackOrRefresh_refreshes_activity_preventing_eviction() {
         tracker.trackOrRefresh("a", "centralA")
 
-        // Advance 4 minutes, refresh, advance 4 more — total 8 min but only 4 since refresh
+        // Advance 4 minutes, refresh, advance 4 more - total 8 min but only 4 since refresh
         timeSource += 4.minutes
         tracker.trackOrRefresh("a", "centralA")
         timeSource += 4.minutes

--- a/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
@@ -44,7 +44,7 @@ class FakeScannerTest {
     fun emptyScanner() =
         runTest {
             val scanner = FakeScanner {}
-            // No pre-configured ads — flow suspends waiting for dynamic emissions
+            // No pre-configured ads - flow suspends waiting for dynamic emissions
             scanner.close()
         }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/adapter/IosBluetoothAdapter.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/adapter/IosBluetoothAdapter.kt
@@ -17,6 +17,6 @@ public class IosBluetoothAdapter : BluetoothAdapter {
         }
 
     override fun close() {
-        // Delegates to singleton — no per-instance cleanup needed
+        // Delegates to singleton - no per-instance cleanup needed
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationPersistence.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationPersistence.ios.kt
@@ -74,7 +74,7 @@ internal actual class ObservationPersistence actual constructor() {
                     ),
                 )
             } catch (_: Exception) {
-                // Skip malformed entries — lenient restore
+                // Skip malformed entries - lenient restore
             }
         }
         return result

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.Volatile
  * Unified [CBPeripheralManager] delegate handling server, advertising,
  * and subscription callbacks.
  *
- * Similar pattern to [KmpBleCentralDelegate] — a single delegate handles
+ * Similar pattern to [KmpBleCentralDelegate] - a single delegate handles
  * all CBPeripheralManager callbacks and routes to registered handlers.
  *
  * The delegate is set at CBPeripheralManager creation time (in
@@ -91,7 +91,7 @@ internal class IosPeripheralManagerDelegate :
     // K/N limitation: peripheralManager:central:didSubscribeToCharacteristic: and
     // peripheralManager:central:didUnsubscribeFromCharacteristic: share the same
     // Kotlin type signature (CBPeripheralManager, CBCentral, CBCharacteristic).
-    // Only one can be overridden — we choose subscribe since it's essential for
+    // Only one can be overridden - we choose subscribe since it's essential for
     // connection tracking. Unsubscribe events are not received.
     // See IosGattServer documentation for implications.
     override fun peripheralManager(

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/KmpBleCentralDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/KmpBleCentralDelegate.kt
@@ -60,7 +60,7 @@ internal class KmpBleCentralDelegate :
     private val _restoredPeripherals = MutableSharedFlow<List<CBPeripheral>>(replay = 1)
     internal val restoredPeripherals: SharedFlow<List<CBPeripheral>> = _restoredPeripherals.asSharedFlow()
 
-    // Copy-on-write map — reads from CoreBluetooth queue, writes from Kotlin coroutines.
+    // Copy-on-write map - reads from CoreBluetooth queue, writes from Kotlin coroutines.
     // @Volatile ensures visibility across threads. Mutation creates a new map instance.
     @Volatile
     private var connectionCallbacks = mapOf<String, (connected: Boolean, error: NSError?) -> Unit>()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/PeripheralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/PeripheralManagerProvider.kt
@@ -6,7 +6,7 @@ import platform.darwin.dispatch_queue_create
 /**
  * Provides the shared [CBPeripheralManager] instance.
  *
- * Separate from [CentralManagerProvider] — CBPeripheralManager and
+ * Separate from [CentralManagerProvider] - CBPeripheralManager and
  * CBCentralManager coexist independently. Each has its own dispatch
  * queue and delegate.
  */

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -88,7 +88,7 @@ internal class IosL2capChannel(
 
                         when {
                             bytesRead > 0 -> dataChannel.send(buffer.copyOf(bytesRead))
-                            bytesRead < 0 -> return // Error or EOF — exit readLoop
+                            bytesRead < 0 -> return // Error or EOF - exit readLoop
                         }
                     }
                     consecutiveIdlePolls = 0

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
@@ -88,7 +88,7 @@ internal class ApplePeripheralBridge(
             }
 
             // K/N maps didUpdateValue and didWriteValue for characteristics to the same
-            // Kotlin signature. Only didUpdateValue is overridden — handles reads + notifications.
+            // Kotlin signature. Only didUpdateValue is overridden - handles reads + notifications.
             // Write confirmations are handled by the IosPeripheral completing the write deferred
             // when this callback fires with a pending write operation.
             override fun peripheral(

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -278,7 +278,7 @@ public class IosPeripheral(
                 is AppleCallbackEvent.DidDiscoverCharacteristics -> handleCharacteristicsDiscovered()
                 is AppleCallbackEvent.DidUpdateValueForCharacteristic -> {
                     // K/N may route both didUpdateValue and didWriteValue here (same
-                    // Kotlin type signature). The GATT queue serializes ops — at most
+                    // Kotlin type signature). The GATT queue serializes ops - at most
                     // one of read/write is pending. Check write first, then read, then notification.
                     val cbChar = event.characteristic
                     val error = event.error
@@ -381,7 +381,7 @@ public class IosPeripheral(
             if (char != null) {
                 enableNotifications(char)
             } else {
-                // Characteristic no longer exists — complete that observation
+                // Characteristic no longer exists - complete that observation
                 observationManager.completeObservation(key)
             }
         }
@@ -579,7 +579,7 @@ public class IosPeripheral(
 
     override suspend fun requestMtu(mtu: Int): Int {
         checkNotClosed()
-        // iOS negotiates MTU automatically — no explicit request API.
+        // iOS negotiates MTU automatically - no explicit request API.
         // Read the actual negotiated value from CoreBluetooth.
         val actualMtu =
             cbPeripheral

--- a/src/iosMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.ios.kt
@@ -12,7 +12,7 @@ import platform.CoreBluetooth.CBManagerAuthorizationRestricted
  * Checks `CBCentralManager.authorization` (iOS 13+).
  * The app must include `NSBluetoothAlwaysUsageDescription` in Info.plist.
  *
- * Note: this only checks authorization status — it does NOT trigger the
+ * Note: this only checks authorization status - it does NOT trigger the
  * permission prompt. The prompt appears when a CBCentralManager is first created.
  */
 public actual fun checkBlePermissions(): PermissionResult {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosAdvertiser.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosAdvertiser.kt
@@ -30,10 +30,10 @@ import kotlin.concurrent.AtomicInt
  *
  * [AdvertiseConfig] fields that don't map to iOS are silently ignored
  * with a log warning:
- * - [AdvertiseConfig.manufacturerData] — ignored (iOS foreground limitation)
- * - [AdvertiseConfig.includeTxPower] — ignored (iOS doesn't expose)
- * - [AdvertiseConfig.mode] — ignored (iOS controls interval)
- * - [AdvertiseConfig.txPower] — ignored (iOS controls power)
+ * - [AdvertiseConfig.manufacturerData] - ignored (iOS foreground limitation)
+ * - [AdvertiseConfig.includeTxPower] - ignored (iOS doesn't expose)
+ * - [AdvertiseConfig.mode] - ignored (iOS controls interval)
+ * - [AdvertiseConfig.txPower] - ignored (iOS controls power)
  */
 internal class IosAdvertiser(
     private val manager: CBPeripheralManager = PeripheralManagerProvider.manager,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -166,7 +166,7 @@ internal class IosGattServer(
             if (!instanceLock.compareAndSet(0, 1)) {
                 throw ServerException.OpenFailed(
                     "Another IosGattServer is already open. iOS uses a single " +
-                        "CBPeripheralManager — call close() on the existing server first.",
+                        "CBPeripheralManager - call close() on the existing server first.",
                 )
             }
 
@@ -184,7 +184,7 @@ internal class IosGattServer(
     private suspend fun openInternal() {
         setDelegateCallbacks(active = true)
 
-        // Force lazy CBPeripheralManager init — the constructor fires
+        // Force lazy CBPeripheralManager init - the constructor fires
         // peripheralManagerDidUpdateState on our delegate.
         manager
 
@@ -282,7 +282,7 @@ internal class IosGattServer(
      *
      * iOS doesn't distinguish notify vs indicate at the API level.
      * The characteristic property ([CBCharacteristicPropertyIndicate])
-     * determines the behavior — iOS handles confirmation transparently.
+     * determines the behavior - iOS handles confirmation transparently.
      * This method delegates to [notify] with the same underlying
      * `updateValue` call.
      */
@@ -305,7 +305,7 @@ internal class IosGattServer(
 
         logEvent(BleLogEvent.ServerLifecycle("closing"))
 
-        // Stop accepting new callbacks before cancelling scope — prevents
+        // Stop accepting new callbacks before cancelling scope - prevents
         // a GCD-queued callback from scope.launch-ing into a cancelled scope.
         setDelegateCallbacks(active = false)
 
@@ -313,7 +313,7 @@ internal class IosGattServer(
 
         readyToUpdate.cancel(kotlinx.coroutines.CancellationException("Server closed"))
 
-        // Don't clear collections here — races with in-flight coroutines before cancellation.
+        // Don't clear collections here - races with in-flight coroutines before cancellation.
         scope.cancel()
         _connections.value = emptyList()
 
@@ -569,7 +569,7 @@ internal class IosGattServer(
 
     // iOS silently truncates notification/indication payloads to the negotiated
     // ATT MTU. Unlike Android, there is no API to query the per-central MTU or
-    // receive a truncation warning — callers must size payloads conservatively
+    // receive a truncation warning - callers must size payloads conservatively
     // (typically ≤ 182 bytes for default MTU, or negotiate a larger MTU from
     // the central side).
     private suspend fun sendUpdate(
@@ -591,7 +591,7 @@ internal class IosGattServer(
                 }
             } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
                 throw ServerException.NotifyFailed(
-                    "Transmit queue full — timeout waiting for ready (attempt ${attempt + 1}/$MAX_NOTIFY_RETRIES)",
+                    "Transmit queue full - timeout waiting for ready (attempt ${attempt + 1}/$MAX_NOTIFY_RETRIES)",
                 )
             }
         }

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/UnsupportedBle.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/UnsupportedBle.kt
@@ -1,4 +1,4 @@
 package com.atruedev.kmpble
 
 internal fun unsupportedBle(operation: String): Nothing =
-    throw UnsupportedOperationException("$operation is not supported on JVM — BLE requires Android or iOS")
+    throw UnsupportedOperationException("$operation is not supported on JVM - BLE requires Android or iOS")

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.jvm.kt
@@ -1,4 +1,4 @@
 package com.atruedev.kmpble.permissions
 
 public actual fun checkBlePermissions(): PermissionResult =
-    PermissionResult.Denied(listOf("BLE is not supported on JVM — BLE requires Android or iOS"))
+    PermissionResult.Denied(listOf("BLE is not supported on JVM - BLE requires Android or iOS"))

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/GattOperationQueueLifecycleLincheckTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/GattOperationQueueLifecycleLincheckTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
  * The suspend [GattOperationQueue.enqueue] is excluded because Lincheck
  * controls threads, not coroutine dispatchers.
  *
- * Uses [StressOptions] only — [ModelCheckingOptions] conflicts with the
+ * Uses [StressOptions] only - [ModelCheckingOptions] conflicts with the
  * coroutine launched inside [start].
  *
  * [Dispatchers.Unconfined] avoids spawning worker threads per scenario;

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -21,7 +21,7 @@ import kotlin.uuid.Uuid
 
 /**
  * Minimal [Peripheral] stub for Lincheck tests.
- * Only [identifier] and [close] are functional — all other members
+ * Only [identifier] and [close] are functional - all other members
  * throw because Lincheck tests only exercise registry operations.
  */
 @OptIn(ExperimentalUuidApi::class)


### PR DESCRIPTION
## Summary
- Replace all 255 em-dash (—) occurrences with regular hyphens (-) across 97 files
- Covers source code, docs (README, ARCHITECTURE, CHANGELOG, MIGRATION, llms.txt), and CI workflows
- ASCII-only punctuation; no semantic changes

## Test plan
- [x] CI passes (build, lint, tests)
- [x] `grep -rI "—" .` returns no matches outside `.git`