### PR TITLE
fix(deps): pin Bouncy Castle to 1.84 to resolve security advisories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ val securityPatches: Action<DependencyResolveDetails> =
             "io.netty" -> useVersion(libs.versions.netty.get())
             "ch.qos.logback" -> useVersion(libs.versions.logback.get())
             "com.fasterxml.jackson.core" -> useVersion(libs.versions.jackson.get())
+            "org.bouncycastle" -> useVersion(libs.versions.bouncycastle.get())
         }
         when ("${requested.group}:${requested.name}") {
             "org.jdom:jdom2" -> useVersion(libs.versions.jdom2.get())
@@ -29,6 +30,7 @@ buildscript {
                 "io.netty" -> useVersion("4.1.132.Final")
                 "ch.qos.logback" -> useVersion("1.5.25")
                 "com.fasterxml.jackson.core" -> useVersion("2.18.6")
+                "org.bouncycastle" -> useVersion("1.84")
             }
             when ("${requested.group}:${requested.name}") {
                 "org.jdom:jdom2" -> useVersion("2.0.6.1")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ jdom2 = "2.0.6.1"
 jose4j = "0.9.6"
 commonsLang3 = "3.18.0"
 httpclient = "4.5.14"
+bouncycastle = "1.84"
 
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version = "1.18.0" }


### PR DESCRIPTION
## Summary
- Resolves three [Dependabot alerts](https://github.com/gary-quinn/kmp-ble/security/dependabot) for Bouncy Castle pulled in transitively by the vanniktech maven publish plugin's PGP signing classpath:
  - `org.bouncycastle:bcpg-jdk18on` < 1.84 — GHSA-cj8j-37rh-8475 (high, uncontrolled resource consumption)
  - `org.bouncycastle:bcprov-jdk18on` < 1.84 (medium, LDAP injection)
  - `org.bouncycastle:bcpkix-jdk18on` < 1.84 (medium, broken/risky crypto algorithm)
- Adds a group-level `org.bouncycastle -> 1.84` pin to the existing `securityPatches` resolution strategy in both `buildscript` and `allprojects` blocks, mirroring the pattern already used for netty/logback/jackson.
- Adds the version to the catalog so the project-side `securityPatches` action references it via `libs.versions.bouncycastle.get()` (the buildscript block can't access the catalog and keeps the literal, same as the others).

## Test plan
- [x] `./gradlew :buildEnvironment` confirms `bcprov-jdk18on:1.79 -> 1.84` and `bcpkix-jdk18on:1.79 -> 1.84` resolution
- [x] CI green