### PR TITLE
ci: forbid em-dashes in repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ permissions:
   contents: read
 
 jobs:
+  forbid-em-dashes:
+    name: Forbid em-dashes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check for em-dashes
+        run: |
+          EMDASH=$'\u2014'
+          if grep -rIn "$EMDASH" --exclude-dir=.git --exclude-dir=build --exclude-dir=.gradle --exclude-dir=node_modules .; then
+            echo "::error::Em-dash found. Replace with a regular hyphen (-)."
+            exit 1
+          fi
+
   android:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add a fast `forbid-em-dashes` job to CI that fails if any em-dash (U+2014) appears in tracked files
- Excludes `.git`, `build`, `.gradle`, `node_modules`
- Uses bash `$'—'` so the workflow file itself stays clean

## Test plan
- [x] CI passes on this PR (no em-dashes after #153)
- [x] Local sanity: introduce a temporary em-dash, push, confirm CI fails with the expected error annotation