### PR TITLE
ci: add typography-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gary-quinn/shared-actions/typography-check@da652cf908933a8f760fe35a4477ca59273ecd8c # PR #1; switch to @v1 after release
+      - uses: gary-quinn/shared-actions/typography-check@cd697d0da404a22dc157c6280d498f68a5bee6af # v1.0.1
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ permissions:
   contents: read
 
 jobs:
+  typography:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: gary-quinn/shared-actions/typography-check@da652cf908933a8f760fe35a4477ca59273ecd8c # PR #1; switch to @v1 after release
+
   android:
     runs-on: ubuntu-latest
     steps:

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/internal/Sha256.kt
@@ -9,7 +9,7 @@ package com.atruedev.kmpble.dfu.internal
  * transfer. Consider an expect/actual with platform crypto if profiling shows a bottleneck.
  *
  * Allocation strategy: complete 64-byte blocks are processed directly from the source
- * array. Only the 1–2 padding tail blocks (max 128 bytes) are materialized in a
+ * array. Only the 1-2 padding tail blocks (max 128 bytes) are materialized in a
  * temporary buffer - no full-image copy regardless of firmware size.
  */
 @OptIn(ExperimentalUnsignedTypes::class)

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/battery/BatteryLevel.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/battery/BatteryLevel.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.profiles.battery
 /**
  * Parses a Battery Level characteristic value (0x2A19).
  *
- * @return Battery percentage (0–100), or `null` if [data] is empty or out of range.
+ * @return Battery percentage (0-100), or `null` if [data] is empty or out of range.
  */
 public fun parseBatteryLevel(data: ByteArray): Int? {
     if (data.isEmpty()) return null

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/battery/BatteryProfile.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/battery/BatteryProfile.kt
@@ -13,7 +13,7 @@ private val BATTERY_LEVEL_UUID = uuidFrom("2A19")
 /**
  * Reads the current battery level from the Battery Service (0x180F).
  *
- * @return Battery percentage (0–100), or `null` if the service or characteristic is absent.
+ * @return Battery percentage (0-100), or `null` if the service or characteristic is absent.
  */
 public suspend fun Peripheral.readBatteryLevel(): Int? {
     val char = findCharacteristic(ServiceUuid.BATTERY, BATTERY_LEVEL_UUID) ?: return null
@@ -24,7 +24,7 @@ public suspend fun Peripheral.readBatteryLevel(): Int? {
  * Observes battery level notifications from the Battery Service (0x180F).
  *
  * @param backpressure Strategy for handling notifications that arrive faster than the collector.
- * @return Flow of battery percentages (0–100), or an empty flow if the characteristic is absent.
+ * @return Flow of battery percentages (0-100), or an empty flow if the characteristic is absent.
  */
 public fun Peripheral.batteryLevelNotifications(
     backpressure: BackpressureStrategy = BackpressureStrategy.Latest,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -190,7 +190,7 @@ public class AndroidPeripheral internal constructor(
      * Attempts GATT connection with device-specific retry behavior.
      *
      * Pixel devices commonly return GATT error 133 on the first attempt - a retry with
-     * a short delay (1–1.5s) typically succeeds. The retry count and delay are sourced
+     * a short delay (1-1.5s) typically succeeds. The retry count and delay are sourced
      * from [QuirkRegistry] so each OEM gets appropriate handling.
      *
      * The effective timeout is `max(options.timeout, quirks.connectionTimeout)` so that

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
@@ -40,7 +40,7 @@ public interface L2capChannel : AutoCloseable {
      *
      * Maximum payload size for a single write operation.
      * Writes larger than this are segmented automatically by the OS.
-     * Typical values: 2KB–64KB depending on peripheral and connection.
+     * Typical values: 2KB-64KB depending on peripheral and connection.
      *
      * **Platform behavior:**
      * - **Android:** Queried from the socket via `maxTransmitPacketSize`, floored


### PR DESCRIPTION
## Summary

Adds a `typography` job to the CI workflow that calls the new [gary-quinn/shared-actions/typography-check@v1](https://github.com/gary-quinn/shared-actions/pull/1) composite action.

## Why

Tier-1 enforcement is the local pre-commit hook in `.githooks/pre-commit` (added in #156). Tier-2 is this CI job - the safety net for:

- Commits made with `--no-verify`
- Contributors who forgot the one-time `git config core.hooksPath .githooks` setup
- Bots / agents pushing from environments without the hook configured

Same forbidden character set, same `typo-ok` pragma, same path excludes - matched at the action level.

## Pinning

Pinned to the PR-pre-merge SHA of [gary-quinn/shared-actions#1](https://github.com/gary-quinn/shared-actions/pull/1). After that PR merges and the `v1` tag is advanced, swap to `@v1` in a follow-up.

## Merge order

1. Merge gary-quinn/shared-actions#1 first.
2. Merge this PR. (CI on this PR will fail until step 1 because the action does not exist yet at any ref.)

## Test plan

- [ ] Confirm CI green after shared-actions#1 merges.
- [ ] Verify a deliberate em-dash on a follow-up PR is caught with a per-line annotation.