### PR TITLE
refactor(peripheral): confine lifecycle deferreds to serial dispatcher

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -22,7 +22,6 @@ import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
-import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -37,34 +36,34 @@ import com.atruedev.kmpble.gatt.internal.ENABLE_NOTIFICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.NotConnectedException
-import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
-import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.BluetoothL2capSocket
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
+import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
+import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import com.atruedev.kmpble.peripheral.internal.PeripheralRegistry
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
+import com.atruedev.kmpble.peripheral.internal.findCharacteristic
+import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.quirks.BleQuirks
 import com.atruedev.kmpble.quirks.QuirkRegistry
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.getAndUpdate
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -92,16 +91,9 @@ public class AndroidPeripheral internal constructor(
     private val peripheralContext = PeripheralContext(identifier)
     private val bridge = AndroidGattBridge(device, context)
 
-    @Volatile
-    private var connectionComplete: CompletableDeferred<Unit>? = null
-
-    @Volatile
-    private var discoveryComplete: CompletableDeferred<List<DiscoveredService>>? = null
-
-    @Volatile
-    private var disconnectComplete: CompletableDeferred<Unit>? = null
     private val pendingOps = PendingOperations()
     private val observationManager = ObservationManager()
+    private val slots = LifecycleSlots()
 
     private val nativeCharMap = mutableMapOf<Characteristic, BluetoothGattCharacteristic>()
     private val nativeDescMap = mutableMapOf<Descriptor, BluetoothGattDescriptor>()
@@ -120,8 +112,12 @@ public class AndroidPeripheral internal constructor(
     @Volatile
     private var closed = false
 
-    @Volatile
+    /**
+     * Confined to [peripheralContext.dispatcher]. Read by [handleConnectionStateChanged]
+     * to decide whether bonding is required for the freshly-established link.
+     */
     private var currentConnectionOptions: ConnectionOptions? = null
+
     private val reconnectionHandler =
         ReconnectionHandler(
             scope = peripheralContext.scope,
@@ -147,11 +143,11 @@ public class AndroidPeripheral internal constructor(
     @OptIn(ExperimentalBleApi::class)
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
-        currentConnectionOptions = options
         reconnectionHandler.start(options)
         bondManager.start()
 
         withContext(peripheralContext.dispatcher) {
+            currentConnectionOptions = options
             pairingRequestHandler.setHandler(options.pairingHandler)
             pairingRequestHandler.start()
             ensureBondedIfRequired(options)
@@ -160,7 +156,7 @@ public class AndroidPeripheral internal constructor(
     }
 
     /**
-     * Samsung quirk: some Galaxy devices require bonding BEFORE calling connectGatt(),
+     * Samsung quirk: certain Galaxy devices must be bonded BEFORE `connectGatt()`,
      * otherwise the connection fails silently or returns GATT 133.
      */
     private suspend fun ensureBondedIfRequired(options: ConnectionOptions) {
@@ -171,9 +167,7 @@ public class AndroidPeripheral internal constructor(
         val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
         logEvent(BleLogEvent.BondEvent(identifier, "Quirk: bond-before-connect initiated"))
         try {
-            withTimeout(bondTimeout) {
-                bondManager.createBond()
-            }
+            withTimeout(bondTimeout) { bondManager.createBond() }
             logEvent(BleLogEvent.BondEvent(identifier, "Quirk: bond-before-connect succeeded"))
         } catch (_: TimeoutCancellationException) {
             logEvent(
@@ -187,15 +181,10 @@ public class AndroidPeripheral internal constructor(
     }
 
     /**
-     * Attempts GATT connection with device-specific retry behavior.
-     *
-     * Pixel devices commonly return GATT error 133 on the first attempt - a retry with
-     * a short delay (1–1.5s) typically succeeds. The retry count and delay are sourced
-     * from [QuirkRegistry] so each OEM gets appropriate handling.
-     *
-     * The effective timeout is `max(options.timeout, quirks.connectionTimeout)` so that
-     * user-configured values are respected while still accommodating OEMs that need longer
-     * timeouts (e.g. Huawei at 35s vs the 30s default).
+     * GATT connect with OEM-specific retry behaviour. Pixel devices commonly return
+     * GATT 133 on the first attempt; a short delay and a second attempt typically
+     * succeeds. Effective timeout is `max(options.timeout, quirks.connectionTimeout)`
+     * to honour both user config and OEMs that need longer (e.g. Huawei).
      */
     private suspend fun connectWithRetry(options: ConnectionOptions) {
         val maxAttempts = quirkRegistry.resolve(BleQuirks.GattRetryCount)
@@ -217,25 +206,19 @@ public class AndroidPeripheral internal constructor(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            val deferred = CompletableDeferred<Unit>()
-            connectionComplete = deferred
-
+            val deferred = slots.armConnect()
             val gatt = bridge.connect(options)
             if (gatt == null) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("connectGatt returned null")),
                 )
-                connectionComplete = null
-                if (attempt < maxAttempts - 1) {
-                    delay(retryDelay)
-                }
+                slots.clearConnect()
+                if (attempt < maxAttempts - 1) delay(retryDelay)
                 return@repeat
             }
 
             try {
-                withTimeout(timeout) {
-                    deferred.await()
-                }
+                withTimeout(timeout) { deferred.await() }
             } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
                 bridge.releaseGatt()
@@ -243,12 +226,10 @@ public class AndroidPeripheral internal constructor(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("Connection timeout after $timeout")),
                 )
             } finally {
-                connectionComplete = null
+                slots.clearConnect()
             }
 
-            if (peripheralContext.state.value is State.Connected) {
-                return
-            }
+            if (peripheralContext.state.value is State.Connected) return
 
             if (attempt < maxAttempts - 1) {
                 bridge.releaseGatt()
@@ -266,8 +247,7 @@ public class AndroidPeripheral internal constructor(
             pairingRequestHandler.stop()
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            val deferred = CompletableDeferred<Unit>()
-            disconnectComplete = deferred
+            val deferred = slots.armDisconnect()
             bridge.disconnect()
 
             try {
@@ -277,7 +257,7 @@ public class AndroidPeripheral internal constructor(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
                 )
             } finally {
-                disconnectComplete = null
+                slots.clearDisconnect()
                 bridge.releaseGatt()
             }
         }
@@ -306,16 +286,15 @@ public class AndroidPeripheral internal constructor(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            val deferred = CompletableDeferred<List<DiscoveredService>>()
-            discoveryComplete = deferred
+            val deferred = slots.armDiscovery()
             if (!bridge.discoverServices()) {
-                discoveryComplete = null
+                slots.clearDiscovery()
                 throw BleException(OperationFailed("discoverServices initiation failed"))
             }
             try {
                 withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
-                discoveryComplete = null
+                slots.clearDiscovery()
             }
         }
     }
@@ -323,22 +302,13 @@ public class AndroidPeripheral internal constructor(
     override fun findCharacteristic(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
-    ): Characteristic? =
-        services.value
-            ?.firstOrNull { it.uuid == serviceUuid }
-            ?.characteristics
-            ?.firstOrNull { it.uuid == characteristicUuid }
+    ): Characteristic? = services.value.findCharacteristic(serviceUuid, characteristicUuid)
 
     override fun findDescriptor(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
         descriptorUuid: Uuid,
-    ): Descriptor? {
-        val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return null
-        return char.descriptors.firstOrNull { it.uuid == descriptorUuid }
-    }
-
-    // --- GATT callback handling (runs on HandlerThread, bridges to PeripheralContext) ---
+    ): Descriptor? = services.value.findDescriptor(serviceUuid, characteristicUuid, descriptorUuid)
 
     private fun handleGattEvent(event: GattCallbackEvent) {
         peripheralContext.scope.launch {
@@ -346,158 +316,149 @@ public class AndroidPeripheral internal constructor(
                 is GattCallbackEvent.ConnectionStateChanged -> handleConnectionStateChanged(event)
                 is GattCallbackEvent.ServicesDiscovered -> handleServicesDiscovered(event)
                 is GattCallbackEvent.MtuChanged -> handleMtuChanged(event)
-                is GattCallbackEvent.CharacteristicRead -> {
-                    val status = event.status.toGattStatus()
-                    pendingOps.complete(PendingOp.CharacteristicRead, GattResult(event.value, status))
-                }
-                is GattCallbackEvent.CharacteristicWrite -> {
+                is GattCallbackEvent.CharacteristicRead ->
+                    pendingOps.complete(
+                        PendingOp.CharacteristicRead,
+                        GattResult(event.value, event.status.toGattStatus()),
+                    )
+                is GattCallbackEvent.CharacteristicWrite ->
                     pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
-                }
                 is GattCallbackEvent.CharacteristicChanged -> {
-                    val uuid = Uuid.parse(event.characteristic.uuid.toString())
-                    val serviceUuid =
-                        Uuid.parse(
-                            event.characteristic.service.uuid
-                                .toString(),
-                        )
-                    observationManager.emitByUuid(serviceUuid, uuid, event.value)
+                    val charUuid = Uuid.parse(event.characteristic.uuid.toString())
+                    val serviceUuid = Uuid.parse(event.characteristic.service.uuid.toString())
+                    observationManager.emitByUuid(serviceUuid, charUuid, event.value)
                 }
-                is GattCallbackEvent.DescriptorRead -> {
-                    val status = event.status.toGattStatus()
-                    pendingOps.complete(PendingOp.DescriptorRead, GattResult(event.value, status))
-                }
-                is GattCallbackEvent.DescriptorWrite -> {
+                is GattCallbackEvent.DescriptorRead ->
+                    pendingOps.complete(
+                        PendingOp.DescriptorRead,
+                        GattResult(event.value, event.status.toGattStatus()),
+                    )
+                is GattCallbackEvent.DescriptorWrite ->
                     pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
-                }
-                is GattCallbackEvent.ReadRemoteRssi -> {
-                    val status = event.status.toGattStatus()
-                    if (status.isSuccess()) {
-                        pendingOps.complete(PendingOp.RssiRead, event.rssi)
-                    } else {
-                        pendingOps.fail(
-                            PendingOp.RssiRead,
-                            BleException(GattError("readRssi", status)),
-                        )
-                    }
-                }
+                is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
             }
+        }
+    }
+
+    private fun handleRssiResult(event: GattCallbackEvent.ReadRemoteRssi) {
+        val status = event.status.toGattStatus()
+        if (status.isSuccess()) {
+            pendingOps.complete(PendingOp.RssiRead, event.rssi)
+        } else {
+            pendingOps.fail(PendingOp.RssiRead, BleException(GattError("readRssi", status)))
         }
     }
 
     private suspend fun handleConnectionStateChanged(event: GattCallbackEvent.ConnectionStateChanged) {
         val status = event.status.toGattStatus()
         when (event.newState) {
-            BluetoothProfile.STATE_CONNECTED -> {
-                if (status.isSuccess()) {
-                    peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
-                    val bondPref = currentConnectionOptions?.bondingPreference
-                    if (bondPref == BondingPreference.Required &&
-                        device.bondState != BluetoothDevice.BOND_BONDED
-                    ) {
-                        peripheralContext.processEvent(ConnectionEvent.BondRequired)
-                        val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
-                        val bonded =
-                            try {
-                                withTimeout(bondTimeout) {
-                                    bondManager.createBond()
-                                }
-                            } catch (_: TimeoutCancellationException) {
-                                logEvent(
-                                    BleLogEvent.Error(
-                                        identifier,
-                                        "Bond state change timed out after $bondTimeout",
-                                        cause = null,
-                                    ),
-                                )
-                                false
-                            }
-                        if (!bonded) {
-                            peripheralContext.processEvent(
-                                ConnectionEvent.BondFailed(ConnectionFailed("Bonding rejected or timed out")),
-                            )
-                            connectionComplete?.complete(Unit)
-                            return
-                        }
-                        if (quirkRegistry.resolve(BleQuirks.RefreshServicesOnBond)) {
-                            logEvent(
-                                BleLogEvent.GattOperation(
-                                    identifier,
-                                    "Quirk: refreshing GATT cache after bond",
-                                    uuid = null,
-                                    status = null,
-                                ),
-                            )
-                            bridge.refreshDeviceCache()
-                        }
-                    }
-                    bridge.discoverServices()
-                } else {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(ConnectionFailed("GATT status: $status", event.status)),
-                    )
-                    connectionComplete?.complete(Unit)
-                }
-            }
-            BluetoothProfile.STATE_DISCONNECTED -> {
-                if (peripheralContext.state.value is State.Disconnecting.Requested) {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(OperationFailed("disconnect")),
-                    )
-                    disconnectComplete?.complete(Unit)
-                } else {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(ConnectionLost("Remote disconnect", event.status)),
-                    )
-                }
-                onDisconnectCleanup()
-                connectionComplete?.complete(Unit)
-            }
+            BluetoothProfile.STATE_CONNECTED -> handleLinkUp(status, event.status)
+            BluetoothProfile.STATE_DISCONNECTED -> handleLinkDown(event.status)
         }
+    }
+
+    private suspend fun handleLinkUp(status: com.atruedev.kmpble.error.GattStatus, rawStatus: Int) {
+        if (!status.isSuccess()) {
+            peripheralContext.processEvent(
+                ConnectionEvent.ConnectionLost(ConnectionFailed("GATT status: $status", rawStatus)),
+            )
+            slots.completeConnect()
+            return
+        }
+
+        peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+        if (!bondIfRequiredForLink()) return
+        bridge.discoverServices()
+    }
+
+    /**
+     * Returns false if the connection has been failed and the caller should not proceed
+     * with discovery.
+     */
+    private suspend fun bondIfRequiredForLink(): Boolean {
+        val pref = currentConnectionOptions?.bondingPreference
+        if (pref != BondingPreference.Required || device.bondState == BluetoothDevice.BOND_BONDED) return true
+
+        peripheralContext.processEvent(ConnectionEvent.BondRequired)
+        val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
+        val bonded =
+            try {
+                withTimeout(bondTimeout) { bondManager.createBond() }
+            } catch (_: TimeoutCancellationException) {
+                logEvent(
+                    BleLogEvent.Error(
+                        identifier,
+                        "Bond state change timed out after $bondTimeout",
+                        cause = null,
+                    ),
+                )
+                false
+            }
+
+        if (!bonded) {
+            peripheralContext.processEvent(
+                ConnectionEvent.BondFailed(ConnectionFailed("Bonding rejected or timed out")),
+            )
+            slots.completeConnect()
+            return false
+        }
+
+        if (quirkRegistry.resolve(BleQuirks.RefreshServicesOnBond)) {
+            logEvent(
+                BleLogEvent.GattOperation(
+                    identifier,
+                    "Quirk: refreshing GATT cache after bond",
+                    uuid = null,
+                    status = null,
+                ),
+            )
+            bridge.refreshDeviceCache()
+        }
+        return true
+    }
+
+    private suspend fun handleLinkDown(rawStatus: Int) {
+        if (peripheralContext.state.value is State.Disconnecting.Requested) {
+            peripheralContext.processEvent(ConnectionEvent.ConnectionLost(OperationFailed("disconnect")))
+            slots.completeDisconnect()
+        } else {
+            peripheralContext.processEvent(
+                ConnectionEvent.ConnectionLost(ConnectionLost("Remote disconnect", rawStatus)),
+            )
+        }
+        onDisconnectCleanup()
+        slots.completeConnect()
     }
 
     private suspend fun handleServicesDiscovered(event: GattCallbackEvent.ServicesDiscovered) {
         val status = event.status.toGattStatus()
-        if (status.isSuccess()) {
-            val discovered = event.services.map { it.toDiscoveredService() }
-            peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
-            peripheralContext.updateServices(discovered)
-
-            resubscribeObservations()
-
-            peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
-            connectionComplete?.complete(Unit)
-            discoveryComplete?.complete(discovered)
-        } else {
-            peripheralContext.processEvent(
-                ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)),
-            )
-            connectionComplete?.complete(Unit)
-            discoveryComplete?.completeExceptionally(
-                BleException(GattError("discoverServices", status)),
-            )
+        if (!status.isSuccess()) {
+            peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)))
+            slots.completeConnect()
+            slots.failDiscovery(BleException(GattError("discoverServices", status)))
+            return
         }
+
+        val discovered = event.services.map { it.toDiscoveredService() }
+        peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
+        peripheralContext.updateServices(discovered)
+        resubscribeObservations()
+        peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
+        slots.completeConnect()
+        slots.completeDiscovery(discovered)
     }
 
     private suspend fun resubscribeObservations() {
-        val toResubscribe = observationManager.getObservationsToResubscribe()
-        for (key in toResubscribe) {
+        for (key in observationManager.getObservationsToResubscribe()) {
             val char = findCharacteristic(key.serviceUuid, key.charUuid)
-            if (char != null) {
-                enableNotifications(char)
-            } else {
-                observationManager.completeObservation(key)
-            }
+            if (char != null) enableNotifications(char) else observationManager.completeObservation(key)
         }
     }
 
     private suspend fun handleMtuChanged(event: GattCallbackEvent.MtuChanged) {
-        if (event.status.toGattStatus().isSuccess()) {
-            peripheralContext.updateMtu(event.mtu)
-        }
+        if (event.status.toGattStatus().isSuccess()) peripheralContext.updateMtu(event.mtu)
         pendingOps.complete(PendingOp.MtuRequest, event.mtu)
     }
-
-    // --- Service parsing ---
 
     private fun android.bluetooth.BluetoothGattService.toDiscoveredService(): DiscoveredService {
         val svcUuid = Uuid.parse(uuid.toString())
@@ -508,9 +469,7 @@ public class AndroidPeripheral internal constructor(
                     val char = nativeChar.toCharacteristic(svcUuid)
                     nativeCharMap[char] = nativeChar
                     char.descriptors.forEachIndexed { i, desc ->
-                        if (i < nativeChar.descriptors.size) {
-                            nativeDescMap[desc] = nativeChar.descriptors[i]
-                        }
+                        if (i < nativeChar.descriptors.size) nativeDescMap[desc] = nativeChar.descriptors[i]
                     }
                     char
                 },
@@ -534,30 +493,22 @@ public class AndroidPeripheral internal constructor(
         return char
     }
 
-    private fun requireNativeChar(characteristic: Characteristic): BluetoothGattCharacteristic =
-        nativeCharMap[characteristic]
+    private fun requireNativeChar(c: Characteristic): BluetoothGattCharacteristic =
+        nativeCharMap[c]
             ?: throw IllegalArgumentException(
-                "Characteristic not found in current GATT profile. " +
-                    "Re-acquire from services after connect.",
+                "Characteristic not found in current GATT profile. Re-acquire from services after connect.",
             )
 
-    private fun requireNativeDesc(descriptor: Descriptor): BluetoothGattDescriptor =
-        nativeDescMap[descriptor]
-            ?: throw IllegalArgumentException("Descriptor not found in current GATT profile.")
-
-    // --- GATT Operations ---
+    private fun requireNativeDesc(d: Descriptor): BluetoothGattDescriptor =
+        nativeDescMap[d] ?: throw IllegalArgumentException("Descriptor not found in current GATT profile.")
 
     override suspend fun read(characteristic: Characteristic): ByteArray {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeChar(characteristic)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.CharacteristicRead, deferred)
-            if (!bridge.readCharacteristic(native)) {
-                pendingOps.clear(PendingOp.CharacteristicRead)
-                throw BleException(GattError("read", GattStatus.Failure))
+            val result = pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                bridge.readCharacteristic(native)
             }
-            val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
@@ -572,75 +523,56 @@ public class AndroidPeripheral internal constructor(
         LargeWriteHandler.validateForWriteType(data, maximumWriteValueLength.value, writeType)
 
         val native = requireNativeChar(characteristic)
-        val androidWriteType =
-            when (writeType) {
-                WriteType.WithResponse -> BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-                WriteType.WithoutResponse -> BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-                WriteType.Signed -> BluetoothGattCharacteristic.WRITE_TYPE_SIGNED
-            }
-
+        val androidWriteType = writeType.toAndroidWriteType()
         val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
+
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
-                val deferred = CompletableDeferred<GattStatus>()
-                pendingOps.set(PendingOp.CharacteristicWrite, deferred)
-                if (!bridge.writeCharacteristic(native, chunk, androidWriteType)) {
-                    pendingOps.clear(PendingOp.CharacteristicWrite)
-                    throw BleException(GattError("write", GattStatus.Failure))
+                val status = pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                    bridge.writeCharacteristic(native, chunk, androidWriteType)
                 }
-                val status = deferred.await()
                 if (!status.isSuccess()) throw BleException(GattError("write", status))
             }
         }
     }
 
+    private fun WriteType.toAndroidWriteType(): Int =
+        when (this) {
+            WriteType.WithResponse -> BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            WriteType.WithoutResponse -> BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            WriteType.Signed -> BluetoothGattCharacteristic.WRITE_TYPE_SIGNED
+        }
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-            }
-        }
+    ): Flow<Observation> {
+        checkNotClosed()
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotificationsBestEffort,
+            mapper = ObservationToObservation,
+        )
+    }
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(event.data)
-                is ObservationEvent.Disconnected -> Unit
-                is ObservationEvent.PermanentlyDisconnected -> Unit
-            }
-        }
-
-    private fun <T> observeInternal(
-        characteristic: Characteristic,
-        backpressure: BackpressureStrategy,
-        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
-    ): Flow<T> {
+    ): Flow<ByteArray> {
         checkNotClosed()
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
-        return flow {
-            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-            eventFlow.collect { event -> mapper(event) }
-        }.onStart {
-            if (peripheralContext.state.value is State.Connected.Ready) {
-                enableNotifications(characteristic)
-            }
-        }.applyBackpressure(backpressure)
-            .onCompletion {
-                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                if (wasLastCollector) {
-                    disableNotifications(characteristic)
-                }
-            }
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotificationsBestEffort,
+            mapper = ObservationToBytes,
+        )
     }
 
     private suspend fun enableNotifications(characteristic: Characteristic) {
@@ -649,17 +581,18 @@ public class AndroidPeripheral internal constructor(
         val cccd = native.getDescriptor(UUID.fromString(CCCD_UUID.toString())) ?: return
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.DescriptorWrite, deferred)
-            bridge.writeDescriptor(cccd, value)
-            val status = deferred.await()
-            if (!status.isSuccess()) {
-                throw BleException(GattError("enableNotifications", status))
+            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "enableNotifications") {
+                bridge.writeDescriptor(cccd, value)
             }
+            if (!status.isSuccess()) throw BleException(GattError("enableNotifications", status))
         }
     }
 
-    private fun disableNotifications(characteristic: Characteristic) {
+    /**
+     * Best-effort CCCD disable. Failures during flow completion must not propagate
+     * back into the consumer's collector.
+     */
+    private fun disableNotificationsBestEffort(characteristic: Characteristic) {
         if (peripheralContext.state.value !is State.Connected) return
         val native = nativeCharMap[characteristic] ?: return
         bridge.setCharacteristicNotification(native, false)
@@ -667,13 +600,12 @@ public class AndroidPeripheral internal constructor(
         peripheralContext.scope.launch {
             try {
                 peripheralContext.gattQueue.enqueue {
-                    val deferred = CompletableDeferred<GattStatus>()
-                    pendingOps.set(PendingOp.DescriptorWrite, deferred)
-                    bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
-                    deferred.await()
+                    pendingOps.awaitGatt(PendingOp.DescriptorWrite, "disableNotifications") {
+                        bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
+                    }
                 }
             } catch (_: Throwable) {
-                // Best-effort - don't fail the flow completion
+                // best-effort
             }
         }
     }
@@ -682,13 +614,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.DescriptorRead, deferred)
-            if (!bridge.readDescriptor(native)) {
-                pendingOps.clear(PendingOp.DescriptorRead)
-                throw BleException(GattError("readDescriptor", GattStatus.Failure))
+            val result = pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                bridge.readDescriptor(native)
             }
-            val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("descriptorRead", result.status))
             result.value
         }
@@ -701,13 +629,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.DescriptorWrite, deferred)
-            if (!bridge.writeDescriptor(native, data)) {
-                pendingOps.clear(PendingOp.DescriptorWrite)
-                throw BleException(GattError("writeDescriptor", GattStatus.Failure))
+            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                bridge.writeDescriptor(native, data)
             }
-            val status = deferred.await()
             if (!status.isSuccess()) throw BleException(GattError("descriptorWrite", status))
         }
     }
@@ -715,45 +639,25 @@ public class AndroidPeripheral internal constructor(
     override suspend fun readRssi(): Int {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<Int>()
-            pendingOps.set(PendingOp.RssiRead, deferred)
-            if (!bridge.readRemoteRssi()) {
-                pendingOps.clear(PendingOp.RssiRead)
-                throw BleException(GattError("readRssi", GattStatus.Failure))
-            }
-            deferred.await()
+            pendingOps.awaitGatt(PendingOp.RssiRead, "readRssi") { bridge.readRemoteRssi() }
         }
     }
 
     override suspend fun requestMtu(mtu: Int): Int {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<Int>()
-            pendingOps.set(PendingOp.MtuRequest, deferred)
-            if (!bridge.requestMtu(mtu)) {
-                pendingOps.clear(PendingOp.MtuRequest)
-                throw BleException(GattError("requestMtu", GattStatus.Failure))
-            }
-            deferred.await()
+            pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
         }
     }
-
-    // --- L2CAP ---
 
     private val activeL2capChannels = MutableStateFlow<List<AndroidL2capChannel>>(emptyList())
 
     /**
-     * Open an L2CAP Connection-Oriented Channel to this peripheral.
+     * Open an L2CAP Connection-Oriented Channel.
      *
-     * Requires Android 10 (API 29) or higher. When [secure] is true, uses
-     * [BluetoothDevice.createL2capChannel] (encrypted); when false, uses
-     * [BluetoothDevice.createInsecureL2capChannel] (unencrypted).
-     *
-     * The [BLUETOOTH_CONNECT][android.Manifest.permission.BLUETOOTH_CONNECT]
-     * permission is required on Android 12+.
-     *
-     * All blocking socket I/O runs on [Dispatchers.IO]; the caller's coroutine
-     * context is never blocked.
+     * Requires Android 10 (API 29) or higher. [secure]=true uses
+     * `createL2capChannel` (encrypted); false uses `createInsecureL2capChannel`.
+     * Blocking socket I/O runs on [Dispatchers.IO].
      */
     override suspend fun openL2capChannel(
         psm: Int,
@@ -763,11 +667,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
 
-        val currentState = state.value
-        if (currentState !is State.Connected.Ready) {
-            throw L2capException.NotConnected(
-                "Peripheral is not connected and ready (state: $currentState)",
-            )
+        val current = state.value
+        if (current !is State.Connected.Ready) {
+            throw L2capException.NotConnected("Peripheral is not connected and ready (state: $current)")
         }
 
         logEvent(
@@ -782,31 +684,19 @@ public class AndroidPeripheral internal constructor(
         return withContext(peripheralContext.dispatcher) {
             val socket =
                 withContext(Dispatchers.IO) {
-                    if (secure) {
-                        device.createL2capChannel(psm)
-                    } else {
-                        device.createInsecureL2capChannel(psm)
-                    }
+                    if (secure) device.createL2capChannel(psm) else device.createInsecureL2capChannel(psm)
                 }
 
             try {
                 withContext(Dispatchers.IO) {
                     withTimeout(L2CAP_OPEN_TIMEOUT) {
                         suspendCancellableCoroutine { cont ->
-                            cont.invokeOnCancellation {
-                                try {
-                                    socket.close()
-                                } catch (_: IOException) {
-                                }
-                            }
+                            cont.invokeOnCancellation { socket.closeQuietly() }
                             try {
                                 socket.connect()
                                 cont.resume(Unit)
                             } catch (e: IOException) {
-                                try {
-                                    socket.close()
-                                } catch (_: IOException) {
-                                }
+                                socket.closeQuietly()
                                 cont.resumeWithException(
                                     L2capException.OpenFailed(psm, "Failed to connect: ${e.message}", e),
                                 )
@@ -822,7 +712,7 @@ public class AndroidPeripheral internal constructor(
                     try {
                         channel.awaitClosed()
                     } finally {
-                        activeL2capChannels.update { channels -> channels - channel }
+                        activeL2capChannels.update { it - channel }
                     }
                 }
 
@@ -839,24 +729,22 @@ public class AndroidPeripheral internal constructor(
             } catch (e: L2capException) {
                 throw e
             } catch (e: CancellationException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, "Connection timed out", e)
             } catch (e: IOException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, e.message ?: "Unknown error", e)
             } catch (e: SecurityException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, "Missing BLUETOOTH_CONNECT permission", e)
             }
+        }
+    }
+
+    private fun android.bluetooth.BluetoothSocket.closeQuietly() {
+        try {
+            close()
+        } catch (_: IOException) {
         }
     }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -330,7 +330,11 @@ public class AndroidPeripheral internal constructor(
                     pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
                 is GattCallbackEvent.CharacteristicChanged -> {
                     val charUuid = Uuid.parse(event.characteristic.uuid.toString())
-                    val serviceUuid = Uuid.parse(event.characteristic.service.uuid.toString())
+                    val serviceUuid =
+                        Uuid.parse(
+                            event.characteristic.service.uuid
+                                .toString(),
+                        )
                     observationManager.emitByUuid(serviceUuid, charUuid, event.value)
                 }
                 is GattCallbackEvent.DescriptorRead ->
@@ -362,7 +366,10 @@ public class AndroidPeripheral internal constructor(
         }
     }
 
-    private suspend fun handleLinkUp(status: com.atruedev.kmpble.error.GattStatus, rawStatus: Int) {
+    private suspend fun handleLinkUp(
+        status: com.atruedev.kmpble.error.GattStatus,
+        rawStatus: Int,
+    ) {
         if (!status.isSuccess()) {
             peripheralContext.processEvent(
                 ConnectionEvent.ConnectionLost(ConnectionFailed("GATT status: $status", rawStatus)),
@@ -511,9 +518,10 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeChar(characteristic)
-            val result = pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
-                bridge.readCharacteristic(native)
-            }
+            val result =
+                pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                    bridge.readCharacteristic(native)
+                }
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
@@ -533,9 +541,10 @@ public class AndroidPeripheral internal constructor(
 
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
-                val status = pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
-                    bridge.writeCharacteristic(native, chunk, androidWriteType)
-                }
+                val status =
+                    pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                        bridge.writeCharacteristic(native, chunk, androidWriteType)
+                    }
                 if (!status.isSuccess()) throw BleException(GattError("write", status))
             }
         }
@@ -586,9 +595,10 @@ public class AndroidPeripheral internal constructor(
         val cccd = native.getDescriptor(UUID.fromString(CCCD_UUID.toString())) ?: return
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
-            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "enableNotifications") {
-                bridge.writeDescriptor(cccd, value)
-            }
+            val status =
+                pendingOps.awaitGatt(PendingOp.DescriptorWrite, "enableNotifications") {
+                    bridge.writeDescriptor(cccd, value)
+                }
             if (!status.isSuccess()) throw BleException(GattError("enableNotifications", status))
         }
     }
@@ -619,9 +629,10 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val result = pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
-                bridge.readDescriptor(native)
-            }
+            val result =
+                pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                    bridge.readDescriptor(native)
+                }
             if (!result.status.isSuccess()) throw BleException(GattError("descriptorRead", result.status))
             result.value
         }
@@ -634,9 +645,10 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
-                bridge.writeDescriptor(native, data)
-            }
+            val status =
+                pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                    bridge.writeDescriptor(native, data)
+                }
             if (!status.isSuccess()) throw BleException(GattError("descriptorWrite", status))
         }
     }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -22,7 +22,6 @@ import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
-import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -37,34 +36,34 @@ import com.atruedev.kmpble.gatt.internal.ENABLE_NOTIFICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.NotConnectedException
-import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
-import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.BluetoothL2capSocket
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
+import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
+import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import com.atruedev.kmpble.peripheral.internal.PeripheralRegistry
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
+import com.atruedev.kmpble.peripheral.internal.findCharacteristic
+import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.quirks.BleQuirks
 import com.atruedev.kmpble.quirks.QuirkRegistry
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.getAndUpdate
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -92,16 +91,9 @@ public class AndroidPeripheral internal constructor(
     private val peripheralContext = PeripheralContext(identifier)
     private val bridge = AndroidGattBridge(device, context)
 
-    @Volatile
-    private var connectionComplete: CompletableDeferred<Unit>? = null
-
-    @Volatile
-    private var discoveryComplete: CompletableDeferred<List<DiscoveredService>>? = null
-
-    @Volatile
-    private var disconnectComplete: CompletableDeferred<Unit>? = null
     private val pendingOps = PendingOperations()
     private val observationManager = ObservationManager()
+    private val slots = LifecycleSlots()
 
     private val nativeCharMap = mutableMapOf<Characteristic, BluetoothGattCharacteristic>()
     private val nativeDescMap = mutableMapOf<Descriptor, BluetoothGattDescriptor>()
@@ -120,8 +112,12 @@ public class AndroidPeripheral internal constructor(
     @Volatile
     private var closed = false
 
-    @Volatile
+    /**
+     * Confined to [peripheralContext.dispatcher]. Read by [handleConnectionStateChanged]
+     * to decide whether bonding is required for the freshly-established link.
+     */
     private var currentConnectionOptions: ConnectionOptions? = null
+
     private val reconnectionHandler =
         ReconnectionHandler(
             scope = peripheralContext.scope,
@@ -147,11 +143,11 @@ public class AndroidPeripheral internal constructor(
     @OptIn(ExperimentalBleApi::class)
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
-        currentConnectionOptions = options
         reconnectionHandler.start(options)
         bondManager.start()
 
         withContext(peripheralContext.dispatcher) {
+            currentConnectionOptions = options
             pairingRequestHandler.setHandler(options.pairingHandler)
             pairingRequestHandler.start()
             ensureBondedIfRequired(options)
@@ -160,7 +156,7 @@ public class AndroidPeripheral internal constructor(
     }
 
     /**
-     * Samsung quirk: some Galaxy devices require bonding BEFORE calling connectGatt(),
+     * Samsung quirk: certain Galaxy devices must be bonded BEFORE `connectGatt()`,
      * otherwise the connection fails silently or returns GATT 133.
      */
     private suspend fun ensureBondedIfRequired(options: ConnectionOptions) {
@@ -171,9 +167,7 @@ public class AndroidPeripheral internal constructor(
         val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
         logEvent(BleLogEvent.BondEvent(identifier, "Quirk: bond-before-connect initiated"))
         try {
-            withTimeout(bondTimeout) {
-                bondManager.createBond()
-            }
+            withTimeout(bondTimeout) { bondManager.createBond() }
             logEvent(BleLogEvent.BondEvent(identifier, "Quirk: bond-before-connect succeeded"))
         } catch (_: TimeoutCancellationException) {
             logEvent(
@@ -217,25 +211,19 @@ public class AndroidPeripheral internal constructor(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            val deferred = CompletableDeferred<Unit>()
-            connectionComplete = deferred
-
+            val deferred = slots.armConnect()
             val gatt = bridge.connect(options)
             if (gatt == null) {
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("connectGatt returned null")),
                 )
-                connectionComplete = null
-                if (attempt < maxAttempts - 1) {
-                    delay(retryDelay)
-                }
+                slots.clearConnect()
+                if (attempt < maxAttempts - 1) delay(retryDelay)
                 return@repeat
             }
 
             try {
-                withTimeout(timeout) {
-                    deferred.await()
-                }
+                withTimeout(timeout) { deferred.await() }
             } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
                 bridge.releaseGatt()
@@ -243,12 +231,10 @@ public class AndroidPeripheral internal constructor(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("Connection timeout after $timeout")),
                 )
             } finally {
-                connectionComplete = null
+                slots.clearConnect()
             }
 
-            if (peripheralContext.state.value is State.Connected) {
-                return
-            }
+            if (peripheralContext.state.value is State.Connected) return
 
             if (attempt < maxAttempts - 1) {
                 bridge.releaseGatt()
@@ -266,8 +252,7 @@ public class AndroidPeripheral internal constructor(
             pairingRequestHandler.stop()
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            val deferred = CompletableDeferred<Unit>()
-            disconnectComplete = deferred
+            val deferred = slots.armDisconnect()
             bridge.disconnect()
 
             try {
@@ -277,7 +262,7 @@ public class AndroidPeripheral internal constructor(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
                 )
             } finally {
-                disconnectComplete = null
+                slots.clearDisconnect()
                 bridge.releaseGatt()
             }
         }
@@ -306,16 +291,15 @@ public class AndroidPeripheral internal constructor(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            val deferred = CompletableDeferred<List<DiscoveredService>>()
-            discoveryComplete = deferred
+            val deferred = slots.armDiscovery()
             if (!bridge.discoverServices()) {
-                discoveryComplete = null
+                slots.clearDiscovery()
                 throw BleException(OperationFailed("discoverServices initiation failed"))
             }
             try {
                 withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
-                discoveryComplete = null
+                slots.clearDiscovery()
             }
         }
     }
@@ -323,22 +307,13 @@ public class AndroidPeripheral internal constructor(
     override fun findCharacteristic(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
-    ): Characteristic? =
-        services.value
-            ?.firstOrNull { it.uuid == serviceUuid }
-            ?.characteristics
-            ?.firstOrNull { it.uuid == characteristicUuid }
+    ): Characteristic? = services.value.findCharacteristic(serviceUuid, characteristicUuid)
 
     override fun findDescriptor(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
         descriptorUuid: Uuid,
-    ): Descriptor? {
-        val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return null
-        return char.descriptors.firstOrNull { it.uuid == descriptorUuid }
-    }
-
-    // --- GATT callback handling (runs on HandlerThread, bridges to PeripheralContext) ---
+    ): Descriptor? = services.value.findDescriptor(serviceUuid, characteristicUuid, descriptorUuid)
 
     private fun handleGattEvent(event: GattCallbackEvent) {
         peripheralContext.scope.launch {
@@ -346,158 +321,149 @@ public class AndroidPeripheral internal constructor(
                 is GattCallbackEvent.ConnectionStateChanged -> handleConnectionStateChanged(event)
                 is GattCallbackEvent.ServicesDiscovered -> handleServicesDiscovered(event)
                 is GattCallbackEvent.MtuChanged -> handleMtuChanged(event)
-                is GattCallbackEvent.CharacteristicRead -> {
-                    val status = event.status.toGattStatus()
-                    pendingOps.complete(PendingOp.CharacteristicRead, GattResult(event.value, status))
-                }
-                is GattCallbackEvent.CharacteristicWrite -> {
+                is GattCallbackEvent.CharacteristicRead ->
+                    pendingOps.complete(
+                        PendingOp.CharacteristicRead,
+                        GattResult(event.value, event.status.toGattStatus()),
+                    )
+                is GattCallbackEvent.CharacteristicWrite ->
                     pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
-                }
                 is GattCallbackEvent.CharacteristicChanged -> {
-                    val uuid = Uuid.parse(event.characteristic.uuid.toString())
-                    val serviceUuid =
-                        Uuid.parse(
-                            event.characteristic.service.uuid
-                                .toString(),
-                        )
-                    observationManager.emitByUuid(serviceUuid, uuid, event.value)
+                    val charUuid = Uuid.parse(event.characteristic.uuid.toString())
+                    val serviceUuid = Uuid.parse(event.characteristic.service.uuid.toString())
+                    observationManager.emitByUuid(serviceUuid, charUuid, event.value)
                 }
-                is GattCallbackEvent.DescriptorRead -> {
-                    val status = event.status.toGattStatus()
-                    pendingOps.complete(PendingOp.DescriptorRead, GattResult(event.value, status))
-                }
-                is GattCallbackEvent.DescriptorWrite -> {
+                is GattCallbackEvent.DescriptorRead ->
+                    pendingOps.complete(
+                        PendingOp.DescriptorRead,
+                        GattResult(event.value, event.status.toGattStatus()),
+                    )
+                is GattCallbackEvent.DescriptorWrite ->
                     pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
-                }
-                is GattCallbackEvent.ReadRemoteRssi -> {
-                    val status = event.status.toGattStatus()
-                    if (status.isSuccess()) {
-                        pendingOps.complete(PendingOp.RssiRead, event.rssi)
-                    } else {
-                        pendingOps.fail(
-                            PendingOp.RssiRead,
-                            BleException(GattError("readRssi", status)),
-                        )
-                    }
-                }
+                is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
             }
+        }
+    }
+
+    private fun handleRssiResult(event: GattCallbackEvent.ReadRemoteRssi) {
+        val status = event.status.toGattStatus()
+        if (status.isSuccess()) {
+            pendingOps.complete(PendingOp.RssiRead, event.rssi)
+        } else {
+            pendingOps.fail(PendingOp.RssiRead, BleException(GattError("readRssi", status)))
         }
     }
 
     private suspend fun handleConnectionStateChanged(event: GattCallbackEvent.ConnectionStateChanged) {
         val status = event.status.toGattStatus()
         when (event.newState) {
-            BluetoothProfile.STATE_CONNECTED -> {
-                if (status.isSuccess()) {
-                    peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
-                    val bondPref = currentConnectionOptions?.bondingPreference
-                    if (bondPref == BondingPreference.Required &&
-                        device.bondState != BluetoothDevice.BOND_BONDED
-                    ) {
-                        peripheralContext.processEvent(ConnectionEvent.BondRequired)
-                        val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
-                        val bonded =
-                            try {
-                                withTimeout(bondTimeout) {
-                                    bondManager.createBond()
-                                }
-                            } catch (_: TimeoutCancellationException) {
-                                logEvent(
-                                    BleLogEvent.Error(
-                                        identifier,
-                                        "Bond state change timed out after $bondTimeout",
-                                        cause = null,
-                                    ),
-                                )
-                                false
-                            }
-                        if (!bonded) {
-                            peripheralContext.processEvent(
-                                ConnectionEvent.BondFailed(ConnectionFailed("Bonding rejected or timed out")),
-                            )
-                            connectionComplete?.complete(Unit)
-                            return
-                        }
-                        if (quirkRegistry.resolve(BleQuirks.RefreshServicesOnBond)) {
-                            logEvent(
-                                BleLogEvent.GattOperation(
-                                    identifier,
-                                    "Quirk: refreshing GATT cache after bond",
-                                    uuid = null,
-                                    status = null,
-                                ),
-                            )
-                            bridge.refreshDeviceCache()
-                        }
-                    }
-                    bridge.discoverServices()
-                } else {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(ConnectionFailed("GATT status: $status", event.status)),
-                    )
-                    connectionComplete?.complete(Unit)
-                }
-            }
-            BluetoothProfile.STATE_DISCONNECTED -> {
-                if (peripheralContext.state.value is State.Disconnecting.Requested) {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(OperationFailed("disconnect")),
-                    )
-                    disconnectComplete?.complete(Unit)
-                } else {
-                    peripheralContext.processEvent(
-                        ConnectionEvent.ConnectionLost(ConnectionLost("Remote disconnect", event.status)),
-                    )
-                }
-                onDisconnectCleanup()
-                connectionComplete?.complete(Unit)
-            }
+            BluetoothProfile.STATE_CONNECTED -> handleLinkUp(status, event.status)
+            BluetoothProfile.STATE_DISCONNECTED -> handleLinkDown(event.status)
         }
+    }
+
+    private suspend fun handleLinkUp(status: com.atruedev.kmpble.error.GattStatus, rawStatus: Int) {
+        if (!status.isSuccess()) {
+            peripheralContext.processEvent(
+                ConnectionEvent.ConnectionLost(ConnectionFailed("GATT status: $status", rawStatus)),
+            )
+            slots.completeConnect()
+            return
+        }
+
+        peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+        if (!bondIfRequiredForLink()) return
+        bridge.discoverServices()
+    }
+
+    /**
+     * Returns false if the connection has been failed and the caller should not proceed
+     * with discovery.
+     */
+    private suspend fun bondIfRequiredForLink(): Boolean {
+        val pref = currentConnectionOptions?.bondingPreference
+        if (pref != BondingPreference.Required || device.bondState == BluetoothDevice.BOND_BONDED) return true
+
+        peripheralContext.processEvent(ConnectionEvent.BondRequired)
+        val bondTimeout = quirkRegistry.resolve(BleQuirks.BondStateTimeout)
+        val bonded =
+            try {
+                withTimeout(bondTimeout) { bondManager.createBond() }
+            } catch (_: TimeoutCancellationException) {
+                logEvent(
+                    BleLogEvent.Error(
+                        identifier,
+                        "Bond state change timed out after $bondTimeout",
+                        cause = null,
+                    ),
+                )
+                false
+            }
+
+        if (!bonded) {
+            peripheralContext.processEvent(
+                ConnectionEvent.BondFailed(ConnectionFailed("Bonding rejected or timed out")),
+            )
+            slots.completeConnect()
+            return false
+        }
+
+        if (quirkRegistry.resolve(BleQuirks.RefreshServicesOnBond)) {
+            logEvent(
+                BleLogEvent.GattOperation(
+                    identifier,
+                    "Quirk: refreshing GATT cache after bond",
+                    uuid = null,
+                    status = null,
+                ),
+            )
+            bridge.refreshDeviceCache()
+        }
+        return true
+    }
+
+    private suspend fun handleLinkDown(rawStatus: Int) {
+        if (peripheralContext.state.value is State.Disconnecting.Requested) {
+            peripheralContext.processEvent(ConnectionEvent.ConnectionLost(OperationFailed("disconnect")))
+            slots.completeDisconnect()
+        } else {
+            peripheralContext.processEvent(
+                ConnectionEvent.ConnectionLost(ConnectionLost("Remote disconnect", rawStatus)),
+            )
+        }
+        onDisconnectCleanup()
+        slots.completeConnect()
     }
 
     private suspend fun handleServicesDiscovered(event: GattCallbackEvent.ServicesDiscovered) {
         val status = event.status.toGattStatus()
-        if (status.isSuccess()) {
-            val discovered = event.services.map { it.toDiscoveredService() }
-            peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
-            peripheralContext.updateServices(discovered)
-
-            resubscribeObservations()
-
-            peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
-            connectionComplete?.complete(Unit)
-            discoveryComplete?.complete(discovered)
-        } else {
-            peripheralContext.processEvent(
-                ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)),
-            )
-            connectionComplete?.complete(Unit)
-            discoveryComplete?.completeExceptionally(
-                BleException(GattError("discoverServices", status)),
-            )
+        if (!status.isSuccess()) {
+            peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)))
+            slots.completeConnect()
+            slots.failDiscovery(BleException(GattError("discoverServices", status)))
+            return
         }
+
+        val discovered = event.services.map { it.toDiscoveredService() }
+        peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
+        peripheralContext.updateServices(discovered)
+        resubscribeObservations()
+        peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
+        slots.completeConnect()
+        slots.completeDiscovery(discovered)
     }
 
     private suspend fun resubscribeObservations() {
-        val toResubscribe = observationManager.getObservationsToResubscribe()
-        for (key in toResubscribe) {
+        for (key in observationManager.getObservationsToResubscribe()) {
             val char = findCharacteristic(key.serviceUuid, key.charUuid)
-            if (char != null) {
-                enableNotifications(char)
-            } else {
-                observationManager.completeObservation(key)
-            }
+            if (char != null) enableNotifications(char) else observationManager.completeObservation(key)
         }
     }
 
     private suspend fun handleMtuChanged(event: GattCallbackEvent.MtuChanged) {
-        if (event.status.toGattStatus().isSuccess()) {
-            peripheralContext.updateMtu(event.mtu)
-        }
+        if (event.status.toGattStatus().isSuccess()) peripheralContext.updateMtu(event.mtu)
         pendingOps.complete(PendingOp.MtuRequest, event.mtu)
     }
-
-    // --- Service parsing ---
 
     private fun android.bluetooth.BluetoothGattService.toDiscoveredService(): DiscoveredService {
         val svcUuid = Uuid.parse(uuid.toString())
@@ -508,9 +474,7 @@ public class AndroidPeripheral internal constructor(
                     val char = nativeChar.toCharacteristic(svcUuid)
                     nativeCharMap[char] = nativeChar
                     char.descriptors.forEachIndexed { i, desc ->
-                        if (i < nativeChar.descriptors.size) {
-                            nativeDescMap[desc] = nativeChar.descriptors[i]
-                        }
+                        if (i < nativeChar.descriptors.size) nativeDescMap[desc] = nativeChar.descriptors[i]
                     }
                     char
                 },
@@ -534,30 +498,22 @@ public class AndroidPeripheral internal constructor(
         return char
     }
 
-    private fun requireNativeChar(characteristic: Characteristic): BluetoothGattCharacteristic =
-        nativeCharMap[characteristic]
+    private fun requireNativeChar(c: Characteristic): BluetoothGattCharacteristic =
+        nativeCharMap[c]
             ?: throw IllegalArgumentException(
-                "Characteristic not found in current GATT profile. " +
-                    "Re-acquire from services after connect.",
+                "Characteristic not found in current GATT profile. Re-acquire from services after connect.",
             )
 
-    private fun requireNativeDesc(descriptor: Descriptor): BluetoothGattDescriptor =
-        nativeDescMap[descriptor]
-            ?: throw IllegalArgumentException("Descriptor not found in current GATT profile.")
-
-    // --- GATT Operations ---
+    private fun requireNativeDesc(d: Descriptor): BluetoothGattDescriptor =
+        nativeDescMap[d] ?: throw IllegalArgumentException("Descriptor not found in current GATT profile.")
 
     override suspend fun read(characteristic: Characteristic): ByteArray {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeChar(characteristic)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.CharacteristicRead, deferred)
-            if (!bridge.readCharacteristic(native)) {
-                pendingOps.clear(PendingOp.CharacteristicRead)
-                throw BleException(GattError("read", GattStatus.Failure))
+            val result = pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                bridge.readCharacteristic(native)
             }
-            val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
@@ -572,75 +528,56 @@ public class AndroidPeripheral internal constructor(
         LargeWriteHandler.validateForWriteType(data, maximumWriteValueLength.value, writeType)
 
         val native = requireNativeChar(characteristic)
-        val androidWriteType =
-            when (writeType) {
-                WriteType.WithResponse -> BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-                WriteType.WithoutResponse -> BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-                WriteType.Signed -> BluetoothGattCharacteristic.WRITE_TYPE_SIGNED
-            }
-
+        val androidWriteType = writeType.toAndroidWriteType()
         val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
+
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
-                val deferred = CompletableDeferred<GattStatus>()
-                pendingOps.set(PendingOp.CharacteristicWrite, deferred)
-                if (!bridge.writeCharacteristic(native, chunk, androidWriteType)) {
-                    pendingOps.clear(PendingOp.CharacteristicWrite)
-                    throw BleException(GattError("write", GattStatus.Failure))
+                val status = pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                    bridge.writeCharacteristic(native, chunk, androidWriteType)
                 }
-                val status = deferred.await()
                 if (!status.isSuccess()) throw BleException(GattError("write", status))
             }
         }
     }
 
+    private fun WriteType.toAndroidWriteType(): Int =
+        when (this) {
+            WriteType.WithResponse -> BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            WriteType.WithoutResponse -> BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            WriteType.Signed -> BluetoothGattCharacteristic.WRITE_TYPE_SIGNED
+        }
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-            }
-        }
+    ): Flow<Observation> {
+        checkNotClosed()
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotificationsBestEffort,
+            mapper = ObservationToObservation,
+        )
+    }
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(event.data)
-                is ObservationEvent.Disconnected -> Unit
-                is ObservationEvent.PermanentlyDisconnected -> Unit
-            }
-        }
-
-    private fun <T> observeInternal(
-        characteristic: Characteristic,
-        backpressure: BackpressureStrategy,
-        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
-    ): Flow<T> {
+    ): Flow<ByteArray> {
         checkNotClosed()
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
-        return flow {
-            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-            eventFlow.collect { event -> mapper(event) }
-        }.onStart {
-            if (peripheralContext.state.value is State.Connected.Ready) {
-                enableNotifications(characteristic)
-            }
-        }.applyBackpressure(backpressure)
-            .onCompletion {
-                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                if (wasLastCollector) {
-                    disableNotifications(characteristic)
-                }
-            }
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotificationsBestEffort,
+            mapper = ObservationToBytes,
+        )
     }
 
     private suspend fun enableNotifications(characteristic: Characteristic) {
@@ -649,17 +586,18 @@ public class AndroidPeripheral internal constructor(
         val cccd = native.getDescriptor(UUID.fromString(CCCD_UUID.toString())) ?: return
         val value = if (characteristic.properties.indicate) ENABLE_INDICATION_VALUE else ENABLE_NOTIFICATION_VALUE
         peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.DescriptorWrite, deferred)
-            bridge.writeDescriptor(cccd, value)
-            val status = deferred.await()
-            if (!status.isSuccess()) {
-                throw BleException(GattError("enableNotifications", status))
+            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "enableNotifications") {
+                bridge.writeDescriptor(cccd, value)
             }
+            if (!status.isSuccess()) throw BleException(GattError("enableNotifications", status))
         }
     }
 
-    private fun disableNotifications(characteristic: Characteristic) {
+    /**
+     * Best-effort CCCD disable. Failures during flow completion must not propagate
+     * back into the consumer's collector.
+     */
+    private fun disableNotificationsBestEffort(characteristic: Characteristic) {
         if (peripheralContext.state.value !is State.Connected) return
         val native = nativeCharMap[characteristic] ?: return
         bridge.setCharacteristicNotification(native, false)
@@ -667,13 +605,12 @@ public class AndroidPeripheral internal constructor(
         peripheralContext.scope.launch {
             try {
                 peripheralContext.gattQueue.enqueue {
-                    val deferred = CompletableDeferred<GattStatus>()
-                    pendingOps.set(PendingOp.DescriptorWrite, deferred)
-                    bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
-                    deferred.await()
+                    pendingOps.awaitGatt(PendingOp.DescriptorWrite, "disableNotifications") {
+                        bridge.writeDescriptor(cccd, DISABLE_NOTIFICATION_VALUE)
+                    }
                 }
             } catch (_: Throwable) {
-                // Best-effort - don't fail the flow completion
+                // best-effort
             }
         }
     }
@@ -682,13 +619,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.DescriptorRead, deferred)
-            if (!bridge.readDescriptor(native)) {
-                pendingOps.clear(PendingOp.DescriptorRead)
-                throw BleException(GattError("readDescriptor", GattStatus.Failure))
+            val result = pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                bridge.readDescriptor(native)
             }
-            val result = deferred.await()
             if (!result.status.isSuccess()) throw BleException(GattError("descriptorRead", result.status))
             result.value
         }
@@ -701,13 +634,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeDesc(descriptor)
-            val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.DescriptorWrite, deferred)
-            if (!bridge.writeDescriptor(native, data)) {
-                pendingOps.clear(PendingOp.DescriptorWrite)
-                throw BleException(GattError("writeDescriptor", GattStatus.Failure))
+            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                bridge.writeDescriptor(native, data)
             }
-            val status = deferred.await()
             if (!status.isSuccess()) throw BleException(GattError("descriptorWrite", status))
         }
     }
@@ -715,45 +644,25 @@ public class AndroidPeripheral internal constructor(
     override suspend fun readRssi(): Int {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<Int>()
-            pendingOps.set(PendingOp.RssiRead, deferred)
-            if (!bridge.readRemoteRssi()) {
-                pendingOps.clear(PendingOp.RssiRead)
-                throw BleException(GattError("readRssi", GattStatus.Failure))
-            }
-            deferred.await()
+            pendingOps.awaitGatt(PendingOp.RssiRead, "readRssi") { bridge.readRemoteRssi() }
         }
     }
 
     override suspend fun requestMtu(mtu: Int): Int {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<Int>()
-            pendingOps.set(PendingOp.MtuRequest, deferred)
-            if (!bridge.requestMtu(mtu)) {
-                pendingOps.clear(PendingOp.MtuRequest)
-                throw BleException(GattError("requestMtu", GattStatus.Failure))
-            }
-            deferred.await()
+            pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
         }
     }
-
-    // --- L2CAP ---
 
     private val activeL2capChannels = MutableStateFlow<List<AndroidL2capChannel>>(emptyList())
 
     /**
-     * Open an L2CAP Connection-Oriented Channel to this peripheral.
+     * Open an L2CAP Connection-Oriented Channel.
      *
-     * Requires Android 10 (API 29) or higher. When [secure] is true, uses
-     * [BluetoothDevice.createL2capChannel] (encrypted); when false, uses
-     * [BluetoothDevice.createInsecureL2capChannel] (unencrypted).
-     *
-     * The [BLUETOOTH_CONNECT][android.Manifest.permission.BLUETOOTH_CONNECT]
-     * permission is required on Android 12+.
-     *
-     * All blocking socket I/O runs on [Dispatchers.IO]; the caller's coroutine
-     * context is never blocked.
+     * Requires Android 10 (API 29) or higher. [secure]=true uses
+     * `createL2capChannel` (encrypted); false uses `createInsecureL2capChannel`.
+     * Blocking socket I/O runs on [Dispatchers.IO].
      */
     override suspend fun openL2capChannel(
         psm: Int,
@@ -763,11 +672,9 @@ public class AndroidPeripheral internal constructor(
         checkNotClosed()
         if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
 
-        val currentState = state.value
-        if (currentState !is State.Connected.Ready) {
-            throw L2capException.NotConnected(
-                "Peripheral is not connected and ready (state: $currentState)",
-            )
+        val current = state.value
+        if (current !is State.Connected.Ready) {
+            throw L2capException.NotConnected("Peripheral is not connected and ready (state: $current)")
         }
 
         logEvent(
@@ -782,31 +689,19 @@ public class AndroidPeripheral internal constructor(
         return withContext(peripheralContext.dispatcher) {
             val socket =
                 withContext(Dispatchers.IO) {
-                    if (secure) {
-                        device.createL2capChannel(psm)
-                    } else {
-                        device.createInsecureL2capChannel(psm)
-                    }
+                    if (secure) device.createL2capChannel(psm) else device.createInsecureL2capChannel(psm)
                 }
 
             try {
                 withContext(Dispatchers.IO) {
                     withTimeout(L2CAP_OPEN_TIMEOUT) {
                         suspendCancellableCoroutine { cont ->
-                            cont.invokeOnCancellation {
-                                try {
-                                    socket.close()
-                                } catch (_: IOException) {
-                                }
-                            }
+                            cont.invokeOnCancellation { socket.closeQuietly() }
                             try {
                                 socket.connect()
                                 cont.resume(Unit)
                             } catch (e: IOException) {
-                                try {
-                                    socket.close()
-                                } catch (_: IOException) {
-                                }
+                                socket.closeQuietly()
                                 cont.resumeWithException(
                                     L2capException.OpenFailed(psm, "Failed to connect: ${e.message}", e),
                                 )
@@ -822,7 +717,7 @@ public class AndroidPeripheral internal constructor(
                     try {
                         channel.awaitClosed()
                     } finally {
-                        activeL2capChannels.update { channels -> channels - channel }
+                        activeL2capChannels.update { it - channel }
                     }
                 }
 
@@ -839,24 +734,22 @@ public class AndroidPeripheral internal constructor(
             } catch (e: L2capException) {
                 throw e
             } catch (e: CancellationException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, "Connection timed out", e)
             } catch (e: IOException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, e.message ?: "Unknown error", e)
             } catch (e: SecurityException) {
-                try {
-                    socket.close()
-                } catch (_: IOException) {
-                }
+                socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, "Missing BLUETOOTH_CONNECT permission", e)
             }
+        }
+    }
+
+    private fun android.bluetooth.BluetoothSocket.closeQuietly() {
+        try {
+            close()
+        } catch (_: IOException) {
         }
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlots.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlots.kt
@@ -1,0 +1,66 @@
+package com.atruedev.kmpble.peripheral.internal
+
+import com.atruedev.kmpble.gatt.DiscoveredService
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * One-shot completion handles for the connect / discovery / disconnect lifecycle.
+ *
+ * Mutation is confined to the owning peripheral's serial dispatcher
+ * (`limitedParallelism(1)`), so no `@Volatile` or other synchronization primitives
+ * are required. Each slot rejects re-entrant arming - a second `armConnect()`
+ * call while a connect is already in flight throws, surfacing the bug instead
+ * of silently overwriting the deferred.
+ */
+internal class LifecycleSlots {
+    private var connect: CompletableDeferred<Unit>? = null
+    private var discovery: CompletableDeferred<List<DiscoveredService>>? = null
+    private var disconnect: CompletableDeferred<Unit>? = null
+
+    fun armConnect(): CompletableDeferred<Unit> {
+        check(connect == null) { "connect() is already in progress on this peripheral" }
+        return CompletableDeferred<Unit>().also { connect = it }
+    }
+
+    fun armDiscovery(): CompletableDeferred<List<DiscoveredService>> {
+        check(discovery == null) { "service discovery is already in progress" }
+        return CompletableDeferred<List<DiscoveredService>>().also { discovery = it }
+    }
+
+    fun armDisconnect(): CompletableDeferred<Unit> {
+        check(disconnect == null) { "disconnect() is already in progress on this peripheral" }
+        return CompletableDeferred<Unit>().also { disconnect = it }
+    }
+
+    fun completeConnect() {
+        connect?.complete(Unit)
+        connect = null
+    }
+
+    fun completeDiscovery(services: List<DiscoveredService>) {
+        discovery?.complete(services)
+        discovery = null
+    }
+
+    fun failDiscovery(cause: Throwable) {
+        discovery?.completeExceptionally(cause)
+        discovery = null
+    }
+
+    fun completeDisconnect() {
+        disconnect?.complete(Unit)
+        disconnect = null
+    }
+
+    fun clearConnect() {
+        connect = null
+    }
+
+    fun clearDiscovery() {
+        discovery = null
+    }
+
+    fun clearDisconnect() {
+        disconnect = null
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralSupport.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralSupport.kt
@@ -1,0 +1,112 @@
+package com.atruedev.kmpble.peripheral.internal
+
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.gatt.BackpressureStrategy
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.Descriptor
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.Observation
+import com.atruedev.kmpble.gatt.internal.ObservationEvent
+import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.gatt.internal.PendingOp
+import com.atruedev.kmpble.gatt.internal.PendingOperations
+import com.atruedev.kmpble.gatt.internal.applyBackpressure
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+internal fun List<DiscoveredService>?.findCharacteristic(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+): Characteristic? =
+    this
+        ?.firstOrNull { it.uuid == serviceUuid }
+        ?.characteristics
+        ?.firstOrNull { it.uuid == characteristicUuid }
+
+@OptIn(ExperimentalUuidApi::class)
+internal fun List<DiscoveredService>?.findDescriptor(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    descriptorUuid: Uuid,
+): Descriptor? =
+    findCharacteristic(serviceUuid, characteristicUuid)
+        ?.descriptors
+        ?.firstOrNull { it.uuid == descriptorUuid }
+
+/**
+ * Submit a native GATT call and await its asynchronous result via [PendingOperations].
+ *
+ * The pending slot is set before submission, so a callback that fires synchronously
+ * still finds a deferred to complete. If the platform reports rejection ([submit]
+ * returns false), the slot is cleared and the caller is failed deterministically.
+ *
+ * Confined to the peripheral's serial dispatcher.
+ */
+internal suspend fun <T> PendingOperations.awaitGatt(
+    op: PendingOp<T>,
+    label: String,
+    submit: () -> Boolean,
+): T {
+    val deferred = CompletableDeferred<T>()
+    set(op, deferred)
+    if (!submit()) {
+        clear(op)
+        throw BleException(GattError(label, GattStatus.Failure))
+    }
+    return deferred.await()
+}
+
+/**
+ * Builds the standard `observe()` flow shape used by every platform peripheral:
+ *   subscribe -> map events -> apply backpressure -> unsubscribe + maybe disable CCCD.
+ *
+ * The CCCD enable/disable side is platform-specific and supplied by [enable] and
+ * [disable]. State checks for "ready before enabling" are also injected so that
+ * observation flows can be started before the peripheral connects.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal fun <T> buildObservationFlow(
+    characteristic: Characteristic,
+    backpressure: BackpressureStrategy,
+    observationManager: ObservationManager,
+    isReady: () -> Boolean,
+    enable: suspend (Characteristic) -> Unit,
+    disable: suspend (Characteristic) -> Unit,
+    mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
+): Flow<T> {
+    val serviceUuid = characteristic.serviceUuid
+    val charUuid = characteristic.uuid
+
+    return flow {
+        observationManager
+            .subscribe(serviceUuid, charUuid, backpressure)
+            .collect { event -> mapper(event) }
+    }.onStart {
+        if (isReady()) enable(characteristic)
+    }.applyBackpressure(backpressure)
+        .onCompletion {
+            val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
+            if (wasLastCollector) disable(characteristic)
+        }
+}
+
+internal val ObservationToObservation: suspend FlowCollector<Observation>.(ObservationEvent) -> Unit = { event ->
+    when (event) {
+        is ObservationEvent.Value -> emit(Observation.Value(event.data))
+        is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
+        is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
+    }
+}
+
+internal val ObservationToBytes: suspend FlowCollector<ByteArray>.(ObservationEvent) -> Unit = { event ->
+    if (event is ObservationEvent.Value) emit(event.data)
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
@@ -137,36 +137,41 @@ internal class ApplePeripheralBridge(
         CentralManagerProvider.manager.connectPeripheral(cbPeripheral, options = null)
     }
 
-    internal fun discoverServices() {
+    internal fun discoverServices(): Boolean {
         cbPeripheral.discoverServices(null)
+        return true
     }
 
     internal fun discoverCharacteristics(service: CBService) {
         cbPeripheral.discoverCharacteristics(null, service)
     }
 
-    internal fun readCharacteristic(characteristic: CBCharacteristic) {
+    internal fun readCharacteristic(characteristic: CBCharacteristic): Boolean {
         cbPeripheral.readValueForCharacteristic(characteristic)
+        return true
     }
 
     internal fun writeCharacteristic(
         characteristic: CBCharacteristic,
         data: NSData,
         withResponse: Boolean,
-    ) {
+    ): Boolean {
         val type = if (withResponse) CBCharacteristicWriteWithResponse else CBCharacteristicWriteWithoutResponse
         cbPeripheral.writeValue(data, characteristic, type)
+        return true
     }
 
-    internal fun readDescriptor(descriptor: CBDescriptor) {
+    internal fun readDescriptor(descriptor: CBDescriptor): Boolean {
         cbPeripheral.readValueForDescriptor(descriptor)
+        return true
     }
 
     internal fun writeDescriptor(
         descriptor: CBDescriptor,
         data: NSData,
-    ) {
+    ): Boolean {
         cbPeripheral.writeValue(data, descriptor)
+        return true
     }
 
     internal fun setNotifyValue(
@@ -176,8 +181,9 @@ internal class ApplePeripheralBridge(
         cbPeripheral.setNotifyValue(enabled, characteristic)
     }
 
-    internal fun readRSSI() {
+    internal fun readRSSI(): Boolean {
         cbPeripheral.readRSSI()
+        return true
     }
 
     internal fun openL2CAPChannel(psm: UShort) {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -15,7 +15,6 @@ import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
-import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -26,31 +25,32 @@ import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.NotConnectedException
-import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.gatt.internal.PersistedObservation
-import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import com.atruedev.kmpble.internal.StateRestorationHandler
 import com.atruedev.kmpble.l2cap.DEFAULT_L2CAP_MTU
 import com.atruedev.kmpble.l2cap.IosL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
+import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
+import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
+import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import com.atruedev.kmpble.peripheral.internal.PeripheralRegistry
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
+import com.atruedev.kmpble.peripheral.internal.findCharacteristic
+import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.getAndUpdate
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -84,23 +84,13 @@ public class IosPeripheral(
     private val bridge = ApplePeripheralBridge(cbPeripheral)
     private val centralDelegate = CentralManagerProvider.scanDelegate
 
-    @Volatile
-    private var connectionComplete: CompletableDeferred<Unit>? = null
-
-    @Volatile
-    private var discoveryComplete: CompletableDeferred<List<DiscoveredService>>? = null
-
-    @Volatile
-    private var disconnectComplete: CompletableDeferred<Unit>? = null
     private val pendingOps = PendingOperations()
     private val observationManager = ObservationManager()
+    private val slots = LifecycleSlots()
 
-    // Map our Characteristic/Descriptor objects to native CBCharacteristic/CBDescriptor
     private val nativeCharMap = mutableMapOf<Characteristic, CBCharacteristic>()
     private val nativeDescMap = mutableMapOf<Descriptor, CBDescriptor>()
 
-    // L2CAP state
-    @Volatile
     private var pendingL2capChannel: CompletableDeferred<CBL2CAPChannel>? = null
     private val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
 
@@ -112,7 +102,6 @@ public class IosPeripheral(
     @Volatile
     private var closed = false
 
-    // Safe: all callbacks dispatched to peripheralContext.scope (limitedParallelism(1))
     private var pendingCharacteristicDiscovery = 0
     private val reconnectionHandler =
         ReconnectionHandler(
@@ -129,7 +118,6 @@ public class IosPeripheral(
         centralDelegate.registerConnectionCallback(identifier.value) { connected, error ->
             handleConnectionCallback(connected, error)
         }
-        // Wire observation persistence for state restoration
         if (CentralManagerProvider.isStateRestorationEnabled) {
             observationManager.onObservationsChanged = { observations ->
                 StateRestorationHandler.default.persistObservations(identifier.value, observations)
@@ -144,23 +132,18 @@ public class IosPeripheral(
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
-            val deferred = CompletableDeferred<Unit>()
-            connectionComplete = deferred
+            val deferred = slots.armConnect()
             bridge.connect()
 
-            // didFailToConnectPeripheral is handled by the ObjC delegate proxy
-            // (KmpBleDelegateProxy) which routes through handleConnectionFailure.
             try {
-                withTimeout(options.timeout) {
-                    deferred.await()
-                }
+                withTimeout(options.timeout) { deferred.await() }
             } catch (_: TimeoutCancellationException) {
                 bridge.disconnect()
                 peripheralContext.processEvent(
                     ConnectionEvent.ConnectionLost(ConnectionFailed("Connection timeout")),
                 )
             } finally {
-                connectionComplete = null
+                slots.clearConnect()
             }
         }
     }
@@ -171,8 +154,7 @@ public class IosPeripheral(
         withContext(peripheralContext.dispatcher) {
             if (peripheralContext.state.value is State.Disconnected) return@withContext
             peripheralContext.processEvent(ConnectionEvent.DisconnectRequested)
-            val deferred = CompletableDeferred<Unit>()
-            disconnectComplete = deferred
+            val deferred = slots.armDisconnect()
             bridge.disconnect()
 
             try {
@@ -182,7 +164,7 @@ public class IosPeripheral(
                     ConnectionEvent.ConnectionLost(OperationFailed("Disconnect timeout")),
                 )
             } finally {
-                disconnectComplete = null
+                slots.clearDisconnect()
             }
         }
     }
@@ -210,13 +192,12 @@ public class IosPeripheral(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
-            val deferred = CompletableDeferred<List<DiscoveredService>>()
-            discoveryComplete = deferred
+            val deferred = slots.armDiscovery()
             bridge.discoverServices()
             try {
                 withTimeout(DISCOVERY_TIMEOUT) { deferred.await() }
             } finally {
-                discoveryComplete = null
+                slots.clearDiscovery()
             }
         }
     }
@@ -224,22 +205,13 @@ public class IosPeripheral(
     override fun findCharacteristic(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
-    ): Characteristic? =
-        services.value
-            ?.firstOrNull { it.uuid == serviceUuid }
-            ?.characteristics
-            ?.firstOrNull { it.uuid == characteristicUuid }
+    ): Characteristic? = services.value.findCharacteristic(serviceUuid, characteristicUuid)
 
     override fun findDescriptor(
         serviceUuid: Uuid,
         characteristicUuid: Uuid,
         descriptorUuid: Uuid,
-    ): Descriptor? {
-        val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return null
-        return char.descriptors.firstOrNull { it.uuid == descriptorUuid }
-    }
-
-    // --- Central manager connection callbacks ---
+    ): Descriptor? = services.value.findDescriptor(serviceUuid, characteristicUuid, descriptorUuid)
 
     private fun handleConnectionCallback(
         connected: Boolean,
@@ -249,145 +221,134 @@ public class IosPeripheral(
             if (connected) {
                 peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
                 bridge.discoverServices()
-            } else {
-                val bleError =
-                    if (error != null) {
-                        ConnectionFailed(error.localizedDescription, error.code.toInt())
-                    } else {
-                        ConnectionLost("Disconnected")
-                    }
-
-                if (peripheralContext.state.value is State.Disconnecting.Requested) {
-                    peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
-                    disconnectComplete?.complete(Unit)
-                } else {
-                    peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
-                }
-                onDisconnectCleanup()
-                connectionComplete?.complete(Unit)
+                return@launch
             }
+
+            val bleError =
+                if (error != null) {
+                    ConnectionFailed(error.localizedDescription, error.code.toInt())
+                } else {
+                    ConnectionLost("Disconnected")
+                }
+
+            if (peripheralContext.state.value is State.Disconnecting.Requested) {
+                peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
+                slots.completeDisconnect()
+            } else {
+                peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
+            }
+            onDisconnectCleanup()
+            slots.completeConnect()
         }
     }
-
-    // --- Peripheral delegate callbacks ---
 
     private fun handleBridgeEvent(event: AppleCallbackEvent) {
         peripheralContext.scope.launch {
             when (event) {
                 is AppleCallbackEvent.DidDiscoverServices -> handleServicesDiscovered(event)
                 is AppleCallbackEvent.DidDiscoverCharacteristics -> handleCharacteristicsDiscovered()
-                is AppleCallbackEvent.DidUpdateValueForCharacteristic -> {
-                    // K/N may route both didUpdateValue and didWriteValue here (same
-                    // Kotlin type signature). The GATT queue serializes ops - at most
-                    // one of read/write is pending. Check write first, then read, then notification.
-                    val cbChar = event.characteristic
-                    val error = event.error
-                    if (pendingOps.has(PendingOp.CharacteristicWrite)) {
-                        pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
-                    } else if (pendingOps.has(PendingOp.CharacteristicRead)) {
-                        val status = error.toGattStatus()
-                        val value = cbChar.value?.toByteArray() ?: byteArrayOf()
-                        pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, status))
-                    } else {
-                        val value = cbChar.value?.toByteArray() ?: return@launch
-                        val svcUuid = uuidFrom(cbChar.service?.UUID?.UUIDString ?: return@launch)
-                        val charUuid = uuidFrom(cbChar.UUID.UUIDString)
-                        observationManager.emitByUuid(svcUuid, charUuid, value)
-                    }
-                }
-                is AppleCallbackEvent.DidWriteValueForCharacteristic -> {
+                is AppleCallbackEvent.DidUpdateValueForCharacteristic -> handleCharacteristicValue(event)
+                is AppleCallbackEvent.DidWriteValueForCharacteristic ->
                     pendingOps.complete(PendingOp.CharacteristicWrite, event.error.toGattStatus())
-                }
-                is AppleCallbackEvent.DidUpdateValueForDescriptor -> {
-                    val error = event.error
-                    if (pendingOps.has(PendingOp.DescriptorWrite)) {
-                        pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
-                    } else {
-                        val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
-                        pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
-                    }
-                }
-                is AppleCallbackEvent.DidWriteValueForDescriptor -> {
+                is AppleCallbackEvent.DidUpdateValueForDescriptor -> handleDescriptorValue(event)
+                is AppleCallbackEvent.DidWriteValueForDescriptor ->
                     pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
-                }
-                is AppleCallbackEvent.DidReadRSSI -> {
-                    if (event.error == null) {
-                        pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
-                    } else {
-                        pendingOps.fail(
-                            PendingOp.RssiRead,
-                            BleException(GattError("readRssi", event.error.toGattStatus())),
-                        )
-                    }
-                }
-                is AppleCallbackEvent.DidOpenL2CAPChannel -> {
-                    handleDidOpenL2CAPChannel(event)
-                }
+                is AppleCallbackEvent.DidReadRSSI -> handleRssi(event)
+                is AppleCallbackEvent.DidOpenL2CAPChannel -> handleDidOpenL2CAPChannel(event)
             }
+        }
+    }
+
+    /**
+     * K/N maps both `didUpdateValue` (read response, notification) and `didWriteValue`
+     * (write response) to this single signature. Disambiguate by which slot is armed:
+     * the GATT queue ensures only one read/write is pending.
+     */
+    private fun handleCharacteristicValue(event: AppleCallbackEvent.DidUpdateValueForCharacteristic) {
+        val cbChar = event.characteristic
+        val error = event.error
+        when {
+            pendingOps.has(PendingOp.CharacteristicWrite) ->
+                pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
+            pendingOps.has(PendingOp.CharacteristicRead) -> {
+                val value = cbChar.value?.toByteArray() ?: byteArrayOf()
+                pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, error.toGattStatus()))
+            }
+            else -> {
+                val value = cbChar.value?.toByteArray() ?: return
+                val svcUuid = uuidFrom(cbChar.service?.UUID?.UUIDString ?: return)
+                val charUuid = uuidFrom(cbChar.UUID.UUIDString)
+                observationManager.emitByUuid(svcUuid, charUuid, value)
+            }
+        }
+    }
+
+    private fun handleDescriptorValue(event: AppleCallbackEvent.DidUpdateValueForDescriptor) {
+        val error = event.error
+        if (pendingOps.has(PendingOp.DescriptorWrite)) {
+            pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
+        } else {
+            val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
+            pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
+        }
+    }
+
+    private fun handleRssi(event: AppleCallbackEvent.DidReadRSSI) {
+        if (event.error == null) {
+            pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
+        } else {
+            pendingOps.fail(
+                PendingOp.RssiRead,
+                BleException(GattError("readRssi", event.error.toGattStatus())),
+            )
         }
     }
 
     private suspend fun handleServicesDiscovered(event: AppleCallbackEvent.DidDiscoverServices) {
         if (event.error != null) {
-            peripheralContext.processEvent(
-                ConnectionEvent.DiscoveryFailed(
-                    GattError("discoverServices", event.error.toGattStatus()),
-                ),
-            )
-            connectionComplete?.complete(Unit)
-            discoveryComplete?.completeExceptionally(
-                BleException(GattError("discoverServices", event.error.toGattStatus())),
-            )
+            val status = event.error.toGattStatus()
+            peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)))
+            slots.completeConnect()
+            slots.failDiscovery(BleException(GattError("discoverServices", status)))
             return
         }
 
-        val cbServices = cbPeripheral.services?.filterIsInstance<CBService>() ?: emptyList()
+        val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
         if (cbServices.isEmpty()) {
             finishDiscovery(emptyList())
             return
         }
 
-        // Discover characteristics for each service
         pendingCharacteristicDiscovery = cbServices.size
         cbServices.forEach { bridge.discoverCharacteristics(it) }
     }
 
     private suspend fun handleCharacteristicsDiscovered() {
         pendingCharacteristicDiscovery--
+        if (pendingCharacteristicDiscovery > 0) return
 
-        if (pendingCharacteristicDiscovery <= 0) {
-            val cbServices = cbPeripheral.services?.filterIsInstance<CBService>() ?: emptyList()
-            val discovered = cbServices.map { it.toDiscoveredService() }
-            finishDiscovery(discovered)
-        }
+        val discovered = cbPeripheral.services
+            ?.filterIsInstance<CBService>()
+            ?.map { it.toDiscoveredService() }
+            .orEmpty()
+        finishDiscovery(discovered)
     }
 
     private suspend fun finishDiscovery(discovered: List<DiscoveredService>) {
         peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
         peripheralContext.updateServices(discovered)
-
-        // Re-enable notifications for any observations that survived the disconnect
         resubscribeObservations()
-
         peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
-        connectionComplete?.complete(Unit)
-        discoveryComplete?.complete(discovered)
+        slots.completeConnect()
+        slots.completeDiscovery(discovered)
     }
 
     private suspend fun resubscribeObservations() {
-        val toResubscribe = observationManager.getObservationsToResubscribe()
-        for (key in toResubscribe) {
+        for (key in observationManager.getObservationsToResubscribe()) {
             val char = findCharacteristic(key.serviceUuid, key.charUuid)
-            if (char != null) {
-                enableNotifications(char)
-            } else {
-                // Characteristic no longer exists - complete that observation
-                observationManager.completeObservation(key)
-            }
+            if (char != null) enableNotifications(char) else observationManager.completeObservation(key)
         }
     }
-
-    // --- Service parsing ---
 
     private fun CBService.toDiscoveredService(): DiscoveredService {
         val serviceUuid = uuidFrom(UUID.UUIDString)
@@ -403,8 +364,7 @@ public class IosPeripheral(
                         properties =
                             Characteristic.Properties(
                                 read = (props and CBCharacteristicPropertyRead.toInt()) != 0,
-                                write =
-                                    (props and CBCharacteristicPropertyWrite.toInt()) != 0,
+                                write = (props and CBCharacteristicPropertyWrite.toInt()) != 0,
                                 writeWithoutResponse =
                                     (props and CBCharacteristicPropertyWriteWithoutResponse.toInt()) != 0,
                                 signedWrite =
@@ -421,20 +381,17 @@ public class IosPeripheral(
                     nativeDescMap[desc] = cbDesc
                 }
                 char
-            } ?: emptyList()
+            }.orEmpty()
 
         return DiscoveredService(uuid = serviceUuid, characteristics = chars)
     }
 
-    // --- GATT Operations ---
-
-    private fun requireNativeCbChar(characteristic: Characteristic): CBCharacteristic =
-        nativeCharMap[characteristic]
+    private fun requireNativeCbChar(c: Characteristic): CBCharacteristic =
+        nativeCharMap[c]
             ?: throw IllegalArgumentException("Characteristic not found. Re-acquire from services after connect.")
 
-    private fun requireNativeCbDesc(descriptor: Descriptor): CBDescriptor =
-        nativeDescMap[descriptor]
-            ?: throw IllegalArgumentException("Descriptor not found.")
+    private fun requireNativeCbDesc(d: Descriptor): CBDescriptor =
+        nativeDescMap[d] ?: throw IllegalArgumentException("Descriptor not found.")
 
     private fun ByteArray.toNSData(): NSData = BleData(this).nsData
 
@@ -444,10 +401,9 @@ public class IosPeripheral(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbChar(characteristic)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.CharacteristicRead, deferred)
-            bridge.readCharacteristic(native)
-            val result = deferred.await()
+            val result = pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                bridge.readCharacteristic(native)
+            }
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
@@ -464,13 +420,13 @@ public class IosPeripheral(
         val native = requireNativeCbChar(characteristic)
         val withResponse = writeType == WriteType.WithResponse || writeType == WriteType.Signed
         val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
+
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
                 if (withResponse) {
-                    val deferred = CompletableDeferred<GattStatus>()
-                    pendingOps.set(PendingOp.CharacteristicWrite, deferred)
-                    bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
-                    val status = deferred.await()
+                    val status = pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                        bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
+                    }
                     if (!status.isSuccess()) throw BleException(GattError("write", status))
                 } else {
                     bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = false)
@@ -482,55 +438,37 @@ public class IosPeripheral(
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-            }
-        }
+    ): Flow<Observation> {
+        checkNotClosed()
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotifications,
+            mapper = ObservationToObservation,
+        )
+    }
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> =
-        observeInternal(characteristic, backpressure) { event ->
-            when (event) {
-                is ObservationEvent.Value -> emit(event.data)
-                is ObservationEvent.Disconnected -> Unit
-                is ObservationEvent.PermanentlyDisconnected -> Unit
-            }
-        }
-
-    private fun <T> observeInternal(
-        characteristic: Characteristic,
-        backpressure: BackpressureStrategy,
-        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
-    ): Flow<T> {
+    ): Flow<ByteArray> {
         checkNotClosed()
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
-        return flow {
-            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-            eventFlow.collect { event -> mapper(event) }
-        }.onStart {
-            if (peripheralContext.state.value is State.Connected.Ready) {
-                enableNotifications(characteristic)
-            }
-        }.applyBackpressure(backpressure)
-            .onCompletion {
-                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                if (wasLastCollector) {
-                    disableNotifications(characteristic)
-                }
-            }
+        return buildObservationFlow(
+            characteristic = characteristic,
+            backpressure = backpressure,
+            observationManager = observationManager,
+            isReady = { peripheralContext.state.value is State.Connected.Ready },
+            enable = ::enableNotifications,
+            disable = ::disableNotifications,
+            mapper = ObservationToBytes,
+        )
     }
 
     private fun enableNotifications(characteristic: Characteristic) {
-        val native = requireNativeCbChar(characteristic)
-        bridge.setNotifyValue(true, native)
+        bridge.setNotifyValue(true, requireNativeCbChar(characteristic))
     }
 
     private fun disableNotifications(characteristic: Characteristic) {
@@ -543,10 +481,9 @@ public class IosPeripheral(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
-            val deferred = CompletableDeferred<GattResult>()
-            pendingOps.set(PendingOp.DescriptorRead, deferred)
-            bridge.readDescriptor(native)
-            val result = deferred.await()
+            val result = pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                bridge.readDescriptor(native)
+            }
             if (!result.status.isSuccess()) throw BleException(GattError("readDescriptor", result.status))
             result.value
         }
@@ -559,10 +496,9 @@ public class IosPeripheral(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
-            val deferred = CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.DescriptorWrite, deferred)
-            bridge.writeDescriptor(native, data.toNSData())
-            val status = deferred.await()
+            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                bridge.writeDescriptor(native, data.toNSData())
+            }
             if (!status.isSuccess()) throw BleException(GattError("writeDescriptor", status))
         }
     }
@@ -570,27 +506,19 @@ public class IosPeripheral(
     override suspend fun readRssi(): Int {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
-            val deferred = CompletableDeferred<Int>()
-            pendingOps.set(PendingOp.RssiRead, deferred)
-            bridge.readRSSI()
-            deferred.await()
+            pendingOps.awaitGatt(PendingOp.RssiRead, "readRssi") { bridge.readRSSI() }
         }
     }
 
     override suspend fun requestMtu(mtu: Int): Int {
         checkNotClosed()
-        // iOS negotiates MTU automatically - no explicit request API.
-        // Read the actual negotiated value from CoreBluetooth.
         val actualMtu =
             cbPeripheral
-                .maximumWriteValueLengthForType(
-                    CBCharacteristicWriteWithResponse,
-                ).toInt() + ATT_HEADER_SIZE
+                .maximumWriteValueLengthForType(CBCharacteristicWriteWithResponse)
+                .toInt() + ATT_HEADER_SIZE
         peripheralContext.updateMtu(actualMtu)
         return actualMtu
     }
-
-    // --- L2CAP ---
 
     override suspend fun openL2capChannel(
         psm: Int,
@@ -609,14 +537,10 @@ public class IosPeripheral(
             }
             val deferred = CompletableDeferred<CBL2CAPChannel>()
             pendingL2capChannel = deferred
-
             bridge.openL2CAPChannel(psm.toUShort())
 
             try {
-                val cbChannel =
-                    withTimeout(L2CAP_OPEN_TIMEOUT) {
-                        deferred.await()
-                    }
+                val cbChannel = withTimeout(L2CAP_OPEN_TIMEOUT) { deferred.await() }
                 val channel = IosL2capChannel(cbChannel, peripheralContext.scope, mtu ?: DEFAULT_L2CAP_MTU)
                 activeL2capChannels.update { it + channel }
                 channel
@@ -637,25 +561,24 @@ public class IosPeripheral(
         val deferred = pendingL2capChannel ?: return
         pendingL2capChannel = null
 
-        if (event.error != null) {
-            deferred.completeExceptionally(
-                L2capException.OpenFailed(
-                    psm = event.channel?.PSM?.toInt() ?: -1,
-                    message = event.error.localizedDescription,
-                ),
-            )
-        } else if (event.channel != null) {
-            deferred.complete(event.channel)
-        } else {
-            deferred.completeExceptionally(
-                L2capException.OpenFailed(psm = -1, message = "Channel is null with no error"),
-            )
+        when {
+            event.error != null ->
+                deferred.completeExceptionally(
+                    L2capException.OpenFailed(
+                        psm = event.channel?.PSM?.toInt() ?: -1,
+                        message = event.error.localizedDescription,
+                    ),
+                )
+            event.channel != null -> deferred.complete(event.channel)
+            else ->
+                deferred.completeExceptionally(
+                    L2capException.OpenFailed(psm = -1, message = "Channel is null with no error"),
+                )
         }
     }
 
     private fun closeL2capChannels() {
-        val channels = activeL2capChannels.getAndUpdate { emptyList() }
-        channels.forEach { it.close() }
+        activeL2capChannels.getAndUpdate { emptyList() }.forEach { it.close() }
     }
 
     private fun onDisconnectCleanup() {
@@ -669,60 +592,30 @@ public class IosPeripheral(
     /**
      * Restore this peripheral from iOS state restoration.
      *
-     * Called by [StateRestorationHandler] when iOS provides restored CBPeripherals
-     * after app relaunch. Re-populates observation subscriptions from persisted keys
-     * and triggers service discovery + observation re-subscription if the peripheral
-     * is already connected.
-     *
-     * State restoration flow:
-     * ```
-     * iOS restores CBPeripheral (may already be connected)
-     *     │
-     *     ├── cbPeripheral.state == Connected?
-     *     │   ├── YES → discover services → resubscribe observations
-     *     │   └── NO  → wait for connection callback → normal flow resumes
-     *     │
-     *     └── Restore persisted observation keys into ObservationManager
-     * ```
+     * Re-populates persisted observations and triggers discovery if iOS already
+     * delivered the peripheral as connected.
      */
     internal suspend fun restoreFromStateRestoration(savedObservations: Set<PersistedObservation>) {
         if (closed) return
 
         withContext(peripheralContext.dispatcher) {
-            // Pre-populate observation subscriptions from persisted entries.
-            // This ensures that when the peripheral reconnects and services are discovered,
-            // resubscribeObservations() will re-enable CCCD for these characteristics.
-            // The original backpressure strategy is restored from persistence.
             for (obs in savedObservations) {
-                observationManager.subscribe(
-                    obs.key.serviceUuid,
-                    obs.key.charUuid,
-                    obs.backpressure,
-                )
+                observationManager.subscribe(obs.key.serviceUuid, obs.key.charUuid, obs.backpressure)
             }
 
-            // If the peripheral is already connected (iOS maintained the connection),
-            // trigger service discovery to rebuild the native char/desc maps and
-            // re-enable notifications.
             if (cbPeripheral.state == CBPeripheralStateConnected) {
                 peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
                 peripheralContext.gattQueue.start()
                 peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
 
-                val deferred = CompletableDeferred<Unit>()
-                connectionComplete = deferred
+                val deferred = slots.armConnect()
                 bridge.discoverServices()
-
                 try {
-                    withTimeout(DISCOVERY_TIMEOUT) {
-                        deferred.await()
-                    }
+                    withTimeout(DISCOVERY_TIMEOUT) { deferred.await() }
                 } finally {
-                    connectionComplete = null
+                    slots.clearConnect()
                 }
             }
-            // If not connected, the normal connection callback flow will handle it
-            // when iOS reconnects the peripheral.
         }
     }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -327,10 +327,11 @@ public class IosPeripheral(
         pendingCharacteristicDiscovery--
         if (pendingCharacteristicDiscovery > 0) return
 
-        val discovered = cbPeripheral.services
-            ?.filterIsInstance<CBService>()
-            ?.map { it.toDiscoveredService() }
-            .orEmpty()
+        val discovered =
+            cbPeripheral.services
+                ?.filterIsInstance<CBService>()
+                ?.map { it.toDiscoveredService() }
+                .orEmpty()
         finishDiscovery(discovered)
     }
 
@@ -353,35 +354,37 @@ public class IosPeripheral(
     private fun CBService.toDiscoveredService(): DiscoveredService {
         val serviceUuid = uuidFrom(UUID.UUIDString)
         val chars =
-            characteristics?.filterIsInstance<CBCharacteristic>()?.map { cbChar ->
-                val charUuid = uuidFrom(cbChar.UUID.UUIDString)
-                val props = cbChar.properties.toInt()
-                val descs = mutableListOf<Descriptor>()
-                val char =
-                    Characteristic(
-                        serviceUuid = serviceUuid,
-                        uuid = charUuid,
-                        properties =
-                            Characteristic.Properties(
-                                read = (props and CBCharacteristicPropertyRead.toInt()) != 0,
-                                write = (props and CBCharacteristicPropertyWrite.toInt()) != 0,
-                                writeWithoutResponse =
-                                    (props and CBCharacteristicPropertyWriteWithoutResponse.toInt()) != 0,
-                                signedWrite =
-                                    (props and CBCharacteristicPropertyAuthenticatedSignedWrites.toInt()) != 0,
-                                notify = (props and CBCharacteristicPropertyNotify.toInt()) != 0,
-                                indicate = (props and CBCharacteristicPropertyIndicate.toInt()) != 0,
-                            ),
-                        descriptors = descs,
-                    )
-                nativeCharMap[char] = cbChar
-                cbChar.descriptors?.filterIsInstance<CBDescriptor>()?.forEach { cbDesc ->
-                    val desc = Descriptor(char, uuidFrom(cbDesc.UUID.UUIDString))
-                    descs.add(desc)
-                    nativeDescMap[desc] = cbDesc
-                }
-                char
-            }.orEmpty()
+            characteristics
+                ?.filterIsInstance<CBCharacteristic>()
+                ?.map { cbChar ->
+                    val charUuid = uuidFrom(cbChar.UUID.UUIDString)
+                    val props = cbChar.properties.toInt()
+                    val descs = mutableListOf<Descriptor>()
+                    val char =
+                        Characteristic(
+                            serviceUuid = serviceUuid,
+                            uuid = charUuid,
+                            properties =
+                                Characteristic.Properties(
+                                    read = (props and CBCharacteristicPropertyRead.toInt()) != 0,
+                                    write = (props and CBCharacteristicPropertyWrite.toInt()) != 0,
+                                    writeWithoutResponse =
+                                        (props and CBCharacteristicPropertyWriteWithoutResponse.toInt()) != 0,
+                                    signedWrite =
+                                        (props and CBCharacteristicPropertyAuthenticatedSignedWrites.toInt()) != 0,
+                                    notify = (props and CBCharacteristicPropertyNotify.toInt()) != 0,
+                                    indicate = (props and CBCharacteristicPropertyIndicate.toInt()) != 0,
+                                ),
+                            descriptors = descs,
+                        )
+                    nativeCharMap[char] = cbChar
+                    cbChar.descriptors?.filterIsInstance<CBDescriptor>()?.forEach { cbDesc ->
+                        val desc = Descriptor(char, uuidFrom(cbDesc.UUID.UUIDString))
+                        descs.add(desc)
+                        nativeDescMap[desc] = cbDesc
+                    }
+                    char
+                }.orEmpty()
 
         return DiscoveredService(uuid = serviceUuid, characteristics = chars)
     }
@@ -401,9 +404,10 @@ public class IosPeripheral(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbChar(characteristic)
-            val result = pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
-                bridge.readCharacteristic(native)
-            }
+            val result =
+                pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                    bridge.readCharacteristic(native)
+                }
             if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
             result.value
         }
@@ -424,9 +428,10 @@ public class IosPeripheral(
         peripheralContext.gattQueue.enqueue {
             for (chunk in chunks) {
                 if (withResponse) {
-                    val status = pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
-                        bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
-                    }
+                    val status =
+                        pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                            bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = true)
+                        }
                     if (!status.isSuccess()) throw BleException(GattError("write", status))
                 } else {
                     bridge.writeCharacteristic(native, chunk.toNSData(), withResponse = false)
@@ -481,9 +486,10 @@ public class IosPeripheral(
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
-            val result = pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
-                bridge.readDescriptor(native)
-            }
+            val result =
+                pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                    bridge.readDescriptor(native)
+                }
             if (!result.status.isSuccess()) throw BleException(GattError("readDescriptor", result.status))
             result.value
         }
@@ -496,9 +502,10 @@ public class IosPeripheral(
         checkNotClosed()
         peripheralContext.gattQueue.enqueue {
             val native = requireNativeCbDesc(descriptor)
-            val status = pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
-                bridge.writeDescriptor(native, data.toNSData())
-            }
+            val status =
+                pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                    bridge.writeDescriptor(native, data.toNSData())
+                }
             if (!status.isSuccess()) throw BleException(GattError("writeDescriptor", status))
         }
     }


### PR DESCRIPTION
## Summary

The peripheral implementations advertised serial-dispatcher concurrency
("no locks, no mutexes") but kept four `@Volatile CompletableDeferred`
fields on each platform alongside `@Volatile currentConnectionOptions`.
Those primitives were unnecessary - every read and write already runs on
`peripheralContext.dispatcher` (`limitedParallelism(1)`) - and they made
re-entrant `connect()` calls silently overwrite the in-flight deferred.

This change brings the implementation in line with the documented model
and starts collapsing the duplication between `AndroidPeripheral` (895
lines) and `IosPeripheral` (739 lines).

## What changed

- New `commonMain/peripheral/internal/LifecycleSlots`. Holds the
  connect / discovery / disconnect one-shots, mutated only on the serial
  dispatcher, and throws `IllegalStateException` on re-entrant arming.
- New `commonMain/peripheral/internal/PeripheralSupport`. Hosts
  `findCharacteristic` / `findDescriptor`, the shared `observe()` flow
  construction, the standard `Observation` -> public type mappers, and
  `PendingOperations.awaitGatt` - a single helper that replaces the
  twelve-line submit-and-await pattern repeated at every GATT call site.
- `ApplePeripheralBridge`: GATT submission methods now return `Boolean`
  (always `true` on iOS) so both platforms feed `awaitGatt` uniformly.
- `AndroidPeripheral` and `IosPeripheral`: rewritten to use the helpers
  above. The four `@Volatile` lifecycle deferreds and
  `@Volatile currentConnectionOptions` are gone. `closed` is the only
  remaining `@Volatile` field, kept because `close()` is non-suspend and
  may be invoked from any thread (e.g. `ViewModel.onCleared`).

## Concurrency notes

- `LifecycleSlots` and `PendingOperations` are confined to
  `peripheralContext.dispatcher`. Bridge events post to the same
  dispatcher via `peripheralContext.scope.launch`. No `Mutex`, no
  `synchronized`, no extra `@Volatile` introduced.
- A second in-flight `connect()` call now fails fast with
  `IllegalStateException` instead of leaking the previous deferred.
- iOS preserves its existing K/N delegate disambiguation
  (`didUpdateValue` vs `didWriteValue`) inside the new
  `handleCharacteristicValue` / `handleDescriptorValue` helpers.

## Public API

No changes. `Peripheral`, `PeripheralFactory`, and `FakePeripheral` are
untouched.

## Test plan

- [x] `./gradlew :compileKotlinJvm`
- [x] `./gradlew :compileAndroidMain`
- [x] `./gradlew :compileKotlinIosArm64`
- [x] `./gradlew :jvmTest`
- [x] `./gradlew :testAndroidHostTest`
- [ ] iOS-side device validation (out of scope here; CI covers compilation)