### PR TITLE
fix(deps): bump netty to 4.1.133.Final to fix CVE-2026-41417

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ androidMinSdk = "33"
 androidCompileSdk = "36"
 androidTargetSdk = "36"
 # Minimum safe versions for transitive dependencies (see build.gradle.kts resolutionStrategy)
-netty = "4.1.132.Final"
+netty = "4.1.133.Final"
 logback = "1.5.25"
 jackson = "2.18.6"
 jdom2 = "2.0.6.1"


### PR DESCRIPTION
## Summary

- Bumps `netty` floor version from `4.1.132.Final` to `4.1.133.Final` in `gradle/libs.versions.toml`

## Security

Fixes [CVE-2026-41417](https://github.com/gary-quinn/kmp-ble/security/dependabot/27) (medium severity): Start-Line Injection in `DefaultHttpRequest.setUri()` allowing HTTP request smuggling and RTSP request injection. First patched in `4.1.133.Final`.