### PR TITLE
feat(profiles): add typed Codec API with length-prefix framing

### DIFF
--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codec.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codec.kt
@@ -1,0 +1,28 @@
+package com.atruedev.kmpble.profiles.codec
+
+/**
+ * Decodes a BLE characteristic value (or framed stream payload) into a typed value.
+ *
+ * Returns `null` on parse failure — matches the convention used by the built-in
+ * SIG profile parsers (e.g. heart rate, glucose).
+ */
+public fun interface Decoder<out T> {
+    public fun decode(bytes: ByteArray): T?
+}
+
+/**
+ * Encodes a typed value into bytes suitable for a BLE characteristic write,
+ * notification payload, or L2CAP CoC frame.
+ */
+public fun interface Encoder<in T> {
+    public fun encode(value: T): ByteArray
+}
+
+/**
+ * Round-trip codec: pair of [Encoder] and [Decoder] sharing the same wire format.
+ *
+ * Use a [Codec] when both directions are needed at one call site (e.g. a fake
+ * GATT server that round-trips state, or a peer-to-peer stream over L2CAP CoC).
+ * For one-way characteristics, prefer the narrower [Encoder] or [Decoder] alone.
+ */
+public interface Codec<T> : Encoder<T>, Decoder<T>

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codec.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codec.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpble.profiles.codec
 /**
  * Decodes a BLE characteristic value (or framed stream payload) into a typed value.
  *
- * Returns `null` on parse failure — matches the convention used by the built-in
+ * Returns `null` on parse failure -- matches the convention used by the built-in
  * SIG profile parsers (e.g. heart rate, glucose).
  */
 public fun interface Decoder<out T> {

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codecs.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codecs.kt
@@ -1,0 +1,76 @@
+package com.atruedev.kmpble.profiles.codec
+
+import com.atruedev.kmpble.profiles.parsing.BleByteWriter
+
+/** Codec that passes bytes through unchanged. Defensive copies on both sides. */
+public object RawBytesCodec : Codec<ByteArray> {
+    override fun encode(value: ByteArray): ByteArray = value.copyOf()
+
+    override fun decode(bytes: ByteArray): ByteArray = bytes.copyOf()
+}
+
+/**
+ * UTF-8 string codec. [decode] always succeeds; invalid byte sequences are
+ * replaced with the Unicode replacement character per [ByteArray.decodeToString].
+ */
+public object Utf8StringCodec : Codec<String> {
+    override fun encode(value: String): ByteArray = value.encodeToByteArray()
+
+    override fun decode(bytes: ByteArray): String = bytes.decodeToString()
+}
+
+/**
+ * Single-byte unsigned integer codec (0..255). Common for level/enum characteristics
+ * like Battery Level (0x2A19).
+ *
+ * [decode] returns `null` for empty input. [encode] throws if value is out of range.
+ */
+public object Uint8Codec : Codec<Int> {
+    override fun encode(value: Int): ByteArray {
+        require(value in 0..0xFF) { "uint8 out of range: $value" }
+        return byteArrayOf(value.toByte())
+    }
+
+    override fun decode(bytes: ByteArray): Int? =
+        if (bytes.isEmpty()) null else bytes[0].toInt() and 0xFF
+}
+
+/**
+ * Little-endian unsigned 16-bit integer codec (0..65535).
+ *
+ * [decode] returns `null` if input has fewer than 2 bytes. Extra bytes beyond
+ * the first two are ignored.
+ */
+public object Uint16Codec : Codec<Int> {
+    override fun encode(value: Int): ByteArray {
+        require(value in 0..0xFFFF) { "uint16 out of range: $value" }
+        return BleByteWriter(2).writeUInt16(value).toByteArray()
+    }
+
+    override fun decode(bytes: ByteArray): Int? {
+        if (bytes.size < 2) return null
+        return (bytes[0].toInt() and 0xFF) or ((bytes[1].toInt() and 0xFF) shl 8)
+    }
+}
+
+/**
+ * Little-endian unsigned 32-bit integer codec (0..4_294_967_295).
+ *
+ * [decode] returns `null` if input has fewer than 4 bytes. Extra bytes beyond
+ * the first four are ignored.
+ */
+public object Uint32Codec : Codec<Long> {
+    override fun encode(value: Long): ByteArray {
+        require(value in 0..0xFFFFFFFFL) { "uint32 out of range: $value" }
+        return BleByteWriter(4).writeUInt32(value).toByteArray()
+    }
+
+    override fun decode(bytes: ByteArray): Long? {
+        if (bytes.size < 4) return null
+        val b0 = (bytes[0].toInt() and 0xFF).toLong()
+        val b1 = (bytes[1].toInt() and 0xFF).toLong()
+        val b2 = (bytes[2].toInt() and 0xFF).toLong()
+        val b3 = (bytes[3].toInt() and 0xFF).toLong()
+        return (b3 shl 24) or (b2 shl 16) or (b1 shl 8) or b0
+    }
+}

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codecs.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Codecs.kt
@@ -10,20 +10,25 @@ public object RawBytesCodec : Codec<ByteArray> {
 }
 
 /**
- * UTF-8 string codec. [decode] always succeeds; invalid byte sequences are
- * replaced with the Unicode replacement character per [ByteArray.decodeToString].
+ * UTF-8 string codec. [decode] returns `null` on malformed UTF-8 byte sequences
+ * (honoring the [Decoder] contract); pair with a logger if you need to surface
+ * corrupted input.
  */
 public object Utf8StringCodec : Codec<String> {
     override fun encode(value: String): ByteArray = value.encodeToByteArray()
 
-    override fun decode(bytes: ByteArray): String = bytes.decodeToString()
+    override fun decode(bytes: ByteArray): String? = try {
+        bytes.decodeToString(throwOnInvalidSequence = true)
+    } catch (_: CharacterCodingException) {
+        null
+    }
 }
 
 /**
- * Single-byte unsigned integer codec (0..255). Common for level/enum characteristics
- * like Battery Level (0x2A19).
+ * Single-byte unsigned integer codec (0..255). Common for level/enum
+ * characteristics like Battery Level (0x2A19).
  *
- * [decode] returns `null` for empty input. [encode] throws if value is out of range.
+ * Strict size: [decode] returns `null` if input is not exactly 1 byte.
  */
 public object Uint8Codec : Codec<Int> {
     override fun encode(value: Int): ByteArray {
@@ -32,14 +37,22 @@ public object Uint8Codec : Codec<Int> {
     }
 
     override fun decode(bytes: ByteArray): Int? =
-        if (bytes.isEmpty()) null else bytes[0].toInt() and 0xFF
+        if (bytes.size != 1) null else bytes[0].toInt() and 0xFF
+}
+
+/** Single-byte signed integer codec (-128..127). Strict size on decode. */
+public object Int8Codec : Codec<Int> {
+    override fun encode(value: Int): ByteArray {
+        require(value in Byte.MIN_VALUE..Byte.MAX_VALUE) { "int8 out of range: $value" }
+        return byteArrayOf(value.toByte())
+    }
+
+    override fun decode(bytes: ByteArray): Int? =
+        if (bytes.size != 1) null else bytes[0].toInt()
 }
 
 /**
- * Little-endian unsigned 16-bit integer codec (0..65535).
- *
- * [decode] returns `null` if input has fewer than 2 bytes. Extra bytes beyond
- * the first two are ignored.
+ * Little-endian unsigned 16-bit integer codec (0..65535). Strict size on decode.
  */
 public object Uint16Codec : Codec<Int> {
     override fun encode(value: Int): ByteArray {
@@ -48,16 +61,28 @@ public object Uint16Codec : Codec<Int> {
     }
 
     override fun decode(bytes: ByteArray): Int? {
-        if (bytes.size < 2) return null
+        if (bytes.size != 2) return null
         return (bytes[0].toInt() and 0xFF) or ((bytes[1].toInt() and 0xFF) shl 8)
     }
 }
 
+/** Little-endian signed 16-bit integer codec (-32768..32767). Strict size on decode. */
+public object Int16Codec : Codec<Int> {
+    override fun encode(value: Int): ByteArray {
+        require(value in Short.MIN_VALUE..Short.MAX_VALUE) { "int16 out of range: $value" }
+        return BleByteWriter(2).writeInt16(value).toByteArray()
+    }
+
+    override fun decode(bytes: ByteArray): Int? {
+        if (bytes.size != 2) return null
+        val unsigned = (bytes[0].toInt() and 0xFF) or ((bytes[1].toInt() and 0xFF) shl 8)
+        return if (unsigned >= 0x8000) unsigned - 0x10000 else unsigned
+    }
+}
+
 /**
- * Little-endian unsigned 32-bit integer codec (0..4_294_967_295).
- *
- * [decode] returns `null` if input has fewer than 4 bytes. Extra bytes beyond
- * the first four are ignored.
+ * Little-endian unsigned 32-bit integer codec (0..4_294_967_295). Strict size
+ * on decode.
  */
 public object Uint32Codec : Codec<Long> {
     override fun encode(value: Long): ByteArray {
@@ -66,11 +91,27 @@ public object Uint32Codec : Codec<Long> {
     }
 
     override fun decode(bytes: ByteArray): Long? {
-        if (bytes.size < 4) return null
+        if (bytes.size != 4) return null
         val b0 = (bytes[0].toInt() and 0xFF).toLong()
         val b1 = (bytes[1].toInt() and 0xFF).toLong()
         val b2 = (bytes[2].toInt() and 0xFF).toLong()
         val b3 = (bytes[3].toInt() and 0xFF).toLong()
         return (b3 shl 24) or (b2 shl 16) or (b1 shl 8) or b0
+    }
+}
+
+/** Little-endian signed 32-bit integer codec. Strict size on decode. */
+public object Int32Codec : Codec<Int> {
+    override fun encode(value: Int): ByteArray {
+        val unsigned = value.toLong() and 0xFFFFFFFFL
+        return BleByteWriter(4).writeUInt32(unsigned).toByteArray()
+    }
+
+    override fun decode(bytes: ByteArray): Int? {
+        if (bytes.size != 4) return null
+        return (bytes[0].toInt() and 0xFF) or
+            ((bytes[1].toInt() and 0xFF) shl 8) or
+            ((bytes[2].toInt() and 0xFF) shl 16) or
+            ((bytes[3].toInt() and 0xFF) shl 24)
     }
 }

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/FlowFraming.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/FlowFraming.kt
@@ -7,14 +7,18 @@ import kotlinx.coroutines.flow.flow
  * Adapts a stream of byte chunks (e.g. from an L2CAP CoC `incoming` flow) into
  * a stream of complete framed payloads.
  *
- * The [unframer] is consumed lazily - partial frames are buffered until the
- * next chunk completes them. If the source flow completes while a partial
- * frame is still buffered, the partial frame is dropped silently.
+ * Each collection allocates its own fresh [Unframer] via [framer], so the same
+ * [Framer] instance is safe to share across multiple collectors.
  *
- * Pass a fresh [Unframer] per collection - the unframer is stateful and not
- * safe to share across concurrent collectors.
+ * If the source flow completes while bytes are still buffered, the partial
+ * tail is silently dropped. Inspect the source's terminal state or wire your
+ * own diagnostics if that matters.
+ *
+ * A malformed length prefix throws [FrameTooLargeException] downstream, which
+ * cancels the flow. Wrap with `.catch { }` to recover.
  */
-public fun Flow<ByteArray>.unframedBy(unframer: Unframer): Flow<ByteArray> = flow {
+public fun Flow<ByteArray>.unframedBy(framer: Framer): Flow<ByteArray> = flow {
+    val unframer = framer.unframer()
     collect { chunk ->
         for (frame in unframer.feed(chunk)) {
             emit(frame)
@@ -23,22 +27,31 @@ public fun Flow<ByteArray>.unframedBy(unframer: Unframer): Flow<ByteArray> = flo
 }
 
 /**
- * Combines [unframedBy] and [Decoder] into one operator: byte chunks in,
- * typed values out. Frames that fail to decode (decoder returns `null`) are
- * dropped.
+ * Combines unframing and decoding into one operator: byte chunks in, typed
+ * values out.
  *
- * The default [LengthPrefixFramer] uses the standard 1 MiB frame cap.
+ * Frames that fail to decode (decoder returns `null`) are routed to
+ * [onDecodeFailure] and dropped from the output stream. Default is a no-op;
+ * pass a logger or metrics sink in production to surface corrupted payloads.
+ *
+ * A malformed length prefix throws [FrameTooLargeException] downstream, which
+ * cancels the flow. Wrap with `.catch { }` to recover.
  */
 public fun <T> Flow<ByteArray>.decodeFramed(
     decoder: Decoder<T>,
-    framer: LengthPrefixFramer = LengthPrefixFramer(),
+    framer: Framer = LengthPrefixFramer(),
+    onDecodeFailure: (ByteArray) -> Unit = {},
 ): Flow<T> {
     val unframer = framer.unframer()
     return flow {
         collect { chunk ->
             for (frame in unframer.feed(chunk)) {
                 val decoded = decoder.decode(frame)
-                if (decoded != null) emit(decoded)
+                if (decoded != null) {
+                    emit(decoded)
+                } else {
+                    onDecodeFailure(frame)
+                }
             }
         }
     }

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/FlowFraming.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/FlowFraming.kt
@@ -1,0 +1,45 @@
+package com.atruedev.kmpble.profiles.codec
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Adapts a stream of byte chunks (e.g. from an L2CAP CoC `incoming` flow) into
+ * a stream of complete framed payloads.
+ *
+ * The [unframer] is consumed lazily - partial frames are buffered until the
+ * next chunk completes them. If the source flow completes while a partial
+ * frame is still buffered, the partial frame is dropped silently.
+ *
+ * Pass a fresh [Unframer] per collection - the unframer is stateful and not
+ * safe to share across concurrent collectors.
+ */
+public fun Flow<ByteArray>.unframedBy(unframer: Unframer): Flow<ByteArray> = flow {
+    collect { chunk ->
+        for (frame in unframer.feed(chunk)) {
+            emit(frame)
+        }
+    }
+}
+
+/**
+ * Combines [unframedBy] and [Decoder] into one operator: byte chunks in,
+ * typed values out. Frames that fail to decode (decoder returns `null`) are
+ * dropped.
+ *
+ * The default [LengthPrefixFramer] uses the standard 1 MiB frame cap.
+ */
+public fun <T> Flow<ByteArray>.decodeFramed(
+    decoder: Decoder<T>,
+    framer: LengthPrefixFramer = LengthPrefixFramer(),
+): Flow<T> {
+    val unframer = framer.unframer()
+    return flow {
+        collect { chunk ->
+            for (frame in unframer.feed(chunk)) {
+                val decoded = decoder.decode(frame)
+                if (decoded != null) emit(decoded)
+            }
+        }
+    }
+}

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Framing.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Framing.kt
@@ -3,29 +3,43 @@ package com.atruedev.kmpble.profiles.codec
 import com.atruedev.kmpble.profiles.parsing.BleByteWriter
 
 /**
- * Wraps a payload with a frame header so multiple payloads can travel safely
- * over a stream transport (L2CAP CoC, an MTU-spanning concatenation, etc.).
+ * Wraps and recovers payloads on a stream transport (L2CAP CoC, an MTU-spanning
+ * concatenation, etc.).
  *
- * Pair with [Unframer] to recover payloads on the receive side.
+ * A single [Framer] instance is both the encoder ([frame]) and the factory for
+ * fresh decoders ([unframer]). Decoders are stateful, so each receive stream
+ * needs its own; one [Framer] may produce many.
  */
 public interface Framer {
     public fun frame(payload: ByteArray): ByteArray
+
+    public fun unframer(): Unframer
 }
 
 /**
- * Stateful inverse of [Framer]. Implementations buffer partial frames across
- * [feed] calls; each call returns zero or more complete payloads.
+ * Stateful inverse of [Framer.frame]. Implementations buffer partial frames
+ * across [feed] calls; each call returns zero or more complete payloads.
  *
- * Not thread-safe - one [Unframer] per stream.
+ * If the source stream ends with [pendingBytes] > 0, a partial frame was in
+ * flight when the stream closed. Callers that care about completeness should
+ * check this after the stream completes.
+ *
+ * Not thread-safe.
  */
 public interface Unframer {
     public fun feed(bytes: ByteArray): List<ByteArray>
+
+    public fun pendingBytes(): Int
 }
 
 /**
- * Thrown when [Unframer.feed] reads a length prefix that exceeds the configured
- * [LengthPrefixFramer] cap. Indicates either a malformed stream or a buggy /
- * malicious peer; the unframer should not be reused afterwards.
+ * Thrown from [Unframer.feed] when a length prefix exceeds the configured cap.
+ * Indicates a malformed stream or hostile peer; the [Unframer] should not be
+ * reused.
+ *
+ * When propagated through [unframedBy] / [decodeFramed], this exception
+ * terminates the downstream [kotlinx.coroutines.flow.Flow] with an error.
+ * Consumers that want to recover should wrap the Flow with `.catch { }`.
  */
 public class FrameTooLargeException(
     public val size: Long,
@@ -35,12 +49,13 @@ public class FrameTooLargeException(
 /**
  * Length-prefix framing: each frame is `[length: uint32 LE][payload: bytes]`.
  *
- * - Length is the payload size, not including the 4-byte header
- * - Frames larger than [maxFrameSize] cause [Unframer.feed] to throw
- *   [FrameTooLargeException] to prevent unbounded buffering by a hostile peer
+ * Length is the payload size, not including the 4-byte header. Frames larger
+ * than [maxFrameSize] cause [Unframer.feed] to throw [FrameTooLargeException]
+ * to prevent unbounded buffering by a hostile peer.
  *
- * The default 1 MiB cap is conservative for BLE L2CAP CoC (typical MTU 2-64 KB,
- * typical application frames a few KB).
+ * The default cap is 64 KiB, deliberately small for BLE-scale workloads where
+ * a single frame typically encodes one event. Raise it explicitly when a use
+ * case demands larger payloads.
  */
 public class LengthPrefixFramer(
     private val maxFrameSize: Int = DEFAULT_MAX_FRAME_SIZE,
@@ -59,53 +74,80 @@ public class LengthPrefixFramer(
             .toByteArray()
     }
 
-    public fun unframer(): Unframer = LengthPrefixUnframer(maxFrameSize)
+    override fun unframer(): Unframer = LengthPrefixUnframer(maxFrameSize)
 
     public companion object {
         public const val HEADER_SIZE: Int = 4
-        public const val DEFAULT_MAX_FRAME_SIZE: Int = 1 shl 20
+        public const val DEFAULT_MAX_FRAME_SIZE: Int = 64 * 1024
     }
 }
 
 private class LengthPrefixUnframer(private val maxFrameSize: Int) : Unframer {
-    private var pending: ByteArray = EMPTY
+    private var buffer: ByteArray = ByteArray(INITIAL_CAPACITY)
+    private var writePos: Int = 0
+    private var readPos: Int = 0
 
     override fun feed(bytes: ByteArray): List<ByteArray> {
         if (bytes.isEmpty()) return emptyList()
-        pending = if (pending.isEmpty()) bytes.copyOf() else pending + bytes
+        append(bytes)
+        return drainFrames()
+    }
 
+    override fun pendingBytes(): Int = writePos - readPos
+
+    private fun append(bytes: ByteArray) {
+        val needed = writePos + bytes.size
+        if (needed > buffer.size && readPos > 0) {
+            compact()
+        }
+        if (writePos + bytes.size > buffer.size) {
+            var newCap = buffer.size
+            while (newCap < writePos + bytes.size) newCap *= 2
+            buffer = buffer.copyOf(newCap)
+        }
+        bytes.copyInto(buffer, writePos)
+        writePos += bytes.size
+    }
+
+    private fun drainFrames(): List<ByteArray> {
         val out = mutableListOf<ByteArray>()
-        var cursor = 0
         while (true) {
-            val remaining = pending.size - cursor
+            val remaining = writePos - readPos
             if (remaining < LengthPrefixFramer.HEADER_SIZE) break
-            val length = readLengthAt(cursor)
+            val length = readLengthAt(readPos)
             if (length > maxFrameSize) {
                 throw FrameTooLargeException(length, maxFrameSize)
             }
             val total = LengthPrefixFramer.HEADER_SIZE + length.toInt()
             if (remaining < total) break
-            out.add(
-                pending.copyOfRange(
-                    cursor + LengthPrefixFramer.HEADER_SIZE,
-                    cursor + total,
-                ),
-            )
-            cursor += total
+            out.add(buffer.copyOfRange(readPos + LengthPrefixFramer.HEADER_SIZE, readPos + total))
+            readPos += total
         }
-        pending = if (cursor == pending.size) EMPTY else pending.copyOfRange(cursor, pending.size)
+        if (readPos == writePos) {
+            readPos = 0
+            writePos = 0
+        } else if (readPos >= COMPACT_THRESHOLD) {
+            compact()
+        }
         return out
     }
 
+    private fun compact() {
+        buffer.copyInto(buffer, 0, readPos, writePos)
+        writePos -= readPos
+        readPos = 0
+    }
+
     private fun readLengthAt(offset: Int): Long {
-        val b0 = (pending[offset].toInt() and 0xFF).toLong()
-        val b1 = (pending[offset + 1].toInt() and 0xFF).toLong()
-        val b2 = (pending[offset + 2].toInt() and 0xFF).toLong()
-        val b3 = (pending[offset + 3].toInt() and 0xFF).toLong()
+        val b0 = (buffer[offset].toInt() and 0xFF).toLong()
+        val b1 = (buffer[offset + 1].toInt() and 0xFF).toLong()
+        val b2 = (buffer[offset + 2].toInt() and 0xFF).toLong()
+        val b3 = (buffer[offset + 3].toInt() and 0xFF).toLong()
         return (b3 shl 24) or (b2 shl 16) or (b1 shl 8) or b0
     }
 
     private companion object {
-        val EMPTY = ByteArray(0)
+        const val INITIAL_CAPACITY = 256
+        const val COMPACT_THRESHOLD = 4096
     }
 }

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Framing.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/Framing.kt
@@ -1,0 +1,111 @@
+package com.atruedev.kmpble.profiles.codec
+
+import com.atruedev.kmpble.profiles.parsing.BleByteWriter
+
+/**
+ * Wraps a payload with a frame header so multiple payloads can travel safely
+ * over a stream transport (L2CAP CoC, an MTU-spanning concatenation, etc.).
+ *
+ * Pair with [Unframer] to recover payloads on the receive side.
+ */
+public interface Framer {
+    public fun frame(payload: ByteArray): ByteArray
+}
+
+/**
+ * Stateful inverse of [Framer]. Implementations buffer partial frames across
+ * [feed] calls; each call returns zero or more complete payloads.
+ *
+ * Not thread-safe - one [Unframer] per stream.
+ */
+public interface Unframer {
+    public fun feed(bytes: ByteArray): List<ByteArray>
+}
+
+/**
+ * Thrown when [Unframer.feed] reads a length prefix that exceeds the configured
+ * [LengthPrefixFramer] cap. Indicates either a malformed stream or a buggy /
+ * malicious peer; the unframer should not be reused afterwards.
+ */
+public class FrameTooLargeException(
+    public val size: Long,
+    public val maxSize: Int,
+) : RuntimeException("Frame too large: $size > $maxSize")
+
+/**
+ * Length-prefix framing: each frame is `[length: uint32 LE][payload: bytes]`.
+ *
+ * - Length is the payload size, not including the 4-byte header
+ * - Frames larger than [maxFrameSize] cause [Unframer.feed] to throw
+ *   [FrameTooLargeException] to prevent unbounded buffering by a hostile peer
+ *
+ * The default 1 MiB cap is conservative for BLE L2CAP CoC (typical MTU 2-64 KB,
+ * typical application frames a few KB).
+ */
+public class LengthPrefixFramer(
+    private val maxFrameSize: Int = DEFAULT_MAX_FRAME_SIZE,
+) : Framer {
+    init {
+        require(maxFrameSize > 0) { "maxFrameSize must be positive: $maxFrameSize" }
+    }
+
+    override fun frame(payload: ByteArray): ByteArray {
+        require(payload.size <= maxFrameSize) {
+            "payload too large: ${payload.size} > $maxFrameSize"
+        }
+        return BleByteWriter(initialCapacity = payload.size + HEADER_SIZE)
+            .writeUInt32(payload.size.toLong())
+            .writeBytes(payload)
+            .toByteArray()
+    }
+
+    public fun unframer(): Unframer = LengthPrefixUnframer(maxFrameSize)
+
+    public companion object {
+        public const val HEADER_SIZE: Int = 4
+        public const val DEFAULT_MAX_FRAME_SIZE: Int = 1 shl 20
+    }
+}
+
+private class LengthPrefixUnframer(private val maxFrameSize: Int) : Unframer {
+    private var pending: ByteArray = EMPTY
+
+    override fun feed(bytes: ByteArray): List<ByteArray> {
+        if (bytes.isEmpty()) return emptyList()
+        pending = if (pending.isEmpty()) bytes.copyOf() else pending + bytes
+
+        val out = mutableListOf<ByteArray>()
+        var cursor = 0
+        while (true) {
+            val remaining = pending.size - cursor
+            if (remaining < LengthPrefixFramer.HEADER_SIZE) break
+            val length = readLengthAt(cursor)
+            if (length > maxFrameSize) {
+                throw FrameTooLargeException(length, maxFrameSize)
+            }
+            val total = LengthPrefixFramer.HEADER_SIZE + length.toInt()
+            if (remaining < total) break
+            out.add(
+                pending.copyOfRange(
+                    cursor + LengthPrefixFramer.HEADER_SIZE,
+                    cursor + total,
+                ),
+            )
+            cursor += total
+        }
+        pending = if (cursor == pending.size) EMPTY else pending.copyOfRange(cursor, pending.size)
+        return out
+    }
+
+    private fun readLengthAt(offset: Int): Long {
+        val b0 = (pending[offset].toInt() and 0xFF).toLong()
+        val b1 = (pending[offset + 1].toInt() and 0xFF).toLong()
+        val b2 = (pending[offset + 2].toInt() and 0xFF).toLong()
+        val b3 = (pending[offset + 3].toInt() and 0xFF).toLong()
+        return (b3 shl 24) or (b2 shl 16) or (b1 shl 8) or b0
+    }
+
+    private companion object {
+        val EMPTY = ByteArray(0)
+    }
+}

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
@@ -1,0 +1,58 @@
+package com.atruedev.kmpble.profiles.codec
+
+import com.atruedev.kmpble.gatt.BackpressureStrategy
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.mapNotNull
+import kotlin.uuid.Uuid
+
+/**
+ * Reads a characteristic and decodes the value with [decoder].
+ *
+ * Returns `null` if the characteristic is not present after service discovery
+ * or if [decoder] returns `null` for the read bytes.
+ */
+public suspend fun <T> Peripheral.readAs(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    decoder: Decoder<T>,
+): T? {
+    val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return null
+    return decoder.decode(read(char))
+}
+
+/**
+ * Encodes [value] with [encoder] and writes it to a characteristic.
+ *
+ * Silently no-ops if the characteristic is not present after service discovery;
+ * use [Peripheral.findCharacteristic] directly when presence matters to the caller.
+ */
+public suspend fun <T> Peripheral.writeAs(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    value: T,
+    encoder: Encoder<T>,
+    writeType: WriteType = WriteType.WithResponse,
+) {
+    val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return
+    write(char, encoder.encode(value), writeType)
+}
+
+/**
+ * Observes notifications/indications from a characteristic, decoding each
+ * payload with [decoder]. Values that fail to decode (decoder returns `null`)
+ * are dropped from the stream.
+ *
+ * Returns an empty flow if the characteristic is not present.
+ */
+public fun <T> Peripheral.observeAs(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    decoder: Decoder<T>,
+    backpressure: BackpressureStrategy = BackpressureStrategy.Latest,
+): Flow<T> {
+    val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return emptyFlow()
+    return observeValues(char, backpressure).mapNotNull { decoder.decode(it) }
+}

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
@@ -9,13 +9,32 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlin.uuid.Uuid
 
 /**
+ * Sealed root of failures raised by [readAs] / [writeAs] / [observeAs] that
+ * originate inside the codec layer (as opposed to the underlying BLE op).
+ *
+ * Match exhaustively when distinguishing codec failures from arbitrary BLE
+ * errors that may also surface via [Result.failure]:
+ *
+ * ```
+ * when (val cause = result.exceptionOrNull()) {
+ *     is PeripheralCodecException -> when (cause) {
+ *         is CharacteristicNotFoundException -> ...
+ *         is DecodeFailureException -> ...
+ *     }
+ *     else -> ... // BLE error, cancellation, etc.
+ * }
+ * ```
+ */
+public sealed class PeripheralCodecException(message: String) : RuntimeException(message)
+
+/**
  * Thrown when a service+characteristic UUID pair does not resolve against the
  * peripheral's discovered services.
  */
 public class CharacteristicNotFoundException(
     public val serviceUuid: Uuid,
     public val characteristicUuid: Uuid,
-) : RuntimeException("Characteristic $characteristicUuid not found in service $serviceUuid")
+) : PeripheralCodecException("Characteristic $characteristicUuid not found in service $serviceUuid")
 
 /**
  * Thrown when a [Decoder] returns `null` for a value read from a characteristic.
@@ -23,7 +42,7 @@ public class CharacteristicNotFoundException(
  */
 public class DecodeFailureException(
     public val bytes: ByteArray,
-) : RuntimeException("Decoder rejected ${bytes.size} bytes")
+) : PeripheralCodecException("Decoder rejected ${bytes.size} bytes")
 
 /**
  * Reads a characteristic and decodes the value with [decoder].

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodec.kt
@@ -9,25 +9,51 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlin.uuid.Uuid
 
 /**
+ * Thrown when a service+characteristic UUID pair does not resolve against the
+ * peripheral's discovered services.
+ */
+public class CharacteristicNotFoundException(
+    public val serviceUuid: Uuid,
+    public val characteristicUuid: Uuid,
+) : RuntimeException("Characteristic $characteristicUuid not found in service $serviceUuid")
+
+/**
+ * Thrown when a [Decoder] returns `null` for a value read from a characteristic.
+ * The raw [bytes] are preserved so callers can log or inspect the malformed payload.
+ */
+public class DecodeFailureException(
+    public val bytes: ByteArray,
+) : RuntimeException("Decoder rejected ${bytes.size} bytes")
+
+/**
  * Reads a characteristic and decodes the value with [decoder].
  *
- * Returns `null` if the characteristic is not present after service discovery
- * or if [decoder] returns `null` for the read bytes.
+ * Returns a [Result] so callers can distinguish three outcomes:
+ * - success: decoded value
+ * - failure with [CharacteristicNotFoundException]: characteristic absent
+ * - failure with [DecodeFailureException]: payload rejected by [decoder]
+ * - failure with any other exception thrown by the underlying read (BLE error)
  */
 public suspend fun <T> Peripheral.readAs(
     serviceUuid: Uuid,
     characteristicUuid: Uuid,
     decoder: Decoder<T>,
-): T? {
-    val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return null
-    return decoder.decode(read(char))
+): Result<T> {
+    val char = findCharacteristic(serviceUuid, characteristicUuid)
+        ?: return Result.failure(CharacteristicNotFoundException(serviceUuid, characteristicUuid))
+    return runCatching {
+        val bytes = read(char)
+        decoder.decode(bytes) ?: throw DecodeFailureException(bytes)
+    }
 }
 
 /**
  * Encodes [value] with [encoder] and writes it to a characteristic.
  *
- * Silently no-ops if the characteristic is not present after service discovery;
- * use [Peripheral.findCharacteristic] directly when presence matters to the caller.
+ * Accepts an [Encoder] (not a full [Codec]) because write paths never need a
+ * decoder. Returns [Result.failure] with [CharacteristicNotFoundException] if
+ * the characteristic is absent, or with any exception thrown by the underlying
+ * write (BLE error).
  */
 public suspend fun <T> Peripheral.writeAs(
     serviceUuid: Uuid,
@@ -35,24 +61,32 @@ public suspend fun <T> Peripheral.writeAs(
     value: T,
     encoder: Encoder<T>,
     writeType: WriteType = WriteType.WithResponse,
-) {
-    val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return
-    write(char, encoder.encode(value), writeType)
+): Result<Unit> {
+    val char = findCharacteristic(serviceUuid, characteristicUuid)
+        ?: return Result.failure(CharacteristicNotFoundException(serviceUuid, characteristicUuid))
+    return runCatching { write(char, encoder.encode(value), writeType) }
 }
 
 /**
  * Observes notifications/indications from a characteristic, decoding each
- * payload with [decoder]. Values that fail to decode (decoder returns `null`)
- * are dropped from the stream.
+ * payload with [decoder]. Returns an empty flow if the characteristic is
+ * absent, matching the lenient convention used by built-in SIG profiles
+ * (see [com.atruedev.kmpble.profiles.heartrate.heartRateMeasurements]).
  *
- * Returns an empty flow if the characteristic is not present.
+ * Payloads that fail to decode are routed to [onDecodeFailure] (default no-op)
+ * and dropped from the output stream. Mirrors the [decodeFramed] error model.
  */
 public fun <T> Peripheral.observeAs(
     serviceUuid: Uuid,
     characteristicUuid: Uuid,
     decoder: Decoder<T>,
     backpressure: BackpressureStrategy = BackpressureStrategy.Latest,
+    onDecodeFailure: (ByteArray) -> Unit = {},
 ): Flow<T> {
     val char = findCharacteristic(serviceUuid, characteristicUuid) ?: return emptyFlow()
-    return observeValues(char, backpressure).mapNotNull { decoder.decode(it) }
+    return observeValues(char, backpressure).mapNotNull { bytes ->
+        val decoded = decoder.decode(bytes)
+        if (decoded == null) onDecodeFailure(bytes)
+        decoded
+    }
 }

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriter.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriter.kt
@@ -3,34 +3,38 @@ package com.atruedev.kmpble.profiles.parsing
 /**
  * Little-endian byte builder for constructing BLE characteristic payloads.
  *
- * Dual of [BleByteReader]. Designed to be created, written to linearly, and
+ * Symmetric counterpart to [BleByteReader]: same backing storage strategy
+ * (raw [ByteArray] + cursor), same little-endian semantics, same strict
+ * range validation. Designed to be created, written to linearly, and
  * finalized with [toByteArray] within a single pure encode function.
- * Not thread-safe - not intended to be shared.
  *
- * Range-validates every integer write and throws [IllegalArgumentException]
- * on overflow, matching the strictness of [BleByteReader].
+ * Not thread-safe.
  */
 public class BleByteWriter(initialCapacity: Int = 16) {
-    private val buffer: ArrayList<Byte> = ArrayList(initialCapacity)
+    private var buffer: ByteArray = ByteArray(initialCapacity.coerceAtLeast(1))
 
-    public val size: Int get() = buffer.size
+    public var size: Int = 0
+        private set
 
     public fun writeUInt8(value: Int): BleByteWriter {
         require(value in 0..0xFF) { "uint8 out of range: $value" }
-        buffer.add(value.toByte())
+        ensure(1)
+        buffer[size++] = value.toByte()
         return this
     }
 
     public fun writeInt8(value: Int): BleByteWriter {
         require(value in Byte.MIN_VALUE..Byte.MAX_VALUE) { "int8 out of range: $value" }
-        buffer.add(value.toByte())
+        ensure(1)
+        buffer[size++] = value.toByte()
         return this
     }
 
     public fun writeUInt16(value: Int): BleByteWriter {
         require(value in 0..0xFFFF) { "uint16 out of range: $value" }
-        buffer.add((value and 0xFF).toByte())
-        buffer.add(((value shr 8) and 0xFF).toByte())
+        ensure(2)
+        buffer[size++] = (value and 0xFF).toByte()
+        buffer[size++] = ((value shr 8) and 0xFF).toByte()
         return this
     }
 
@@ -42,21 +46,30 @@ public class BleByteWriter(initialCapacity: Int = 16) {
 
     public fun writeUInt32(value: Long): BleByteWriter {
         require(value in 0..0xFFFFFFFFL) { "uint32 out of range: $value" }
-        buffer.add((value and 0xFF).toByte())
-        buffer.add(((value shr 8) and 0xFF).toByte())
-        buffer.add(((value shr 16) and 0xFF).toByte())
-        buffer.add(((value shr 24) and 0xFF).toByte())
+        ensure(4)
+        buffer[size++] = (value and 0xFF).toByte()
+        buffer[size++] = ((value shr 8) and 0xFF).toByte()
+        buffer[size++] = ((value shr 16) and 0xFF).toByte()
+        buffer[size++] = ((value shr 24) and 0xFF).toByte()
         return this
     }
 
-    public fun writeUtf8(value: String): BleByteWriter {
-        return writeBytes(value.encodeToByteArray())
-    }
+    public fun writeUtf8(value: String): BleByteWriter = writeBytes(value.encodeToByteArray())
 
     public fun writeBytes(bytes: ByteArray): BleByteWriter {
-        for (b in bytes) buffer.add(b)
+        ensure(bytes.size)
+        bytes.copyInto(buffer, size)
+        size += bytes.size
         return this
     }
 
-    public fun toByteArray(): ByteArray = buffer.toByteArray()
+    public fun toByteArray(): ByteArray = buffer.copyOf(size)
+
+    private fun ensure(extra: Int) {
+        val needed = size + extra
+        if (needed <= buffer.size) return
+        var newCap = buffer.size
+        while (newCap < needed) newCap *= 2
+        buffer = buffer.copyOf(newCap)
+    }
 }

--- a/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriter.kt
+++ b/kmp-ble-profiles/src/commonMain/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriter.kt
@@ -1,0 +1,62 @@
+package com.atruedev.kmpble.profiles.parsing
+
+/**
+ * Little-endian byte builder for constructing BLE characteristic payloads.
+ *
+ * Dual of [BleByteReader]. Designed to be created, written to linearly, and
+ * finalized with [toByteArray] within a single pure encode function.
+ * Not thread-safe - not intended to be shared.
+ *
+ * Range-validates every integer write and throws [IllegalArgumentException]
+ * on overflow, matching the strictness of [BleByteReader].
+ */
+public class BleByteWriter(initialCapacity: Int = 16) {
+    private val buffer: ArrayList<Byte> = ArrayList(initialCapacity)
+
+    public val size: Int get() = buffer.size
+
+    public fun writeUInt8(value: Int): BleByteWriter {
+        require(value in 0..0xFF) { "uint8 out of range: $value" }
+        buffer.add(value.toByte())
+        return this
+    }
+
+    public fun writeInt8(value: Int): BleByteWriter {
+        require(value in Byte.MIN_VALUE..Byte.MAX_VALUE) { "int8 out of range: $value" }
+        buffer.add(value.toByte())
+        return this
+    }
+
+    public fun writeUInt16(value: Int): BleByteWriter {
+        require(value in 0..0xFFFF) { "uint16 out of range: $value" }
+        buffer.add((value and 0xFF).toByte())
+        buffer.add(((value shr 8) and 0xFF).toByte())
+        return this
+    }
+
+    public fun writeInt16(value: Int): BleByteWriter {
+        require(value in Short.MIN_VALUE..Short.MAX_VALUE) { "int16 out of range: $value" }
+        val unsigned = if (value < 0) value + 0x10000 else value
+        return writeUInt16(unsigned)
+    }
+
+    public fun writeUInt32(value: Long): BleByteWriter {
+        require(value in 0..0xFFFFFFFFL) { "uint32 out of range: $value" }
+        buffer.add((value and 0xFF).toByte())
+        buffer.add(((value shr 8) and 0xFF).toByte())
+        buffer.add(((value shr 16) and 0xFF).toByte())
+        buffer.add(((value shr 24) and 0xFF).toByte())
+        return this
+    }
+
+    public fun writeUtf8(value: String): BleByteWriter {
+        return writeBytes(value.encodeToByteArray())
+    }
+
+    public fun writeBytes(bytes: ByteArray): BleByteWriter {
+        for (b in bytes) buffer.add(b)
+        return this
+    }
+
+    public fun toByteArray(): ByteArray = buffer.toByteArray()
+}

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
@@ -39,6 +39,12 @@ class CodecsTest {
     }
 
     @Test
+    fun utf8DecodeReturnsNullOnInvalidSequence() {
+        val invalid = byteArrayOf(0xC3.toByte(), 0x28)
+        assertNull(Utf8StringCodec.decode(invalid))
+    }
+
+    @Test
     fun uint8RoundTrips() {
         for (v in 0..255) {
             val encoded = Uint8Codec.encode(v)
@@ -48,14 +54,36 @@ class CodecsTest {
     }
 
     @Test
-    fun uint8DecodeEmptyReturnsNull() {
+    fun uint8DecodeRejectsWrongSize() {
         assertNull(Uint8Codec.decode(byteArrayOf()))
+        assertNull(Uint8Codec.decode(byteArrayOf(0x01, 0x02)))
     }
 
     @Test
     fun uint8EncodeRejectsOutOfRange() {
         assertFails { Uint8Codec.encode(-1) }
         assertFails { Uint8Codec.encode(256) }
+    }
+
+    @Test
+    fun int8RoundTripsAcrossFullRange() {
+        for (v in -128..127) {
+            val encoded = Int8Codec.encode(v)
+            assertEquals(1, encoded.size)
+            assertEquals(v, Int8Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun int8DecodeRejectsWrongSize() {
+        assertNull(Int8Codec.decode(byteArrayOf()))
+        assertNull(Int8Codec.decode(byteArrayOf(0x01, 0x02)))
+    }
+
+    @Test
+    fun int8EncodeRejectsOutOfRange() {
+        assertFails { Int8Codec.encode(-129) }
+        assertFails { Int8Codec.encode(128) }
     }
 
     @Test
@@ -68,25 +96,42 @@ class CodecsTest {
     }
 
     @Test
-    fun uint16IsLittleEndian() {
-        assertContentEquals(byteArrayOf(0x80.toByte(), 0x01), Uint16Codec.encode(384))
-    }
-
-    @Test
-    fun uint16DecodeShortReturnsNull() {
+    fun uint16DecodeRejectsWrongSize() {
         assertNull(Uint16Codec.decode(byteArrayOf()))
         assertNull(Uint16Codec.decode(byteArrayOf(0x01)))
-    }
-
-    @Test
-    fun uint16DecodeIgnoresExtraBytes() {
-        assertEquals(384, Uint16Codec.decode(byteArrayOf(0x80.toByte(), 0x01, 0xFF.toByte())))
+        assertNull(Uint16Codec.decode(byteArrayOf(0x01, 0x02, 0x03)))
     }
 
     @Test
     fun uint16EncodeRejectsOutOfRange() {
         assertFails { Uint16Codec.encode(-1) }
         assertFails { Uint16Codec.encode(0x10000) }
+    }
+
+    @Test
+    fun int16RoundTrips() {
+        for (v in listOf(Short.MIN_VALUE.toInt(), -1, 0, 1, Short.MAX_VALUE.toInt())) {
+            val encoded = Int16Codec.encode(v)
+            assertEquals(2, encoded.size)
+            assertEquals(v, Int16Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun int16DecodeNegative() {
+        assertEquals(-1, Int16Codec.decode(byteArrayOf(0xFF.toByte(), 0xFF.toByte())))
+    }
+
+    @Test
+    fun int16DecodeRejectsWrongSize() {
+        assertNull(Int16Codec.decode(byteArrayOf(0x01)))
+        assertNull(Int16Codec.decode(byteArrayOf(0x01, 0x02, 0x03)))
+    }
+
+    @Test
+    fun int16EncodeRejectsOutOfRange() {
+        assertFails { Int16Codec.encode(-32769) }
+        assertFails { Int16Codec.encode(32768) }
     }
 
     @Test
@@ -99,13 +144,9 @@ class CodecsTest {
     }
 
     @Test
-    fun uint32IsLittleEndian() {
-        assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), Uint32Codec.encode(0x12345678L))
-    }
-
-    @Test
-    fun uint32DecodeShortReturnsNull() {
+    fun uint32DecodeRejectsWrongSize() {
         assertNull(Uint32Codec.decode(byteArrayOf(0x01, 0x02, 0x03)))
+        assertNull(Uint32Codec.decode(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)))
     }
 
     @Test
@@ -115,10 +156,21 @@ class CodecsTest {
     }
 
     @Test
-    fun samConversion() {
-        val decoder = Decoder { bytes -> bytes.size }
-        val encoder = Encoder<Int> { value -> ByteArray(value) }
-        assertEquals(3, decoder.decode(byteArrayOf(1, 2, 3)))
-        assertEquals(5, encoder.encode(5).size)
+    fun int32RoundTrips() {
+        for (v in listOf(Int.MIN_VALUE, -1, 0, 1, Int.MAX_VALUE)) {
+            val encoded = Int32Codec.encode(v)
+            assertEquals(4, encoded.size)
+            assertEquals(v, Int32Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun int32IsLittleEndian() {
+        assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), Int32Codec.encode(0x12345678))
+    }
+
+    @Test
+    fun int32DecodeRejectsWrongSize() {
+        assertNull(Int32Codec.decode(byteArrayOf(0x01, 0x02, 0x03)))
     }
 }

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
@@ -1,0 +1,127 @@
+package com.atruedev.kmpble.profiles.codec
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNull
+
+class CodecsTest {
+
+    @Test
+    fun rawBytesRoundTrips() {
+        val original = byteArrayOf(0x01, 0x02, 0x03)
+        val encoded = RawBytesCodec.encode(original)
+        val decoded = RawBytesCodec.decode(encoded)
+        assertContentEquals(original, decoded)
+    }
+
+    @Test
+    fun rawBytesEncodeIsDefensiveCopy() {
+        val original = byteArrayOf(0x01, 0x02)
+        val encoded = RawBytesCodec.encode(original)
+        original[0] = 0xFF.toByte()
+        assertContentEquals(byteArrayOf(0x01, 0x02), encoded)
+    }
+
+    @Test
+    fun rawBytesDecodeIsDefensiveCopy() {
+        val source = byteArrayOf(0x01, 0x02)
+        val decoded = RawBytesCodec.decode(source)
+        source[0] = 0xFF.toByte()
+        assertContentEquals(byteArrayOf(0x01, 0x02), decoded)
+    }
+
+    @Test
+    fun utf8RoundTrips() {
+        val encoded = Utf8StringCodec.encode("Hello, 世界")
+        assertEquals("Hello, 世界", Utf8StringCodec.decode(encoded))
+    }
+
+    @Test
+    fun uint8RoundTrips() {
+        for (v in 0..255) {
+            val encoded = Uint8Codec.encode(v)
+            assertEquals(1, encoded.size)
+            assertEquals(v, Uint8Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun uint8DecodeEmptyReturnsNull() {
+        assertNull(Uint8Codec.decode(byteArrayOf()))
+    }
+
+    @Test
+    fun uint8EncodeRejectsOutOfRange() {
+        assertFails { Uint8Codec.encode(-1) }
+        assertFails { Uint8Codec.encode(256) }
+    }
+
+    @Test
+    fun uint16RoundTrips() {
+        for (v in listOf(0, 1, 255, 256, 384, 0xFFFF)) {
+            val encoded = Uint16Codec.encode(v)
+            assertEquals(2, encoded.size)
+            assertEquals(v, Uint16Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun uint16IsLittleEndian() {
+        // 384 = 0x0180 → 0x80, 0x01
+        assertContentEquals(byteArrayOf(0x80.toByte(), 0x01), Uint16Codec.encode(384))
+    }
+
+    @Test
+    fun uint16DecodeShortReturnsNull() {
+        assertNull(Uint16Codec.decode(byteArrayOf()))
+        assertNull(Uint16Codec.decode(byteArrayOf(0x01)))
+    }
+
+    @Test
+    fun uint16DecodeIgnoresExtraBytes() {
+        assertEquals(384, Uint16Codec.decode(byteArrayOf(0x80.toByte(), 0x01, 0xFF.toByte())))
+    }
+
+    @Test
+    fun uint16EncodeRejectsOutOfRange() {
+        assertFails { Uint16Codec.encode(-1) }
+        assertFails { Uint16Codec.encode(0x10000) }
+    }
+
+    @Test
+    fun uint32RoundTrips() {
+        for (v in listOf(0L, 1L, 0xFFFFL, 0x12345678L, 0xFFFFFFFFL)) {
+            val encoded = Uint32Codec.encode(v)
+            assertEquals(4, encoded.size)
+            assertEquals(v, Uint32Codec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun uint32IsLittleEndian() {
+        // 0x12345678 → 0x78, 0x56, 0x34, 0x12
+        assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), Uint32Codec.encode(0x12345678L))
+    }
+
+    @Test
+    fun uint32DecodeShortReturnsNull() {
+        assertNull(Uint32Codec.decode(byteArrayOf(0x01, 0x02, 0x03)))
+    }
+
+    @Test
+    fun uint32EncodeRejectsOutOfRange() {
+        assertFails { Uint32Codec.encode(-1L) }
+        assertFails { Uint32Codec.encode(0x1_0000_0000L) }
+    }
+
+    /** Sanity check: SAM conversions allow lambda construction. */
+    @Test
+    fun samConversion() {
+        val decoder = Decoder { bytes -> bytes.size }
+        val encoder = Encoder<Int> { value -> ByteArray(value) }
+        assertEquals(3, decoder.decode(byteArrayOf(1, 2, 3)))
+        assertEquals(5, encoder.encode(5).size)
+    }
+}

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/CodecsTest.kt
@@ -69,7 +69,6 @@ class CodecsTest {
 
     @Test
     fun uint16IsLittleEndian() {
-        // 384 = 0x0180 → 0x80, 0x01
         assertContentEquals(byteArrayOf(0x80.toByte(), 0x01), Uint16Codec.encode(384))
     }
 
@@ -101,7 +100,6 @@ class CodecsTest {
 
     @Test
     fun uint32IsLittleEndian() {
-        // 0x12345678 → 0x78, 0x56, 0x34, 0x12
         assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), Uint32Codec.encode(0x12345678L))
     }
 
@@ -116,7 +114,6 @@ class CodecsTest {
         assertFails { Uint32Codec.encode(0x1_0000_0000L) }
     }
 
-    /** Sanity check: SAM conversions allow lambda construction. */
     @Test
     fun samConversion() {
         val decoder = Decoder { bytes -> bytes.size }

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
@@ -14,7 +14,6 @@ class FlowFramingTest {
         val framer = LengthPrefixFramer()
         val frame1 = framer.frame(byteArrayOf(0x01, 0x02))
         val frame2 = framer.frame(byteArrayOf(0x03))
-        // Chunk boundary inside frame1's payload
         val chunks = listOf(
             frame1.copyOfRange(0, 5),
             frame1.copyOfRange(5, frame1.size) + frame2,
@@ -37,7 +36,6 @@ class FlowFramingTest {
     @Test
     fun decodeFramedDropsFramesThatFailToDecode() = runTest {
         val framer = LengthPrefixFramer()
-        // Uint16Codec.decode returns null for inputs shorter than 2 bytes
         val good = framer.frame(Uint16Codec.encode(7))
         val bad = framer.frame(byteArrayOf(0x01))
         val stream = bad + good
@@ -49,7 +47,6 @@ class FlowFramingTest {
     fun decodeFramedHandlesIncrementalChunks() = runTest {
         val framer = LengthPrefixFramer()
         val framed = framer.frame(Uint16Codec.encode(0x1234))
-        // Split into single-byte chunks
         val chunks = Array(framed.size) { byteArrayOf(framed[it]) }
         val values = flowOf(*chunks).decodeFramed(Uint16Codec, framer).toList()
         assertEquals(listOf(0x1234), values)
@@ -58,7 +55,6 @@ class FlowFramingTest {
     @Test
     fun unframedByDropsTrailingPartialFrame() = runTest {
         val framer = LengthPrefixFramer()
-        // Only the header, payload never arrives
         val partial = byteArrayOf(0x05, 0x00, 0x00, 0x00, 0x01, 0x02)
         val frames = flowOf(partial).unframedBy(framer.unframer()).toList()
         assertEquals(emptyList(), frames)

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
@@ -1,11 +1,15 @@
 package com.atruedev.kmpble.profiles.codec
 
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FlowFramingTest {
 
@@ -18,7 +22,7 @@ class FlowFramingTest {
             frame1.copyOfRange(0, 5),
             frame1.copyOfRange(5, frame1.size) + frame2,
         )
-        val frames = flowOf(*chunks.toTypedArray()).unframedBy(framer.unframer()).toList()
+        val frames = flowOf(*chunks.toTypedArray()).unframedBy(framer).toList()
         assertEquals(2, frames.size)
         assertContentEquals(byteArrayOf(0x01, 0x02), frames[0])
         assertContentEquals(byteArrayOf(0x03), frames[1])
@@ -34,13 +38,27 @@ class FlowFramingTest {
     }
 
     @Test
-    fun decodeFramedDropsFramesThatFailToDecode() = runTest {
+    fun decodeFramedRoutesFailuresToCallback() = runTest {
         val framer = LengthPrefixFramer()
         val good = framer.frame(Uint16Codec.encode(7))
-        val bad = framer.frame(byteArrayOf(0x01))
-        val stream = bad + good
-        val values = flowOf(stream).decodeFramed(Uint16Codec, framer).toList()
+        val malformed = framer.frame(byteArrayOf(0x01))
+        val stream = malformed + good
+        val failures = mutableListOf<ByteArray>()
+        val values = flowOf(stream)
+            .decodeFramed(Uint16Codec, framer, onDecodeFailure = { failures.add(it) })
+            .toList()
         assertEquals(listOf(7), values)
+        assertEquals(1, failures.size)
+        assertContentEquals(byteArrayOf(0x01), failures[0])
+    }
+
+    @Test
+    fun decodeFramedDefaultDropsFailuresSilently() = runTest {
+        val framer = LengthPrefixFramer()
+        val malformed = framer.frame(byteArrayOf(0x01))
+        val good = framer.frame(Uint16Codec.encode(42))
+        val values = flowOf(malformed + good).decodeFramed(Uint16Codec, framer).toList()
+        assertEquals(listOf(42), values)
     }
 
     @Test
@@ -56,7 +74,43 @@ class FlowFramingTest {
     fun unframedByDropsTrailingPartialFrame() = runTest {
         val framer = LengthPrefixFramer()
         val partial = byteArrayOf(0x05, 0x00, 0x00, 0x00, 0x01, 0x02)
-        val frames = flowOf(partial).unframedBy(framer.unframer()).toList()
+        val frames = flowOf(partial).unframedBy(framer).toList()
         assertEquals(emptyList(), frames)
+    }
+
+    @Test
+    fun frameTooLargeExceptionPropagatesThroughFlow() = runTest {
+        val framer = LengthPrefixFramer(maxFrameSize = 2)
+        val bad = byteArrayOf(0x03, 0x00, 0x00, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
+        var caught: Throwable? = null
+        flowOf(bad)
+            .unframedBy(framer)
+            .catch { caught = it }
+            .toList()
+        assertTrue(caught is FrameTooLargeException)
+        assertEquals(3L, (caught as FrameTooLargeException).size)
+    }
+
+    @Test
+    fun flowCancellationMidStreamLeavesNoRemnantState() = runTest {
+        val framer = LengthPrefixFramer()
+        val source = flow {
+            emit(framer.frame(byteArrayOf(0x01)))
+            emit(framer.frame(byteArrayOf(0x02)))
+            emit(framer.frame(byteArrayOf(0x03)))
+        }
+        val received = source.unframedBy(framer).take(1).toList()
+        assertEquals(1, received.size)
+        assertContentEquals(byteArrayOf(0x01), received[0])
+    }
+
+    @Test
+    fun framerInstanceIsReusableAcrossCollections() = runTest {
+        val framer = LengthPrefixFramer()
+        val stream = framer.frame(byteArrayOf(0x77))
+        val first = flowOf(stream).unframedBy(framer).toList()
+        val second = flowOf(stream).unframedBy(framer).toList()
+        assertContentEquals(byteArrayOf(0x77), first.single())
+        assertContentEquals(byteArrayOf(0x77), second.single())
     }
 }

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FlowFramingTest.kt
@@ -1,0 +1,66 @@
+package com.atruedev.kmpble.profiles.codec
+
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class FlowFramingTest {
+
+    @Test
+    fun unframedByEmitsFramesFromChunkedStream() = runTest {
+        val framer = LengthPrefixFramer()
+        val frame1 = framer.frame(byteArrayOf(0x01, 0x02))
+        val frame2 = framer.frame(byteArrayOf(0x03))
+        // Chunk boundary inside frame1's payload
+        val chunks = listOf(
+            frame1.copyOfRange(0, 5),
+            frame1.copyOfRange(5, frame1.size) + frame2,
+        )
+        val frames = flowOf(*chunks.toTypedArray()).unframedBy(framer.unframer()).toList()
+        assertEquals(2, frames.size)
+        assertContentEquals(byteArrayOf(0x01, 0x02), frames[0])
+        assertContentEquals(byteArrayOf(0x03), frames[1])
+    }
+
+    @Test
+    fun decodeFramedReturnsDecodedValues() = runTest {
+        val framer = LengthPrefixFramer()
+        val stream = framer.frame(Uint16Codec.encode(42)) +
+            framer.frame(Uint16Codec.encode(0xCAFE))
+        val values = flowOf(stream).decodeFramed(Uint16Codec, framer).toList()
+        assertEquals(listOf(42, 0xCAFE), values)
+    }
+
+    @Test
+    fun decodeFramedDropsFramesThatFailToDecode() = runTest {
+        val framer = LengthPrefixFramer()
+        // Uint16Codec.decode returns null for inputs shorter than 2 bytes
+        val good = framer.frame(Uint16Codec.encode(7))
+        val bad = framer.frame(byteArrayOf(0x01))
+        val stream = bad + good
+        val values = flowOf(stream).decodeFramed(Uint16Codec, framer).toList()
+        assertEquals(listOf(7), values)
+    }
+
+    @Test
+    fun decodeFramedHandlesIncrementalChunks() = runTest {
+        val framer = LengthPrefixFramer()
+        val framed = framer.frame(Uint16Codec.encode(0x1234))
+        // Split into single-byte chunks
+        val chunks = Array(framed.size) { byteArrayOf(framed[it]) }
+        val values = flowOf(*chunks).decodeFramed(Uint16Codec, framer).toList()
+        assertEquals(listOf(0x1234), values)
+    }
+
+    @Test
+    fun unframedByDropsTrailingPartialFrame() = runTest {
+        val framer = LengthPrefixFramer()
+        // Only the header, payload never arrives
+        val partial = byteArrayOf(0x05, 0x00, 0x00, 0x00, 0x01, 0x02)
+        val frames = flowOf(partial).unframedBy(framer.unframer()).toList()
+        assertEquals(emptyList(), frames)
+    }
+}

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
@@ -11,7 +11,6 @@ class FramingTest {
     @Test
     fun frameEmptyPayload() {
         val framed = LengthPrefixFramer().frame(byteArrayOf())
-        // length=0 → 0x00 0x00 0x00 0x00, no payload
         assertContentEquals(byteArrayOf(0, 0, 0, 0), framed)
     }
 
@@ -19,7 +18,6 @@ class FramingTest {
     fun frameLengthIsLittleEndianUint32() {
         val payload = ByteArray(0x180) { it.toByte() }
         val framed = LengthPrefixFramer().frame(payload)
-        // length=0x180 → 0x80, 0x01, 0x00, 0x00
         assertEquals(0x80.toByte(), framed[0])
         assertEquals(0x01.toByte(), framed[1])
         assertEquals(0x00.toByte(), framed[2])
@@ -30,7 +28,7 @@ class FramingTest {
     @Test
     fun frameRejectsPayloadLargerThanCap() {
         val framer = LengthPrefixFramer(maxFrameSize = 4)
-        framer.frame(ByteArray(4))   // boundary OK
+        framer.frame(ByteArray(4))
         assertFailsWith<IllegalArgumentException> { framer.frame(ByteArray(5)) }
     }
 
@@ -59,7 +57,6 @@ class FramingTest {
         val framer = LengthPrefixFramer()
         val framed = framer.frame(byteArrayOf(0x42))
         val unframer = framer.unframer()
-        // Feed bytes one at a time
         for (i in 0 until framed.size - 1) {
             assertEquals(emptyList(), unframer.feed(byteArrayOf(framed[i])))
         }
@@ -73,7 +70,6 @@ class FramingTest {
         val framer = LengthPrefixFramer()
         val framed = framer.frame(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05))
         val unframer = framer.unframer()
-        // Split after byte 6 (header + 2 payload bytes)
         assertEquals(emptyList(), unframer.feed(framed.copyOfRange(0, 6)))
         val frames = unframer.feed(framed.copyOfRange(6, framed.size))
         assertEquals(1, frames.size)
@@ -93,11 +89,9 @@ class FramingTest {
         val second = framer.frame(byteArrayOf(0x02, 0x03))
         val combined = first + second
         val unframer = framer.unframer()
-        // Feed first frame + 3 bytes of second frame's header
         val frames1 = unframer.feed(combined.copyOfRange(0, first.size + 3))
         assertEquals(1, frames1.size)
         assertContentEquals(byteArrayOf(0x01), frames1[0])
-        // Feed remaining bytes
         val frames2 = unframer.feed(combined.copyOfRange(first.size + 3, combined.size))
         assertEquals(1, frames2.size)
         assertContentEquals(byteArrayOf(0x02, 0x03), frames2[0])
@@ -106,7 +100,6 @@ class FramingTest {
     @Test
     fun unframerThrowsOnFrameLargerThanCap() {
         val framer = LengthPrefixFramer(maxFrameSize = 2)
-        // Manually craft a frame claiming length=3
         val bad = byteArrayOf(0x03, 0x00, 0x00, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
         val ex = assertFailsWith<FrameTooLargeException> { framer.unframer().feed(bad) }
         assertEquals(3L, ex.size)

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
@@ -1,0 +1,141 @@
+package com.atruedev.kmpble.profiles.codec
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FramingTest {
+
+    @Test
+    fun frameEmptyPayload() {
+        val framed = LengthPrefixFramer().frame(byteArrayOf())
+        // length=0 → 0x00 0x00 0x00 0x00, no payload
+        assertContentEquals(byteArrayOf(0, 0, 0, 0), framed)
+    }
+
+    @Test
+    fun frameLengthIsLittleEndianUint32() {
+        val payload = ByteArray(0x180) { it.toByte() }
+        val framed = LengthPrefixFramer().frame(payload)
+        // length=0x180 → 0x80, 0x01, 0x00, 0x00
+        assertEquals(0x80.toByte(), framed[0])
+        assertEquals(0x01.toByte(), framed[1])
+        assertEquals(0x00.toByte(), framed[2])
+        assertEquals(0x00.toByte(), framed[3])
+        assertEquals(payload.size + 4, framed.size)
+    }
+
+    @Test
+    fun frameRejectsPayloadLargerThanCap() {
+        val framer = LengthPrefixFramer(maxFrameSize = 4)
+        framer.frame(ByteArray(4))   // boundary OK
+        assertFailsWith<IllegalArgumentException> { framer.frame(ByteArray(5)) }
+    }
+
+    @Test
+    fun unframerSingleCompleteFrameInOneFeed() {
+        val framer = LengthPrefixFramer()
+        val payload = byteArrayOf(0x01, 0x02, 0x03)
+        val framed = framer.frame(payload)
+        val frames = framer.unframer().feed(framed)
+        assertEquals(1, frames.size)
+        assertContentEquals(payload, frames[0])
+    }
+
+    @Test
+    fun unframerMultipleFramesInOneFeed() {
+        val framer = LengthPrefixFramer()
+        val combined = framer.frame(byteArrayOf(0x0A)) + framer.frame(byteArrayOf(0x0B, 0x0C))
+        val frames = framer.unframer().feed(combined)
+        assertEquals(2, frames.size)
+        assertContentEquals(byteArrayOf(0x0A), frames[0])
+        assertContentEquals(byteArrayOf(0x0B, 0x0C), frames[1])
+    }
+
+    @Test
+    fun unframerPartialHeaderBuffersUntilComplete() {
+        val framer = LengthPrefixFramer()
+        val framed = framer.frame(byteArrayOf(0x42))
+        val unframer = framer.unframer()
+        // Feed bytes one at a time
+        for (i in 0 until framed.size - 1) {
+            assertEquals(emptyList(), unframer.feed(byteArrayOf(framed[i])))
+        }
+        val frames = unframer.feed(byteArrayOf(framed.last()))
+        assertEquals(1, frames.size)
+        assertContentEquals(byteArrayOf(0x42), frames[0])
+    }
+
+    @Test
+    fun unframerSplitAcrossFeeds() {
+        val framer = LengthPrefixFramer()
+        val framed = framer.frame(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05))
+        val unframer = framer.unframer()
+        // Split after byte 6 (header + 2 payload bytes)
+        assertEquals(emptyList(), unframer.feed(framed.copyOfRange(0, 6)))
+        val frames = unframer.feed(framed.copyOfRange(6, framed.size))
+        assertEquals(1, frames.size)
+        assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05), frames[0])
+    }
+
+    @Test
+    fun unframerHandlesEmptyFeed() {
+        val unframer = LengthPrefixFramer().unframer()
+        assertEquals(emptyList(), unframer.feed(byteArrayOf()))
+    }
+
+    @Test
+    fun unframerLeavesPartialTailForNextFeed() {
+        val framer = LengthPrefixFramer()
+        val first = framer.frame(byteArrayOf(0x01))
+        val second = framer.frame(byteArrayOf(0x02, 0x03))
+        val combined = first + second
+        val unframer = framer.unframer()
+        // Feed first frame + 3 bytes of second frame's header
+        val frames1 = unframer.feed(combined.copyOfRange(0, first.size + 3))
+        assertEquals(1, frames1.size)
+        assertContentEquals(byteArrayOf(0x01), frames1[0])
+        // Feed remaining bytes
+        val frames2 = unframer.feed(combined.copyOfRange(first.size + 3, combined.size))
+        assertEquals(1, frames2.size)
+        assertContentEquals(byteArrayOf(0x02, 0x03), frames2[0])
+    }
+
+    @Test
+    fun unframerThrowsOnFrameLargerThanCap() {
+        val framer = LengthPrefixFramer(maxFrameSize = 2)
+        // Manually craft a frame claiming length=3
+        val bad = byteArrayOf(0x03, 0x00, 0x00, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
+        val ex = assertFailsWith<FrameTooLargeException> { framer.unframer().feed(bad) }
+        assertEquals(3L, ex.size)
+        assertEquals(2, ex.maxSize)
+    }
+
+    @Test
+    fun unframerHandlesZeroLengthFrame() {
+        val framer = LengthPrefixFramer()
+        val framed = framer.frame(byteArrayOf())
+        val frames = framer.unframer().feed(framed)
+        assertEquals(1, frames.size)
+        assertTrue(frames[0].isEmpty())
+    }
+
+    @Test
+    fun roundTripPreservesPayload() {
+        val framer = LengthPrefixFramer()
+        val payloads = listOf(
+            byteArrayOf(),
+            byteArrayOf(0x42),
+            ByteArray(100) { it.toByte() },
+            ByteArray(1024) { (it * 7).toByte() },
+        )
+        val stream = payloads.fold(byteArrayOf()) { acc, p -> acc + framer.frame(p) }
+        val frames = framer.unframer().feed(stream)
+        assertEquals(payloads.size, frames.size)
+        payloads.zip(frames).forEach { (expected, actual) ->
+            assertContentEquals(expected, actual)
+        }
+    }
+}

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/FramingTest.kt
@@ -131,4 +131,44 @@ class FramingTest {
             assertContentEquals(expected, actual)
         }
     }
+
+    @Test
+    fun pendingBytesReflectsBufferedTail() {
+        val framer = LengthPrefixFramer()
+        val unframer = framer.unframer()
+        assertEquals(0, unframer.pendingBytes())
+        unframer.feed(byteArrayOf(0x05, 0x00, 0x00, 0x00, 0x01, 0x02))
+        assertEquals(6, unframer.pendingBytes())
+        unframer.feed(byteArrayOf(0x03, 0x04, 0x05))
+        assertEquals(0, unframer.pendingBytes())
+    }
+
+    @Test
+    fun unframerHandles1ByteChunksForLargeFrameInLinearTime() {
+        val framer = LengthPrefixFramer(maxFrameSize = 200_000)
+        val payload = ByteArray(100_000) { (it and 0xFF).toByte() }
+        val framed = framer.frame(payload)
+        val unframer = framer.unframer()
+        var collected: ByteArray? = null
+        for (i in 0 until framed.size - 1) {
+            val out = unframer.feed(byteArrayOf(framed[i]))
+            if (out.isNotEmpty()) {
+                collected = out[0]
+                break
+            }
+        }
+        if (collected == null) {
+            val tail = unframer.feed(byteArrayOf(framed.last()))
+            collected = tail.single()
+        }
+        assertContentEquals(payload, collected)
+    }
+
+    @Test
+    fun defaultCapIs64KiB() {
+        assertEquals(64 * 1024, LengthPrefixFramer.DEFAULT_MAX_FRAME_SIZE)
+        val framer = LengthPrefixFramer()
+        framer.frame(ByteArray(64 * 1024))
+        assertFailsWith<IllegalArgumentException> { framer.frame(ByteArray(64 * 1024 + 1)) }
+    }
 }

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodecTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodecTest.kt
@@ -5,14 +5,15 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class PeripheralCodecTest {
 
     @Test
-    fun readAsDecodesValue() = runTest {
+    fun readAsReturnsSuccessWithDecodedValue() = runTest {
         val peripheral = FakePeripheral {
             service("180f") {
                 characteristic("2a19") {
@@ -22,19 +23,23 @@ class PeripheralCodecTest {
             }
         }
         peripheral.connect()
-        val level = peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec)
-        assertEquals(0x55, level)
+        val result = peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec)
+        assertEquals(0x55, result.getOrThrow())
     }
 
     @Test
-    fun readAsReturnsNullWhenCharacteristicMissing() = runTest {
+    fun readAsFailsWithCharacteristicNotFoundWhenMissing() = runTest {
         val peripheral = FakePeripheral {}
         peripheral.connect()
-        assertNull(peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec))
+        val result = peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec)
+        val ex = result.exceptionOrNull()
+        assertIs<CharacteristicNotFoundException>(ex)
+        assertEquals(uuid("180f"), ex.serviceUuid)
+        assertEquals(uuid("2a19"), ex.characteristicUuid)
     }
 
     @Test
-    fun readAsReturnsNullWhenDecoderFails() = runTest {
+    fun readAsFailsWithDecodeFailureWhenDecoderReturnsNull() = runTest {
         val peripheral = FakePeripheral {
             service("180f") {
                 characteristic("2a19") {
@@ -44,11 +49,14 @@ class PeripheralCodecTest {
             }
         }
         peripheral.connect()
-        assertNull(peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec))
+        val result = peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec)
+        val ex = result.exceptionOrNull()
+        assertIs<DecodeFailureException>(ex)
+        assertEquals(0, ex.bytes.size)
     }
 
     @Test
-    fun writeAsEncodesAndWrites() = runTest {
+    fun writeAsReturnsSuccessAndEncodesValue() = runTest {
         var received: ByteArray? = null
         val peripheral = FakePeripheral {
             service("180f") {
@@ -59,15 +67,17 @@ class PeripheralCodecTest {
             }
         }
         peripheral.connect()
-        peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
-        assertEquals(0xAB.toByte(), received?.get(0))
+        val result = peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
+        assertTrue(result.isSuccess)
+        assertContentEquals(byteArrayOf(0xAB.toByte()), received)
     }
 
     @Test
-    fun writeAsNoOpsWhenCharacteristicMissing() = runTest {
+    fun writeAsFailsWithCharacteristicNotFoundWhenMissing() = runTest {
         val peripheral = FakePeripheral {}
         peripheral.connect()
-        peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
+        val result = peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
+        assertIs<CharacteristicNotFoundException>(result.exceptionOrNull())
     }
 
     @Test
@@ -86,7 +96,7 @@ class PeripheralCodecTest {
     }
 
     @Test
-    fun observeAsSkipsDecodeFailures() = runTest {
+    fun observeAsRoutesDecodeFailuresToCallback() = runTest {
         val peripheral = FakePeripheral {
             service("180f") {
                 characteristic("2a19") {
@@ -98,8 +108,19 @@ class PeripheralCodecTest {
             }
         }
         peripheral.connect()
-        val values = peripheral.observeAs(uuid("180f"), uuid("2a19"), Uint8Codec).toList()
+        val failures = mutableListOf<ByteArray>()
+        val values = peripheral
+            .observeAs(
+                uuid("180f"),
+                uuid("2a19"),
+                Uint8Codec,
+                backpressure = com.atruedev.kmpble.gatt.BackpressureStrategy.Unbounded,
+                onDecodeFailure = { failures.add(it) },
+            )
+            .toList()
         assertEquals(listOf(0x10, 0x20), values)
+        assertEquals(1, failures.size)
+        assertEquals(0, failures[0].size)
     }
 
     @Test

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodecTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/codec/PeripheralCodecTest.kt
@@ -1,0 +1,114 @@
+package com.atruedev.kmpble.profiles.codec
+
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PeripheralCodecTest {
+
+    @Test
+    fun readAsDecodesValue() = runTest {
+        val peripheral = FakePeripheral {
+            service("180f") {
+                characteristic("2a19") {
+                    properties(read = true)
+                    onRead { byteArrayOf(0x55) }
+                }
+            }
+        }
+        peripheral.connect()
+        val level = peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec)
+        assertEquals(0x55, level)
+    }
+
+    @Test
+    fun readAsReturnsNullWhenCharacteristicMissing() = runTest {
+        val peripheral = FakePeripheral {}
+        peripheral.connect()
+        assertNull(peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec))
+    }
+
+    @Test
+    fun readAsReturnsNullWhenDecoderFails() = runTest {
+        val peripheral = FakePeripheral {
+            service("180f") {
+                characteristic("2a19") {
+                    properties(read = true)
+                    onRead { byteArrayOf() }
+                }
+            }
+        }
+        peripheral.connect()
+        assertNull(peripheral.readAs(uuid("180f"), uuid("2a19"), Uint8Codec))
+    }
+
+    @Test
+    fun writeAsEncodesAndWrites() = runTest {
+        var received: ByteArray? = null
+        val peripheral = FakePeripheral {
+            service("180f") {
+                characteristic("2a19") {
+                    properties(write = true)
+                    onWrite { bytes, _ -> received = bytes }
+                }
+            }
+        }
+        peripheral.connect()
+        peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
+        assertEquals(0xAB.toByte(), received?.get(0))
+    }
+
+    @Test
+    fun writeAsNoOpsWhenCharacteristicMissing() = runTest {
+        val peripheral = FakePeripheral {}
+        peripheral.connect()
+        peripheral.writeAs(uuid("180f"), uuid("2a19"), 0xAB, Uint8Codec)
+    }
+
+    @Test
+    fun observeAsDecodesNotifications() = runTest {
+        val peripheral = FakePeripheral {
+            service("180f") {
+                characteristic("2a19") {
+                    properties(notify = true)
+                    onObserve { flowOf(byteArrayOf(0x10), byteArrayOf(0x20)) }
+                }
+            }
+        }
+        peripheral.connect()
+        val values = peripheral.observeAs(uuid("180f"), uuid("2a19"), Uint8Codec).toList()
+        assertEquals(listOf(0x10, 0x20), values)
+    }
+
+    @Test
+    fun observeAsSkipsDecodeFailures() = runTest {
+        val peripheral = FakePeripheral {
+            service("180f") {
+                characteristic("2a19") {
+                    properties(notify = true)
+                    onObserve {
+                        flowOf(byteArrayOf(0x10), byteArrayOf(), byteArrayOf(0x20))
+                    }
+                }
+            }
+        }
+        peripheral.connect()
+        val values = peripheral.observeAs(uuid("180f"), uuid("2a19"), Uint8Codec).toList()
+        assertEquals(listOf(0x10, 0x20), values)
+    }
+
+    @Test
+    fun observeAsReturnsEmptyWhenCharacteristicMissing() = runTest {
+        val peripheral = FakePeripheral {}
+        peripheral.connect()
+        val values = peripheral.observeAs(uuid("180f"), uuid("2a19"), Uint8Codec).toList()
+        assertTrue(values.isEmpty())
+    }
+}
+
+private fun uuid(s: String) = com.atruedev.kmpble.scanner.uuidFrom(s)

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
@@ -109,6 +109,23 @@ class BleByteWriterTest {
     }
 
     @Test
+    fun growsBeyondInitialCapacity() {
+        val writer = BleByteWriter(initialCapacity = 4)
+        val big = ByteArray(1000) { (it and 0xFF).toByte() }
+        writer.writeBytes(big)
+        val out = writer.toByteArray()
+        assertEquals(1000, out.size)
+        assertContentEquals(big, out)
+    }
+
+    @Test
+    fun zeroInitialCapacityStillWorks() {
+        val writer = BleByteWriter(initialCapacity = 0)
+        writer.writeUInt8(0xAA)
+        assertContentEquals(byteArrayOf(0xAA.toByte()), writer.toByteArray())
+    }
+
+    @Test
     fun roundTripsThroughReader() {
         val original = BleByteWriter()
             .writeUInt8(0xAB)

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
@@ -1,0 +1,130 @@
+package com.atruedev.kmpble.profiles.parsing
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class BleByteWriterTest {
+
+    @Test
+    fun writeUInt8() {
+        val bytes = BleByteWriter().writeUInt8(0xFF).writeUInt8(0).toByteArray()
+        assertContentEquals(byteArrayOf(0xFF.toByte(), 0x00), bytes)
+    }
+
+    @Test
+    fun writeUInt8RejectsOutOfRange() {
+        assertFails { BleByteWriter().writeUInt8(-1) }
+        assertFails { BleByteWriter().writeUInt8(0x100) }
+    }
+
+    @Test
+    fun writeInt8() {
+        val bytes = BleByteWriter().writeInt8(-1).writeInt8(127).writeInt8(-128).toByteArray()
+        assertContentEquals(byteArrayOf(0xFF.toByte(), 0x7F, 0x80.toByte()), bytes)
+    }
+
+    @Test
+    fun writeInt8RejectsOutOfRange() {
+        assertFails { BleByteWriter().writeInt8(128) }
+        assertFails { BleByteWriter().writeInt8(-129) }
+    }
+
+    @Test
+    fun writeUInt16LittleEndian() {
+        // 384 = 0x0180 → 0x80, 0x01
+        val bytes = BleByteWriter().writeUInt16(384).toByteArray()
+        assertContentEquals(byteArrayOf(0x80.toByte(), 0x01), bytes)
+    }
+
+    @Test
+    fun writeUInt16RejectsOutOfRange() {
+        assertFails { BleByteWriter().writeUInt16(-1) }
+        assertFails { BleByteWriter().writeUInt16(0x10000) }
+    }
+
+    @Test
+    fun writeInt16Negative() {
+        // -1 → 0xFFFF → 0xFF, 0xFF
+        val bytes = BleByteWriter().writeInt16(-1).toByteArray()
+        assertContentEquals(byteArrayOf(0xFF.toByte(), 0xFF.toByte()), bytes)
+    }
+
+    @Test
+    fun writeInt16Boundary() {
+        val bytes = BleByteWriter()
+            .writeInt16(Short.MIN_VALUE.toInt())
+            .writeInt16(Short.MAX_VALUE.toInt())
+            .toByteArray()
+        // -32768 → 0x8000 → 0x00, 0x80
+        // 32767 → 0x7FFF → 0xFF, 0x7F
+        assertContentEquals(
+            byteArrayOf(0x00, 0x80.toByte(), 0xFF.toByte(), 0x7F),
+            bytes,
+        )
+    }
+
+    @Test
+    fun writeUInt32LittleEndian() {
+        // 0x12345678 → 0x78, 0x56, 0x34, 0x12
+        val bytes = BleByteWriter().writeUInt32(0x12345678L).toByteArray()
+        assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), bytes)
+    }
+
+    @Test
+    fun writeUInt32Max() {
+        val bytes = BleByteWriter().writeUInt32(0xFFFFFFFFL).toByteArray()
+        assertContentEquals(
+            byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()),
+            bytes,
+        )
+    }
+
+    @Test
+    fun writeUInt32RejectsOutOfRange() {
+        assertFails { BleByteWriter().writeUInt32(-1L) }
+        assertFails { BleByteWriter().writeUInt32(0x1_0000_0000L) }
+    }
+
+    @Test
+    fun writeUtf8() {
+        val bytes = BleByteWriter().writeUtf8("AB").toByteArray()
+        assertContentEquals(byteArrayOf(0x41, 0x42), bytes)
+    }
+
+    @Test
+    fun writeBytesAppends() {
+        val bytes = BleByteWriter()
+            .writeUInt8(0x01)
+            .writeBytes(byteArrayOf(0x02, 0x03))
+            .writeUInt8(0x04)
+            .toByteArray()
+        assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), bytes)
+    }
+
+    @Test
+    fun sizeReflectsWrites() {
+        val writer = BleByteWriter()
+        assertEquals(0, writer.size)
+        writer.writeUInt8(0)
+        assertEquals(1, writer.size)
+        writer.writeUInt32(0)
+        assertEquals(5, writer.size)
+    }
+
+    @Test
+    fun roundTripsThroughReader() {
+        val original = BleByteWriter()
+            .writeUInt8(0xAB)
+            .writeInt16(-1234)
+            .writeUInt32(0xCAFEBABEL)
+            .writeUtf8("hi")
+            .toByteArray()
+        val reader = BleByteReader(original)
+        assertEquals(0xAB, reader.readUInt8())
+        assertEquals(-1234, reader.readInt16())
+        assertEquals(0xCAFEBABEL, reader.readUInt32())
+        assertEquals("hi", reader.readUtf8(2))
+    }
+}

--- a/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
+++ b/kmp-ble-profiles/src/commonTest/kotlin/com/atruedev/kmpble/profiles/parsing/BleByteWriterTest.kt
@@ -33,7 +33,6 @@ class BleByteWriterTest {
 
     @Test
     fun writeUInt16LittleEndian() {
-        // 384 = 0x0180 → 0x80, 0x01
         val bytes = BleByteWriter().writeUInt16(384).toByteArray()
         assertContentEquals(byteArrayOf(0x80.toByte(), 0x01), bytes)
     }
@@ -46,7 +45,6 @@ class BleByteWriterTest {
 
     @Test
     fun writeInt16Negative() {
-        // -1 → 0xFFFF → 0xFF, 0xFF
         val bytes = BleByteWriter().writeInt16(-1).toByteArray()
         assertContentEquals(byteArrayOf(0xFF.toByte(), 0xFF.toByte()), bytes)
     }
@@ -57,8 +55,6 @@ class BleByteWriterTest {
             .writeInt16(Short.MIN_VALUE.toInt())
             .writeInt16(Short.MAX_VALUE.toInt())
             .toByteArray()
-        // -32768 → 0x8000 → 0x00, 0x80
-        // 32767 → 0x7FFF → 0xFF, 0x7F
         assertContentEquals(
             byteArrayOf(0x00, 0x80.toByte(), 0xFF.toByte(), 0x7F),
             bytes,
@@ -67,7 +63,6 @@ class BleByteWriterTest {
 
     @Test
     fun writeUInt32LittleEndian() {
-        // 0x12345678 → 0x78, 0x56, 0x34, 0x12
         val bytes = BleByteWriter().writeUInt32(0x12345678L).toByteArray()
         assertContentEquals(byteArrayOf(0x78, 0x56, 0x34, 0x12), bytes)
     }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capChannel.kt
@@ -36,11 +36,12 @@ import kotlinx.coroutines.flow.Flow
  */
 public interface L2capChannel : AutoCloseable {
     /**
-     * The MTU (Maximum Transmission Unit) for this channel.
+     * The MTU (Maximum Transmission Unit) for this L2CAP CoC channel.
      *
-     * Maximum payload size for a single write operation.
-     * Writes larger than this are segmented automatically by the OS.
-     * Typical values: 2KB-64KB depending on peripheral and connection.
+     * Maximum payload size for a single write operation. Writes larger than
+     * this are segmented automatically by the OS. Distinct from the GATT
+     * ATT_MTU (default 23, max 517) - this is the L2CAP SDU MTU, typically
+     * 2 KB to 64 KB depending on peripheral and connection.
      *
      * **Platform behavior:**
      * - **Android:** Queried from the socket via `maxTransmitPacketSize`, floored


### PR DESCRIPTION
## Summary

Foundation for typed BLE characteristic and stream transport handling, plus the extension functions that make it usable in-tree.

- `Codec<T>` (= `Encoder<T>` + `Decoder<T>`): generic abstraction so consumers can plug their own typed data structures without hand-rolling byte parsing every time. SAM-friendly via `fun interface`.
- `BleByteWriter`: symmetric counterpart to `BleByteReader`. Both use a raw `ByteArray` with cursor; same little-endian semantics, same strict range validation.
- `LengthPrefixFramer` + `Unframer` + `Flow<ByteArray>.unframedBy(...)` / `decodeFramed(...)`: needed for stream transports (L2CAP CoC) where the OS may merge or split application payloads at arbitrary boundaries. Length-prefix is the simplest safe choice for binary payloads (CBOR, Protobuf).
- Built-in codecs: `RawBytesCodec`, `Utf8StringCodec`, `Uint8/Uint16/Uint32`, `Int8/Int16/Int32`. All fixed-width codecs strictly check input size.
- `Peripheral.readAs<T>` / `writeAs<T>` / `observeAs<T>` extensions: in-tree consumer of the codec API. Custom GATT profiles can now read/write/observe typed values without re-implementing service/characteristic lookup boilerplate.

This is Phase 0 of a two-PR sequence. Phase 1 adds server-side L2CAP listener support and uses the framing + codec API to stream framed typed payloads from a peripheral (real or fake) to a central.

## Why now

Downstream use cases (Wi-Fi analytics, healthcare telemetry, agri sensor batches) need to push typed objects bigger than a GATT MTU to a phone. L2CAP CoC plus length-prefix framing plus a swappable codec is the right primitive; GATT chunking would re-invent flow control at the application layer.

L2CAP CoC SDU MTU is distinct from GATT ATT_MTU (default 23, max 517) and is typically 2-64 KB depending on platform and connection; see `L2capChannel.mtu` for current per-platform behavior (this PR also clarifies that KDoc). The framer default cap of 64 KiB is deliberately small for BLE-scale workloads; raise it explicitly when needed.

No public API of existing profiles changes; this is additive.

## Implementation notes

- `BleByteWriter` is `ByteArray`-backed (doubling growth on overflow), not `ArrayList<Byte>`; the latter would box every byte on JVM and burn ~17x memory vs the wire size.
- `LengthPrefixUnframer` uses a cursor over a single buffer with in-place compaction; feeding the same N bytes in 1-byte chunks is O(N), not O(N^2).
- `Utf8StringCodec.decode` returns `null` on malformed UTF-8 (`throwOnInvalidSequence = true` + catch), honoring the `Decoder<T>` contract.
- `decodeFramed` exposes decode failures via `onDecodeFailure: (ByteArray) -> Unit = {}` callback; silent drop is opt-in by accepting the default.
- `Unframer.pendingBytes()` lets a stream consumer detect a dangling partial frame when the source flow completes mid-frame.
- `FrameTooLargeException` propagates through Flow operators and cancels the downstream; wrap with `.catch { }` to recover.

## Extension signature notes

- `readAs(...): Result<T>` and `writeAs(...): Result<Unit>` so callers can distinguish three failure modes:
  - `CharacteristicNotFoundException` (characteristic absent after service discovery)
  - `DecodeFailureException` (read succeeded, decoder rejected the bytes)
  - any other exception thrown by the underlying BLE op (caught into the Result by `runCatching`)
- `writeAs` accepts `Encoder<T>` (not `Codec<T>`) since write paths never need the decode half.
- `observeAs` keeps `Flow<T>` return shape and adds the same `onDecodeFailure` callback as `decodeFramed`. Missing characteristic returns an empty flow to match the lenient convention used by the built-in SIG profiles (`Peripheral.heartRateMeasurements`, etc.).

## Test plan

- [x] `:kmp-ble-profiles:jvmTest`: 73 tests pass. Covers round-trips, framing with chunk split/merge boundaries, partial frame buffering, frame cap enforcement, 1-byte streaming throughput on a 100 KB frame (proxy for the O(n) fix), Flow cancellation mid-frame, decode-failure callback dispatch, strict-size rejection, invalid UTF-8 rejection, `FrameTooLargeException` propagation through Flow, `pendingBytes` accounting, Peripheral extension `Result` outcomes via `FakePeripheral`.
- [x] `compileKotlinIosArm64` + `compileTestKotlinIosSimulatorArm64`: verify no JVM-only assumptions.
- [x] Typography check: ASCII-only.
- [ ] Manual sanity check on Android emulator once Phase 1 lands.