### PR TITLE
feat(l2cap): add server-side L2capListener for peripheral mode

### DIFF
--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
@@ -50,6 +50,9 @@ fun ServerScreen(onBack: () -> Unit) {
     val activeSets by vm.activeSets.collectAsState()
     val connectionLog by vm.connectionLog.collectAsState()
     val error by vm.error.collectAsState()
+    val l2capOpen by vm.l2capOpen.collectAsState()
+    val l2capPsm by vm.l2capPsm.collectAsState()
+    val l2capLog by vm.l2capLog.collectAsState()
 
     LaunchedEffect(error) {
         error?.let {
@@ -79,6 +82,7 @@ fun ServerScreen(onBack: () -> Unit) {
             if (serverOpen) {
                 item { ClientPreviewCard(heartRate, connectionLog.size) }
             }
+            item { L2capServerCard(l2capOpen, l2capPsm, l2capLog, vm) }
             item { LegacyAdvertiserCard(isAdvertising, vm) }
             item { ExtendedAdvertiserCard(activeSets, vm) }
             item { ConnectionLogCard(connectionLog) }
@@ -138,6 +142,63 @@ private fun GattServerCard(
                     }
                     OutlinedButton(onClick = { vm.notifyClients() }) {
                         Text("Notify All")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun L2capServerCard(
+    open: Boolean,
+    psm: Int,
+    log: List<String>,
+    vm: ServerViewModel,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("L2CAP Server (echo)", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Publishes an L2CAP CoC listener. Accepted channels echo any bytes received back to the client.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            FilterChip(
+                selected = open,
+                onClick = {},
+                label = {
+                    Text(if (open) "Open (PSM=$psm)" else "Closed")
+                },
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = { vm.openL2capServer(secure = true) },
+                    enabled = !open,
+                ) { Text("Open Secure") }
+
+                OutlinedButton(
+                    onClick = { vm.closeL2capServer() },
+                    enabled = open,
+                ) { Text("Close") }
+            }
+
+            if (log.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    log.take(8).forEach { line ->
+                        Text(
+                            line,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                 }
             }

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.atruedev.kmpble.BleData
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.l2cap.L2capListener
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.server.AdvertiseConfig
 import com.atruedev.kmpble.server.AdvertiseInterval
@@ -137,6 +139,71 @@ class ServerViewModel : ViewModel() {
         _error.value = null
     }
 
+    // --- L2CAP echo server ---
+
+    private val _l2capOpen = MutableStateFlow(false)
+    val l2capOpen: StateFlow<Boolean> = _l2capOpen.asStateFlow()
+
+    private val _l2capPsm = MutableStateFlow(0)
+    val l2capPsm: StateFlow<Int> = _l2capPsm.asStateFlow()
+
+    private val _l2capLog = MutableStateFlow(emptyList<String>())
+    val l2capLog: StateFlow<List<String>> = _l2capLog.asStateFlow()
+
+    private var l2capListener: L2capListener? = null
+    private var l2capAcceptJob: Job? = null
+    private val l2capChannels = mutableListOf<L2capChannel>()
+
+    fun openL2capServer(secure: Boolean = true) {
+        launchWithErrorHandling {
+            l2capListener?.close()
+            val listener = L2capListener()
+            l2capListener = listener
+            l2capAcceptJob?.cancel()
+            l2capAcceptJob = viewModelScope.launch {
+                listener.incoming.collect { channel -> handleL2capChannel(channel) }
+            }
+            listener.open(secure)
+            _l2capPsm.value = listener.psm
+            _l2capOpen.value = true
+            appendL2capLog("Listener open (PSM=${listener.psm}, secure=$secure)")
+        }
+    }
+
+    fun closeL2capServer() {
+        l2capAcceptJob?.cancel()
+        l2capAcceptJob = null
+        l2capListener?.close()
+        l2capListener = null
+        l2capChannels.forEach { it.close() }
+        l2capChannels.clear()
+        _l2capOpen.value = false
+        _l2capPsm.value = 0
+        appendL2capLog("Listener closed")
+    }
+
+    private suspend fun handleL2capChannel(channel: L2capChannel) {
+        l2capChannels.add(channel)
+        appendL2capLog("Channel accepted (mtu=${channel.mtu})")
+        try {
+            channel.incoming.collect { bytes ->
+                appendL2capLog("RX ${bytes.size} bytes; echoing")
+                try {
+                    channel.write(bytes)
+                } catch (e: Exception) {
+                    appendL2capLog("Echo failed: ${e.message}")
+                }
+            }
+        } finally {
+            l2capChannels.remove(channel)
+            appendL2capLog("Channel closed")
+        }
+    }
+
+    private fun appendL2capLog(msg: String) {
+        _l2capLog.value = (listOf(msg) + _l2capLog.value).take(20)
+    }
+
     private var connectionEventJob: Job? = null
 
     // Called from openServer() which runs on Main via viewModelScope.launch.
@@ -156,6 +223,7 @@ class ServerViewModel : ViewModel() {
     }
 
     override fun onCleared() {
+        closeL2capServer()
         advertiser.close()
         extAdvertiser.close()
         server.close()

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private val HEART_RATE_SERVICE = uuidFrom("180D")
@@ -152,7 +153,7 @@ class ServerViewModel : ViewModel() {
 
     private var l2capListener: L2capListener? = null
     private var l2capAcceptJob: Job? = null
-    private val l2capChannels = mutableListOf<L2capChannel>()
+    private val _l2capChannels = MutableStateFlow<List<L2capChannel>>(emptyList())
 
     fun openL2capServer(secure: Boolean = true) {
         launchWithErrorHandling {
@@ -160,9 +161,10 @@ class ServerViewModel : ViewModel() {
             val listener = L2capListener()
             l2capListener = listener
             l2capAcceptJob?.cancel()
-            l2capAcceptJob = viewModelScope.launch {
-                listener.incoming.collect { channel -> handleL2capChannel(channel) }
-            }
+            l2capAcceptJob =
+                viewModelScope.launch {
+                    listener.incoming.collect { channel -> handleL2capChannel(channel) }
+                }
             listener.open(secure)
             _l2capPsm.value = listener.psm
             _l2capOpen.value = true
@@ -175,15 +177,14 @@ class ServerViewModel : ViewModel() {
         l2capAcceptJob = null
         l2capListener?.close()
         l2capListener = null
-        l2capChannels.forEach { it.close() }
-        l2capChannels.clear()
+        _l2capChannels.value.forEach { it.close() }
+        _l2capChannels.value = emptyList()
         _l2capOpen.value = false
-        _l2capPsm.value = 0
         appendL2capLog("Listener closed")
     }
 
     private suspend fun handleL2capChannel(channel: L2capChannel) {
-        l2capChannels.add(channel)
+        _l2capChannels.update { it + channel }
         appendL2capLog("Channel accepted (mtu=${channel.mtu})")
         try {
             channel.incoming.collect { bytes ->
@@ -195,7 +196,7 @@ class ServerViewModel : ViewModel() {
                 }
             }
         } finally {
-            l2capChannels.remove(channel)
+            _l2capChannels.update { it - channel }
             appendL2capLog("Channel closed")
         }
     }

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -163,7 +163,9 @@ class ServerViewModel : ViewModel() {
             l2capAcceptJob?.cancel()
             l2capAcceptJob =
                 viewModelScope.launch {
-                    listener.incoming.collect { channel -> handleL2capChannel(channel) }
+                    listener.incoming.collect { channel ->
+                        launch { handleL2capChannel(channel) }
+                    }
                 }
             listener.open(secure)
             _l2capPsm.value = listener.psm
@@ -202,7 +204,7 @@ class ServerViewModel : ViewModel() {
     }
 
     private fun appendL2capLog(msg: String) {
-        _l2capLog.value = (listOf(msg) + _l2capLog.value).take(20)
+        _l2capLog.update { (listOf(msg) + it).take(20) }
     }
 
     private var connectionEventJob: Job? = null

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
@@ -76,14 +76,18 @@ internal class AndroidL2capListener(
                 }
             }
 
+        val assignedPsm = socket.psm
         serverSocket = socket
-        _psm = socket.psm
+        _psm = assignedPsm
         _isOpen.value = true
 
-        acceptJob = scope.launch { acceptLoop(socket) }
+        acceptJob = scope.launch { acceptLoop(socket, assignedPsm) }
     }
 
-    private suspend fun acceptLoop(serverSocket: BluetoothServerSocket) {
+    private suspend fun acceptLoop(
+        serverSocket: BluetoothServerSocket,
+        assignedPsm: Int,
+    ) {
         try {
             while (coroutineContext[Job]?.isActive == true && !closed) {
                 val accepted =
@@ -105,7 +109,7 @@ internal class AndroidL2capListener(
                 val channel =
                     AndroidL2capChannel(
                         socket = BluetoothL2capSocket(accepted),
-                        psm = serverSocket.psm,
+                        psm = assignedPsm,
                         scope = channelScope,
                     )
                 channelScope.launch {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
@@ -11,16 +11,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.coroutineContext
 
 internal class AndroidL2capListener(
@@ -33,12 +33,12 @@ internal class AndroidL2capListener(
     private var _psm: Int = 0
     override val psm: Int get() = _psm
 
-    private val _incoming = MutableSharedFlow<L2capChannel>(
-        replay = 0,
-        extraBufferCapacity = 16,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+    private val _incoming =
+        MutableSharedFlow<L2capChannel>(
+            replay = 0,
+            extraBufferCapacity = 16,
+        )
+    override val incoming: SharedFlow<L2capChannel> = _incoming.asSharedFlow()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -48,28 +48,33 @@ internal class AndroidL2capListener(
     @Volatile
     private var closed: Boolean = false
 
-    override suspend fun open(secure: Boolean) {
+    override suspend fun open(
+        secure: Boolean,
+        mtu: Int?,
+    ) {
         if (closed) throw L2capException.InvalidState("Listener has been closed")
         if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
 
-        val adapter = (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
-            ?: throw L2capException.NotSupported("Bluetooth adapter unavailable")
+        val adapter =
+            (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+                ?: throw L2capException.NotSupported("Bluetooth adapter unavailable")
 
-        val socket = withContext(Dispatchers.IO) {
-            try {
-                if (secure) adapter.listenUsingL2capChannel() else adapter.listenUsingInsecureL2capChannel()
-            } catch (e: IOException) {
-                throw L2capException.PublishFailed(
-                    "listenUsingL2capChannel failed: ${e.message}",
-                    e,
-                )
-            } catch (e: SecurityException) {
-                throw L2capException.PublishFailed(
-                    "Missing BLUETOOTH_CONNECT permission",
-                    e,
-                )
+        val socket =
+            withContext(Dispatchers.IO) {
+                try {
+                    if (secure) adapter.listenUsingL2capChannel() else adapter.listenUsingInsecureL2capChannel()
+                } catch (e: IOException) {
+                    throw L2capException.PublishFailed(
+                        "BluetoothAdapter.listenUsingL2capChannel failed: ${e.message}",
+                        e,
+                    )
+                } catch (e: SecurityException) {
+                    throw L2capException.PublishFailed(
+                        "Missing BLUETOOTH_CONNECT permission for listenUsingL2capChannel",
+                        e,
+                    )
+                }
             }
-        }
 
         serverSocket = socket
         _psm = socket.psm
@@ -79,27 +84,44 @@ internal class AndroidL2capListener(
     }
 
     private suspend fun acceptLoop(serverSocket: BluetoothServerSocket) {
-        while (coroutineContext[Job]?.isActive == true && !closed) {
-            val accepted = try {
-                serverSocket.accept()
-            } catch (_: IOException) {
-                break
-            }
+        try {
+            while (coroutineContext[Job]?.isActive == true && !closed) {
+                val accepted =
+                    try {
+                        serverSocket.accept()
+                    } catch (_: IOException) {
+                        break
+                    }
 
-            val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-            val channel = AndroidL2capChannel(
-                socket = BluetoothL2capSocket(accepted),
-                psm = serverSocket.psm,
-                scope = channelScope,
-            )
-            channelScope.launch {
-                channel.awaitClosed()
-                channelScope.cancel()
-            }
+                if (closed) {
+                    try {
+                        accepted.close()
+                    } catch (_: IOException) {
+                    }
+                    break
+                }
 
-            if (!_incoming.tryEmit(channel)) {
-                channel.close()
+                val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+                val channel =
+                    AndroidL2capChannel(
+                        socket = BluetoothL2capSocket(accepted),
+                        psm = serverSocket.psm,
+                        scope = channelScope,
+                    )
+                channelScope.launch {
+                    channel.awaitClosed()
+                    channelScope.cancel()
+                }
+
+                try {
+                    _incoming.emit(channel)
+                } catch (e: CancellationException) {
+                    channel.close()
+                    throw e
+                }
             }
+        } finally {
+            _isOpen.value = false
         }
     }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
@@ -1,0 +1,122 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.l2cap
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothServerSocket
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import kotlin.coroutines.coroutineContext
+
+internal class AndroidL2capListener(
+    private val context: Context,
+) : L2capListener {
+    private val _isOpen = MutableStateFlow(false)
+    override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    @Volatile
+    private var _psm: Int = 0
+    override val psm: Int get() = _psm
+
+    private val _incoming = MutableSharedFlow<L2capChannel>(
+        replay = 0,
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private var serverSocket: BluetoothServerSocket? = null
+    private var acceptJob: Job? = null
+
+    @Volatile
+    private var closed: Boolean = false
+
+    override suspend fun open(secure: Boolean) {
+        if (closed) throw L2capException.InvalidState("Listener has been closed")
+        if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
+
+        val adapter = (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+            ?: throw L2capException.NotSupported("Bluetooth adapter unavailable")
+
+        val socket = withContext(Dispatchers.IO) {
+            try {
+                if (secure) adapter.listenUsingL2capChannel() else adapter.listenUsingInsecureL2capChannel()
+            } catch (e: IOException) {
+                throw L2capException.PublishFailed(
+                    "listenUsingL2capChannel failed: ${e.message}",
+                    e,
+                )
+            } catch (e: SecurityException) {
+                throw L2capException.PublishFailed(
+                    "Missing BLUETOOTH_CONNECT permission",
+                    e,
+                )
+            }
+        }
+
+        serverSocket = socket
+        _psm = socket.psm
+        _isOpen.value = true
+
+        acceptJob = scope.launch { acceptLoop(socket) }
+    }
+
+    private suspend fun acceptLoop(serverSocket: BluetoothServerSocket) {
+        while (coroutineContext[Job]?.isActive == true && !closed) {
+            val accepted = try {
+                serverSocket.accept()
+            } catch (_: IOException) {
+                break
+            }
+
+            val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val channel = AndroidL2capChannel(
+                socket = BluetoothL2capSocket(accepted),
+                psm = serverSocket.psm,
+                scope = channelScope,
+            )
+            channelScope.launch {
+                channel.awaitClosed()
+                channelScope.cancel()
+            }
+
+            if (!_incoming.tryEmit(channel)) {
+                channel.close()
+            }
+        }
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        _isOpen.value = false
+
+        try {
+            serverSocket?.close()
+        } catch (_: IOException) {
+        }
+        serverSocket = null
+
+        acceptJob?.cancel()
+        acceptJob = null
+
+        scope.cancel()
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.android.kt
@@ -1,0 +1,5 @@
+package com.atruedev.kmpble.l2cap
+
+import com.atruedev.kmpble.KmpBle
+
+public actual fun L2capListener(): L2capListener = AndroidL2capListener(KmpBle.requireContext())

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capException.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capException.kt
@@ -46,12 +46,13 @@ public sealed class L2capException(
     ) : L2capException(message)
 
     /**
-     * Failed to publish an L2CAP listener (server side).
+     * Failed to publish an L2CAP listener (server side). The [message]
+     * is used verbatim; callers should phrase it as a complete sentence.
      */
     public class PublishFailed(
         message: String,
         cause: Throwable? = null,
-    ) : L2capException("Failed to publish L2CAP listener: $message", cause)
+    ) : L2capException(message, cause)
 
     /**
      * Listener is in the wrong state for the requested operation

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capException.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capException.kt
@@ -44,4 +44,20 @@ public sealed class L2capException(
     public class NotSupported(
         message: String = "L2CAP channels are not supported",
     ) : L2capException(message)
+
+    /**
+     * Failed to publish an L2CAP listener (server side).
+     */
+    public class PublishFailed(
+        message: String,
+        cause: Throwable? = null,
+    ) : L2capException("Failed to publish L2CAP listener: $message", cause)
+
+    /**
+     * Listener is in the wrong state for the requested operation
+     * (e.g. opening an already-open listener, or accepting on a closed one).
+     */
+    public class InvalidState(
+        message: String,
+    ) : L2capException(message)
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
@@ -1,0 +1,108 @@
+package com.atruedev.kmpble.l2cap
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Server-side L2CAP CoC listener.
+ *
+ * Counterpart to [com.atruedev.kmpble.peripheral.Peripheral.openL2capChannel]
+ * (client side). [open] publishes the listener; the OS assigns a PSM that
+ * centrals discover (typically by reading a custom GATT characteristic) and
+ * use to open channels. Each accepted channel is emitted through [incoming].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val listener = L2capListener()
+ * listener.open(secure = true)
+ * val psm = listener.psm
+ *
+ * // Expose PSM through a GATT characteristic so centrals can discover it
+ * gattServer.notify(PSM_CHAR_UUID, null, BleData(psm.toUInt16LeBytes()))
+ *
+ * listener.incoming.collect { channel ->
+ *     scope.launch {
+ *         channel.incoming.collect { bytes -> handle(bytes) }
+ *     }
+ * }
+ *
+ * listener.close()
+ * ```
+ *
+ * ## Independence from GattServer
+ *
+ * The listener is conceptually independent from [com.atruedev.kmpble.server.GattServer]:
+ * a peripheral may publish L2CAP without GATT, or vice versa. On iOS the
+ * underlying `CBPeripheralManager` is shared with `GattServer` and `Advertiser`
+ * out of platform necessity, but the surface API does not require either to
+ * be active.
+ *
+ * ## Lifecycle
+ *
+ * - Created via [L2capListener] factory function (no OS resources allocated)
+ * - [open] allocates OS resources and starts accepting connections
+ * - [close] stops accepting new connections; channels already accepted via
+ *   [incoming] are NOT closed (caller owns their lifecycles)
+ *
+ * ## Channel ownership
+ *
+ * Each [L2capChannel] emitted from [incoming] is fully open and owned by the
+ * consumer. The listener does not track them. Consumers must call
+ * [L2capChannel.close] on each channel when done with it.
+ */
+public interface L2capListener : AutoCloseable {
+    /**
+     * PSM (Protocol/Service Multiplexer) assigned by the OS after [open].
+     *
+     * `0` before [open] completes successfully. Stable for the lifetime of
+     * the listener once assigned.
+     */
+    public val psm: Int
+
+    /**
+     * Whether the listener is currently accepting connections.
+     */
+    public val isOpen: StateFlow<Boolean>
+
+    /**
+     * Flow of newly-accepted L2CAP channels.
+     *
+     * Buffered: up to 16 unconsumed connections are retained; older ones
+     * are dropped if the buffer is full. Start collecting before calling
+     * [open] to avoid missing early connections.
+     */
+    public val incoming: Flow<L2capChannel>
+
+    /**
+     * Open the listener and request a PSM from the OS.
+     *
+     * @param secure If true, requires encrypted connections.
+     *   - Android: uses `BluetoothAdapter.listenUsingL2capChannel()` (encrypted)
+     *     when true, `listenUsingInsecureL2capChannel()` when false.
+     *   - iOS: passes the flag to `CBPeripheralManager.publishL2CAPChannel(withEncryption:)`.
+     * @throws L2capException.PublishFailed if the OS rejects the publish request
+     * @throws L2capException.InvalidState if already open
+     * @throws L2capException.NotSupported if L2CAP server is unavailable
+     */
+    public suspend fun open(secure: Boolean = true)
+
+    /**
+     * Stop accepting connections and release the PSM.
+     *
+     * Previously accepted channels (emitted through [incoming]) remain open.
+     * Safe to call multiple times.
+     */
+    override fun close()
+}
+
+/**
+ * Create a platform-specific [L2capListener].
+ *
+ * - Android: backed by `BluetoothAdapter.listenUsingL2capChannel()`.
+ *   Requires `BLUETOOTH_CONNECT` permission at runtime.
+ * - iOS: backed by `CBPeripheralManager.publishL2CAPChannel()`.
+ *   Shares the underlying `CBPeripheralManager` with `GattServer` and `Advertiser`.
+ * - JVM: throws [L2capException.NotSupported] (no Bluetooth stack on JVM host).
+ */
+public expect fun L2capListener(): L2capListener

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
@@ -1,6 +1,6 @@
 package com.atruedev.kmpble.l2cap
 
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -66,13 +66,20 @@ public interface L2capListener : AutoCloseable {
     public val isOpen: StateFlow<Boolean>
 
     /**
-     * Flow of newly-accepted L2CAP channels.
+     * Hot stream of newly-accepted L2CAP channels.
      *
-     * Buffered: up to 16 unconsumed connections are retained; older ones
-     * are dropped if the buffer is full. Start collecting before calling
-     * [open] to avoid missing early connections.
+     * Buffered: up to 16 unconsumed connections are retained. When the
+     * buffer is full, the accept loop applies backpressure to the platform
+     * source (Android) or drops the incoming connection and closes its
+     * streams (iOS) - in either case, no in-flight channel is silently
+     * leaked. Start collecting before calling [open] to avoid missing
+     * early connections.
+     *
+     * Exposed as [SharedFlow] (not plain [kotlinx.coroutines.flow.Flow])
+     * so consumers can inspect `subscriptionCount` and use `onSubscription`
+     * for race-free wiring.
      */
-    public val incoming: Flow<L2capChannel>
+    public val incoming: SharedFlow<L2capChannel>
 
     /**
      * Open the listener and request a PSM from the OS.
@@ -81,11 +88,21 @@ public interface L2capListener : AutoCloseable {
      *   - Android: uses `BluetoothAdapter.listenUsingL2capChannel()` (encrypted)
      *     when true, `listenUsingInsecureL2capChannel()` when false.
      *   - iOS: passes the flag to `CBPeripheralManager.publishL2CAPChannel(withEncryption:)`.
+     * @param mtu Optional MTU hint propagated to each accepted channel.
+     *   - Android: ignored; the MTU is queried from the underlying socket.
+     *   - iOS: used as the `L2capChannel.mtu` value for accepted channels
+     *     (CoreBluetooth does not expose the negotiated MTU). When `null`,
+     *     a conservative platform default applies.
      * @throws L2capException.PublishFailed if the OS rejects the publish request
-     * @throws L2capException.InvalidState if already open
+     *   or the publish times out
+     * @throws L2capException.InvalidState if already open or another listener
+     *   is currently publishing on the shared platform handle (iOS)
      * @throws L2capException.NotSupported if L2CAP server is unavailable
      */
-    public suspend fun open(secure: Boolean = true)
+    public suspend fun open(
+        secure: Boolean = true,
+        mtu: Int? = null,
+    )
 
     /**
      * Stop accepting connections and release the PSM.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/l2cap/L2capListener.kt
@@ -19,7 +19,8 @@ import kotlinx.coroutines.flow.StateFlow
  * val psm = listener.psm
  *
  * // Expose PSM through a GATT characteristic so centrals can discover it
- * gattServer.notify(PSM_CHAR_UUID, null, BleData(psm.toUInt16LeBytes()))
+ * val psmBytes = byteArrayOf((psm and 0xFF).toByte(), ((psm shr 8) and 0xFF).toByte())
+ * gattServer.notify(PSM_CHAR_UUID, null, BleData(psmBytes))
  *
  * listener.incoming.collect { channel ->
  *     scope.launch {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
@@ -3,7 +3,6 @@ package com.atruedev.kmpble.testing
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.l2cap.L2capListener
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -30,7 +29,6 @@ public class FakeL2capListener(
         MutableSharedFlow<L2capChannel>(
             replay = 0,
             extraBufferCapacity = 16,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
     override val incoming: SharedFlow<L2capChannel> = _incoming.asSharedFlow()
 
@@ -51,9 +49,13 @@ public class FakeL2capListener(
         _isOpen.value = false
     }
 
-    /** Test helper: emit an accepted [channel] to subscribers of [incoming]. */
-    public fun simulateIncoming(channel: L2capChannel) {
+    /**
+     * Test helper: emit an accepted [channel] to subscribers of [incoming].
+     * Suspends with the same backpressure semantics as production listeners,
+     * so tests cannot accidentally paper over a slow-consumer leak.
+     */
+    public suspend fun simulateIncoming(channel: L2capChannel) {
         check(_isOpen.value) { "Cannot simulate incoming on a closed listener" }
-        _incoming.tryEmit(channel)
+        _incoming.emit(channel)
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
@@ -1,0 +1,55 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.l2cap.L2capException
+import com.atruedev.kmpble.l2cap.L2capListener
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Fake [L2capListener] for unit tests.
+ *
+ * Tests can drive accept events via [simulateIncoming] and inspect state
+ * through [psm] / [isOpen].
+ */
+public class FakeL2capListener(
+    private val assignedPsm: Int = 0x80,
+) : L2capListener {
+    private val _isOpen = MutableStateFlow(false)
+    override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    private var _psm: Int = 0
+    override val psm: Int get() = _psm
+
+    private val _incoming = MutableSharedFlow<L2capChannel>(
+        replay = 0,
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+
+    private var closed = false
+
+    override suspend fun open(secure: Boolean) {
+        if (closed) throw L2capException.InvalidState("Listener has been closed")
+        if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
+        _psm = assignedPsm
+        _isOpen.value = true
+    }
+
+    override fun close() {
+        closed = true
+        _isOpen.value = false
+    }
+
+    /** Test helper: emit an accepted [channel] to subscribers of [incoming]. */
+    public fun simulateIncoming(channel: L2capChannel) {
+        check(_isOpen.value) { "Cannot simulate incoming on a closed listener" }
+        _incoming.tryEmit(channel)
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeL2capListener.kt
@@ -4,9 +4,9 @@ import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.l2cap.L2capListener
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,16 +26,20 @@ public class FakeL2capListener(
     private var _psm: Int = 0
     override val psm: Int get() = _psm
 
-    private val _incoming = MutableSharedFlow<L2capChannel>(
-        replay = 0,
-        extraBufferCapacity = 16,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+    private val _incoming =
+        MutableSharedFlow<L2capChannel>(
+            replay = 0,
+            extraBufferCapacity = 16,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    override val incoming: SharedFlow<L2capChannel> = _incoming.asSharedFlow()
 
     private var closed = false
 
-    override suspend fun open(secure: Boolean) {
+    override suspend fun open(
+        secure: Boolean,
+        mtu: Int?,
+    ) {
         if (closed) throw L2capException.InvalidState("Listener has been closed")
         if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
         _psm = assignedPsm

--- a/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
@@ -1,14 +1,13 @@
-@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-
 package com.atruedev.kmpble.l2cap
 
 import com.atruedev.kmpble.testing.FakeL2capListener
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,48 +16,58 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FakeL2capListenerTest {
+    @Test
+    fun openSetsIsOpenAndPsm() =
+        runTest {
+            val listener = FakeL2capListener(assignedPsm = 0x42)
+            assertFalse(listener.isOpen.value)
+            assertEquals(0, listener.psm)
+
+            listener.open(secure = true)
+
+            assertTrue(listener.isOpen.value)
+            assertEquals(0x42, listener.psm)
+        }
 
     @Test
-    fun openSetsIsOpenAndPsm() = runTest {
-        val listener = FakeL2capListener(assignedPsm = 0x42)
-        assertFalse(listener.isOpen.value)
-        assertEquals(0, listener.psm)
-
-        listener.open(secure = true)
-
-        assertTrue(listener.isOpen.value)
-        assertEquals(0x42, listener.psm)
-    }
+    fun openWhenAlreadyOpenThrows() =
+        runTest {
+            val listener = FakeL2capListener()
+            listener.open()
+            assertFailsWith<L2capException.InvalidState> { listener.open() }
+        }
 
     @Test
-    fun openWhenAlreadyOpenThrows() = runTest {
-        val listener = FakeL2capListener()
-        listener.open()
-        assertFailsWith<L2capException.InvalidState> { listener.open() }
-    }
+    fun openAfterCloseThrows() =
+        runTest {
+            val listener = FakeL2capListener()
+            listener.open()
+            listener.close()
+            assertFailsWith<L2capException.InvalidState> { listener.open() }
+        }
 
     @Test
-    fun openAfterCloseThrows() = runTest {
-        val listener = FakeL2capListener()
-        listener.open()
-        listener.close()
-        assertFailsWith<L2capException.InvalidState> { listener.open() }
-    }
+    fun simulateIncomingEmitsChannels() =
+        runTest {
+            val listener = FakeL2capListener()
+            listener.open()
+            val channel = StubChannel(psm = listener.psm)
 
-    @Test
-    fun simulateIncomingEmitsChannels() = runTest {
-        val listener = FakeL2capListener()
-        listener.open()
-        val channel = StubChannel(psm = listener.psm)
+            val subscribed = CompletableDeferred<Unit>()
+            val collected =
+                async {
+                    listener.incoming
+                        .onSubscription { subscribed.complete(Unit) }
+                        .take(1)
+                        .toList()
+                }
+            subscribed.await()
+            listener.simulateIncoming(channel)
+            val received = collected.await()
 
-        val collected = async { listener.incoming.take(1).toList() }
-        runCurrent()
-        listener.simulateIncoming(channel)
-        val received = collected.await()
-
-        assertEquals(1, received.size)
-        assertEquals(listener.psm, received[0].psm)
-    }
+            assertEquals(1, received.size)
+            assertEquals(listener.psm, received[0].psm)
+        }
 
     @Test
     fun simulateIncomingBeforeOpenThrows() {
@@ -69,19 +78,24 @@ class FakeL2capListenerTest {
     }
 
     @Test
-    fun closeIsIdempotent() = runTest {
-        val listener = FakeL2capListener()
-        listener.open()
-        listener.close()
-        listener.close()
-        assertFalse(listener.isOpen.value)
-    }
+    fun closeIsIdempotent() =
+        runTest {
+            val listener = FakeL2capListener()
+            listener.open()
+            listener.close()
+            listener.close()
+            assertFalse(listener.isOpen.value)
+        }
 }
 
-private class StubChannel(override val psm: Int) : L2capChannel {
+private class StubChannel(
+    override val psm: Int,
+) : L2capChannel {
     override val mtu: Int = 2048
     override val isOpen: Boolean = true
     override val incoming: Flow<ByteArray> = flowOf()
+
     override suspend fun write(data: ByteArray) {}
+
     override fun close() {}
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
@@ -1,0 +1,87 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.atruedev.kmpble.l2cap
+
+import com.atruedev.kmpble.testing.FakeL2capListener
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FakeL2capListenerTest {
+
+    @Test
+    fun openSetsIsOpenAndPsm() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x42)
+        assertFalse(listener.isOpen.value)
+        assertEquals(0, listener.psm)
+
+        listener.open(secure = true)
+
+        assertTrue(listener.isOpen.value)
+        assertEquals(0x42, listener.psm)
+    }
+
+    @Test
+    fun openWhenAlreadyOpenThrows() = runTest {
+        val listener = FakeL2capListener()
+        listener.open()
+        assertFailsWith<L2capException.InvalidState> { listener.open() }
+    }
+
+    @Test
+    fun openAfterCloseThrows() = runTest {
+        val listener = FakeL2capListener()
+        listener.open()
+        listener.close()
+        assertFailsWith<L2capException.InvalidState> { listener.open() }
+    }
+
+    @Test
+    fun simulateIncomingEmitsChannels() = runTest {
+        val listener = FakeL2capListener()
+        listener.open()
+        val channel = StubChannel(psm = listener.psm)
+
+        val collected = async { listener.incoming.take(1).toList() }
+        runCurrent()
+        listener.simulateIncoming(channel)
+        val received = collected.await()
+
+        assertEquals(1, received.size)
+        assertEquals(listener.psm, received[0].psm)
+    }
+
+    @Test
+    fun simulateIncomingBeforeOpenThrows() {
+        val listener = FakeL2capListener()
+        assertFailsWith<IllegalStateException> {
+            listener.simulateIncoming(StubChannel(psm = 1))
+        }
+    }
+
+    @Test
+    fun closeIsIdempotent() = runTest {
+        val listener = FakeL2capListener()
+        listener.open()
+        listener.close()
+        listener.close()
+        assertFalse(listener.isOpen.value)
+    }
+}
+
+private class StubChannel(override val psm: Int) : L2capChannel {
+    override val mtu: Int = 2048
+    override val isOpen: Boolean = true
+    override val incoming: Flow<ByteArray> = flowOf()
+    override suspend fun write(data: ByteArray) {}
+    override fun close() {}
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/l2cap/FakeL2capListenerTest.kt
@@ -70,12 +70,13 @@ class FakeL2capListenerTest {
         }
 
     @Test
-    fun simulateIncomingBeforeOpenThrows() {
-        val listener = FakeL2capListener()
-        assertFailsWith<IllegalStateException> {
-            listener.simulateIncoming(StubChannel(psm = 1))
+    fun simulateIncomingBeforeOpenThrows() =
+        runTest {
+            val listener = FakeL2capListener()
+            assertFailsWith<IllegalStateException> {
+                listener.simulateIncoming(StubChannel(psm = 1))
+            }
         }
-    }
 
     @Test
     fun closeIsIdempotent() =

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.internal
 
-import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -115,7 +114,6 @@ internal class IosPeripheralManagerDelegate :
         onReadyToUpdate?.invoke()
     }
 
-    @ObjCSignatureOverride
     override fun peripheralManager(
         peripheral: CBPeripheralManager,
         didPublishL2CAPChannel: CBL2CAPPSM,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.internal
 
+import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,7 +16,6 @@ import platform.CoreBluetooth.CBService
 import platform.Foundation.NSError
 import platform.darwin.NSObject
 import kotlin.concurrent.Volatile
-import kotlinx.cinterop.ObjCSignatureOverride
 
 /**
  * Unified [CBPeripheralManager] delegate handling server, advertising,
@@ -54,15 +54,11 @@ internal class IosPeripheralManagerDelegate :
     @Volatile
     internal var onStartAdvertising: ((NSError?) -> Unit)? = null
 
-    // Callbacks set by IosL2capListener
     @Volatile
     internal var onPublishL2cap: ((CBL2CAPPSM, NSError?) -> Unit)? = null
 
     @Volatile
     internal var onOpenL2capChannel: ((CBL2CAPChannel?, NSError?) -> Unit)? = null
-
-    @Volatile
-    internal var onUnpublishL2cap: ((CBL2CAPPSM, NSError?) -> Unit)? = null
 
     // --- Required delegate method ---
 
@@ -134,14 +130,5 @@ internal class IosPeripheralManagerDelegate :
         error: NSError?,
     ) {
         onOpenL2capChannel?.invoke(didOpenL2CAPChannel, error)
-    }
-
-    @ObjCSignatureOverride
-    override fun peripheralManager(
-        peripheral: CBPeripheralManager,
-        didUnpublishL2CAPChannel: CBL2CAPPSM,
-        error: NSError?,
-    ) {
-        onUnpublishL2cap?.invoke(didUnpublishL2CAPChannel, error)
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/IosPeripheralManagerDelegate.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import platform.CoreBluetooth.CBATTRequest
 import platform.CoreBluetooth.CBCentral
 import platform.CoreBluetooth.CBCharacteristic
+import platform.CoreBluetooth.CBL2CAPChannel
+import platform.CoreBluetooth.CBL2CAPPSM
 import platform.CoreBluetooth.CBPeripheralManager
 import platform.CoreBluetooth.CBPeripheralManagerDelegateProtocol
 import platform.CoreBluetooth.CBPeripheralManagerStateUnknown
@@ -13,6 +15,7 @@ import platform.CoreBluetooth.CBService
 import platform.Foundation.NSError
 import platform.darwin.NSObject
 import kotlin.concurrent.Volatile
+import kotlinx.cinterop.ObjCSignatureOverride
 
 /**
  * Unified [CBPeripheralManager] delegate handling server, advertising,
@@ -50,6 +53,16 @@ internal class IosPeripheralManagerDelegate :
     // Callback set by IosAdvertiser
     @Volatile
     internal var onStartAdvertising: ((NSError?) -> Unit)? = null
+
+    // Callbacks set by IosL2capListener
+    @Volatile
+    internal var onPublishL2cap: ((CBL2CAPPSM, NSError?) -> Unit)? = null
+
+    @Volatile
+    internal var onOpenL2capChannel: ((CBL2CAPChannel?, NSError?) -> Unit)? = null
+
+    @Volatile
+    internal var onUnpublishL2cap: ((CBL2CAPPSM, NSError?) -> Unit)? = null
 
     // --- Required delegate method ---
 
@@ -104,5 +117,31 @@ internal class IosPeripheralManagerDelegate :
 
     override fun peripheralManagerIsReadyToUpdateSubscribers(peripheral: CBPeripheralManager) {
         onReadyToUpdate?.invoke()
+    }
+
+    @ObjCSignatureOverride
+    override fun peripheralManager(
+        peripheral: CBPeripheralManager,
+        didPublishL2CAPChannel: CBL2CAPPSM,
+        error: NSError?,
+    ) {
+        onPublishL2cap?.invoke(didPublishL2CAPChannel, error)
+    }
+
+    override fun peripheralManager(
+        peripheral: CBPeripheralManager,
+        didOpenL2CAPChannel: CBL2CAPChannel?,
+        error: NSError?,
+    ) {
+        onOpenL2capChannel?.invoke(didOpenL2CAPChannel, error)
+    }
+
+    @ObjCSignatureOverride
+    override fun peripheralManager(
+        peripheral: CBPeripheralManager,
+        didUnpublishL2CAPChannel: CBL2CAPPSM,
+        error: NSError?,
+    ) {
+        onUnpublishL2cap?.invoke(didUnpublishL2CAPChannel, error)
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -104,9 +104,7 @@ internal class IosL2capChannel(
             }
         } finally {
             if (_isOpen.compareAndSet(expect = true, update = false)) {
-                closeStreams()
-                dataChannel.close()
-                closedSignal.complete(Unit)
+                finalizeClose()
             }
         }
     }
@@ -153,6 +151,10 @@ internal class IosL2capChannel(
     override fun close() {
         if (!_isOpen.compareAndSet(expect = true, update = false)) return
         readJob.cancel()
+        finalizeClose()
+    }
+
+    private fun finalizeClose() {
         closeStreams()
         dataChannel.close()
         closedSignal.complete(Unit)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -6,6 +6,7 @@ import kotlinx.cinterop.UByteVar
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -39,7 +40,11 @@ internal class IosL2capChannel(
     private val dataChannel = Channel<ByteArray>(Channel.BUFFERED)
     override val incoming: Flow<ByteArray> = dataChannel.receiveAsFlow()
 
+    private val closedSignal = CompletableDeferred<Unit>()
+
     private val readJob: Job
+
+    internal suspend fun awaitClosed() = closedSignal.await()
 
     init {
         val inputOk = cbChannel.inputStream?.streamStatus == NSStreamStatusOpen
@@ -101,6 +106,7 @@ internal class IosL2capChannel(
             if (_isOpen.compareAndSet(expect = true, update = false)) {
                 closeStreams()
                 dataChannel.close()
+                closedSignal.complete(Unit)
             }
         }
     }
@@ -149,6 +155,7 @@ internal class IosL2capChannel(
         readJob.cancel()
         closeStreams()
         dataChannel.close()
+        closedSignal.complete(Unit)
     }
 
     private fun closeStreams() {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
@@ -1,0 +1,104 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.atruedev.kmpble.l2cap
+
+import com.atruedev.kmpble.internal.PeripheralManagerProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.CoreBluetooth.CBL2CAPPSM
+
+internal class IosL2capListener : L2capListener {
+    private val _isOpen = MutableStateFlow(false)
+    override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    private var _psm: Int = 0
+    override val psm: Int get() = _psm
+
+    private val _incoming = MutableSharedFlow<L2capChannel>(
+        replay = 0,
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private var publishedPsm: CBL2CAPPSM = 0u
+    private var closed: Boolean = false
+
+    override suspend fun open(secure: Boolean) {
+        if (closed) throw L2capException.InvalidState("Listener has been closed")
+        if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
+
+        val delegate = PeripheralManagerProvider.delegate
+        val manager = PeripheralManagerProvider.manager
+
+        val publishResult = CompletableDeferred<CBL2CAPPSM>()
+        delegate.onPublishL2cap = { psmAssigned, error ->
+            if (error != null) {
+                publishResult.completeExceptionally(
+                    L2capException.PublishFailed(error.localizedDescription),
+                )
+            } else {
+                publishResult.complete(psmAssigned)
+            }
+        }
+
+        delegate.onOpenL2capChannel = { cbChannel, error ->
+            if (cbChannel != null && error == null) {
+                val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val channel = IosL2capChannel(
+                    cbChannel = cbChannel,
+                    scope = channelScope,
+                    mtu = DEFAULT_L2CAP_MTU,
+                )
+                if (!_incoming.tryEmit(channel)) {
+                    channel.close()
+                    channelScope.cancel()
+                }
+            }
+        }
+
+        manager.publishL2CAPChannelWithEncryption(secure)
+
+        val assigned = try {
+            publishResult.await()
+        } catch (e: L2capException) {
+            delegate.onPublishL2cap = null
+            throw e
+        }
+
+        publishedPsm = assigned
+        _psm = assigned.toInt()
+        _isOpen.value = true
+        delegate.onPublishL2cap = null
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        _isOpen.value = false
+
+        val delegate = PeripheralManagerProvider.delegate
+        delegate.onOpenL2capChannel = null
+
+        if (publishedPsm != 0.toUShort()) {
+            try {
+                PeripheralManagerProvider.manager.unpublishL2CAPChannel(publishedPsm)
+            } catch (_: Throwable) {
+            }
+        }
+
+        scope.cancel()
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
@@ -173,7 +173,15 @@ internal class IosL2capListener : L2capListener {
             }
         }
 
+        // Drain buffered handoff queue before cancelling the scope, otherwise
+        // the drainer can be cancelled at a suspension point with cbChannels
+        // still in the buffer (input/output streams open, never closed).
         acceptedChannels.close()
+        while (true) {
+            val orphan = acceptedChannels.tryReceive().getOrNull() ?: break
+            orphan.inputStream?.close()
+            orphan.outputStream?.close()
+        }
         scope.cancel()
     }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
@@ -92,6 +92,11 @@ internal class IosL2capListener : L2capListener {
         // gave up, the callback still runs and unpublishes the PSM itself.
         // Otherwise the PSM would stay registered on CBPeripheralManager
         // until process exit.
+        //
+        // Degenerate case: if CoreBluetooth never delivers the callback at
+        // all (broken HW/OS state), this slot stays held and the next
+        // L2capListener.open() fails the require-check with InvalidState
+        // until the process exits.
         delegate.onPublishL2cap = { psmAssigned, error ->
             when {
                 error != null -> {
@@ -102,15 +107,15 @@ internal class IosL2capListener : L2capListener {
                             ),
                         )
                     }
-                    PeripheralManagerProvider.delegate.onPublishL2cap = null
+                    delegate.onPublishL2cap = null
                 }
                 closed -> {
                     // Late successful delivery after open() already gave up - clean up.
                     try {
-                        PeripheralManagerProvider.manager.unpublishL2CAPChannel(psmAssigned)
+                        manager.unpublishL2CAPChannel(psmAssigned)
                     } catch (_: Throwable) {
                     }
-                    PeripheralManagerProvider.delegate.onPublishL2cap = null
+                    delegate.onPublishL2cap = null
                 }
                 else -> {
                     publishedPsm = psmAssigned
@@ -144,7 +149,7 @@ internal class IosL2capListener : L2capListener {
                 // before we set closed=true, drop it ourselves.
                 if (publishedPsm != 0.toUShort()) {
                     try {
-                        PeripheralManagerProvider.manager.unpublishL2CAPChannel(publishedPsm)
+                        manager.unpublishL2CAPChannel(publishedPsm)
                     } catch (_: Throwable) {
                     }
                     publishedPsm = 0u
@@ -203,11 +208,12 @@ internal class IosL2capListener : L2capListener {
         _isOpen.value = false
 
         val delegate = PeripheralManagerProvider.delegate
+        val manager = PeripheralManagerProvider.manager
         delegate.onOpenL2capChannel = null
 
         if (publishedPsm != 0.toUShort()) {
             try {
-                PeripheralManagerProvider.manager.unpublishL2CAPChannel(publishedPsm)
+                manager.unpublishL2CAPChannel(publishedPsm)
             } catch (_: Throwable) {
             }
         }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
@@ -64,11 +64,13 @@ internal class IosL2capListener : L2capListener {
         val delegate = PeripheralManagerProvider.delegate
         val manager = PeripheralManagerProvider.manager
 
-        require(delegate.onPublishL2cap == null) {
-            "Another L2capListener is publishing; only one listener can publish at a time"
+        if (delegate.onPublishL2cap != null) {
+            throw L2capException.InvalidState(
+                "Another L2capListener is publishing; only one listener can publish at a time",
+            )
         }
-        require(delegate.onOpenL2capChannel == null) {
-            "Another L2capListener is accepting connections"
+        if (delegate.onOpenL2capChannel != null) {
+            throw L2capException.InvalidState("Another L2capListener is accepting connections")
         }
 
         val effectiveMtu = mtu ?: DEFAULT_L2CAP_MTU
@@ -84,15 +86,37 @@ internal class IosL2capListener : L2capListener {
             }
         }
 
+        // Callback survives the publish timeout window: if
+        // `publishL2CAPChannelWithEncryption` actually succeeded at the OS
+        // level but the assignment notification arrives after we already
+        // gave up, the callback still runs and unpublishes the PSM itself.
+        // Otherwise the PSM would stay registered on CBPeripheralManager
+        // until process exit.
         delegate.onPublishL2cap = { psmAssigned, error ->
-            if (error != null) {
-                publishResult.completeExceptionally(
-                    L2capException.PublishFailed(
-                        "CBPeripheralManager publishL2CAPChannel error: ${error.localizedDescription}",
-                    ),
-                )
-            } else {
-                publishResult.complete(psmAssigned)
+            when {
+                error != null -> {
+                    if (!publishResult.isCompleted) {
+                        publishResult.completeExceptionally(
+                            L2capException.PublishFailed(
+                                "CBPeripheralManager publishL2CAPChannel error: ${error.localizedDescription}",
+                            ),
+                        )
+                    }
+                    PeripheralManagerProvider.delegate.onPublishL2cap = null
+                }
+                closed -> {
+                    // Late successful delivery after open() already gave up - clean up.
+                    try {
+                        PeripheralManagerProvider.manager.unpublishL2CAPChannel(psmAssigned)
+                    } catch (_: Throwable) {
+                    }
+                    PeripheralManagerProvider.delegate.onPublishL2cap = null
+                }
+                else -> {
+                    publishedPsm = psmAssigned
+                    publishResult.complete(psmAssigned)
+                    // Success path clears the delegate slot explicitly below.
+                }
             }
         }
 
@@ -108,11 +132,23 @@ internal class IosL2capListener : L2capListener {
                     publishResult.await()
                 }
             } catch (e: Throwable) {
+                // Mark closed BEFORE giving up on the callback so that any
+                // late onPublishL2cap delivery sees `closed == true` and
+                // unpublishes the assigned PSM itself.
                 closed = true
                 delegate.onOpenL2capChannel = null
                 drainJob?.cancel()
                 drainJob = null
                 acceptedChannels.close()
+                // Defensive: if the callback raced ahead and stored the PSM
+                // before we set closed=true, drop it ourselves.
+                if (publishedPsm != 0.toUShort()) {
+                    try {
+                        PeripheralManagerProvider.manager.unpublishL2CAPChannel(publishedPsm)
+                    } catch (_: Throwable) {
+                    }
+                    publishedPsm = 0u
+                }
                 throw when (e) {
                     is L2capException -> e
                     is TimeoutCancellationException ->
@@ -122,9 +158,12 @@ internal class IosL2capListener : L2capListener {
                         )
                     else -> e
                 }
-            } finally {
-                delegate.onPublishL2cap = null
             }
+
+        // Clear the slot now so a subsequent listener's require-check sees a
+        // clean delegate. The success-path branch of the callback intentionally
+        // skips clearing to keep this single deterministic owner.
+        delegate.onPublishL2cap = null
 
         publishedPsm = assigned
         _psm = assigned.toInt()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capListener.kt
@@ -6,82 +6,156 @@ import com.atruedev.kmpble.internal.PeripheralManagerProvider
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreBluetooth.CBL2CAPPSM
+import platform.CoreBluetooth.CBPeripheralManagerStatePoweredOn
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 internal class IosL2capListener : L2capListener {
     private val _isOpen = MutableStateFlow(false)
     override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
 
+    @Volatile
     private var _psm: Int = 0
     override val psm: Int get() = _psm
 
-    private val _incoming = MutableSharedFlow<L2capChannel>(
-        replay = 0,
-        extraBufferCapacity = 16,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    override val incoming: Flow<L2capChannel> = _incoming.asSharedFlow()
+    private val _incoming =
+        MutableSharedFlow<L2capChannel>(
+            replay = 0,
+            extraBufferCapacity = 16,
+        )
+    override val incoming: SharedFlow<L2capChannel> = _incoming.asSharedFlow()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    private val acceptedChannels = Channel<CBL2CAPChannel>(Channel.BUFFERED)
+
+    @Volatile
     private var publishedPsm: CBL2CAPPSM = 0u
+
+    @Volatile
     private var closed: Boolean = false
 
-    override suspend fun open(secure: Boolean) {
+    private var drainJob: Job? = null
+
+    override suspend fun open(
+        secure: Boolean,
+        mtu: Int?,
+    ) {
         if (closed) throw L2capException.InvalidState("Listener has been closed")
         if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
 
         val delegate = PeripheralManagerProvider.delegate
         val manager = PeripheralManagerProvider.manager
 
+        require(delegate.onPublishL2cap == null) {
+            "Another L2capListener is publishing; only one listener can publish at a time"
+        }
+        require(delegate.onOpenL2capChannel == null) {
+            "Another L2capListener is accepting connections"
+        }
+
+        val effectiveMtu = mtu ?: DEFAULT_L2CAP_MTU
         val publishResult = CompletableDeferred<CBL2CAPPSM>()
+
+        delegate.onOpenL2capChannel = { cbChannel, error ->
+            if (closed || cbChannel == null || error != null) {
+                cbChannel?.inputStream?.close()
+                cbChannel?.outputStream?.close()
+            } else if (acceptedChannels.trySend(cbChannel).isFailure) {
+                cbChannel.inputStream?.close()
+                cbChannel.outputStream?.close()
+            }
+        }
+
         delegate.onPublishL2cap = { psmAssigned, error ->
             if (error != null) {
                 publishResult.completeExceptionally(
-                    L2capException.PublishFailed(error.localizedDescription),
+                    L2capException.PublishFailed(
+                        "CBPeripheralManager publishL2CAPChannel error: ${error.localizedDescription}",
+                    ),
                 )
             } else {
                 publishResult.complete(psmAssigned)
             }
         }
 
-        delegate.onOpenL2capChannel = { cbChannel, error ->
-            if (cbChannel != null && error == null) {
-                val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-                val channel = IosL2capChannel(
-                    cbChannel = cbChannel,
-                    scope = channelScope,
-                    mtu = DEFAULT_L2CAP_MTU,
-                )
-                if (!_incoming.tryEmit(channel)) {
-                    channel.close()
-                    channelScope.cancel()
+        drainJob = scope.launch { drainAcceptedChannels(effectiveMtu) }
+
+        val assigned: CBL2CAPPSM =
+            try {
+                withTimeout(PUBLISH_TIMEOUT) {
+                    if (delegate.managerState.value != CBPeripheralManagerStatePoweredOn) {
+                        delegate.managerState.first { it == CBPeripheralManagerStatePoweredOn }
+                    }
+                    manager.publishL2CAPChannelWithEncryption(secure)
+                    publishResult.await()
                 }
+            } catch (e: Throwable) {
+                closed = true
+                delegate.onOpenL2capChannel = null
+                drainJob?.cancel()
+                drainJob = null
+                acceptedChannels.close()
+                throw when (e) {
+                    is L2capException -> e
+                    is TimeoutCancellationException ->
+                        L2capException.PublishFailed(
+                            "publishL2CAPChannel timed out after $PUBLISH_TIMEOUT",
+                            e,
+                        )
+                    else -> e
+                }
+            } finally {
+                delegate.onPublishL2cap = null
             }
-        }
-
-        manager.publishL2CAPChannelWithEncryption(secure)
-
-        val assigned = try {
-            publishResult.await()
-        } catch (e: L2capException) {
-            delegate.onPublishL2cap = null
-            throw e
-        }
 
         publishedPsm = assigned
         _psm = assigned.toInt()
         _isOpen.value = true
-        delegate.onPublishL2cap = null
+    }
+
+    private suspend fun drainAcceptedChannels(mtu: Int) {
+        for (cbChannel in acceptedChannels) {
+            if (closed) {
+                cbChannel.inputStream?.close()
+                cbChannel.outputStream?.close()
+                continue
+            }
+            val channelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val channel =
+                IosL2capChannel(
+                    cbChannel = cbChannel,
+                    scope = channelScope,
+                    mtu = mtu,
+                )
+            channelScope.launch {
+                channel.awaitClosed()
+                channelScope.cancel()
+            }
+            try {
+                _incoming.emit(channel)
+            } catch (e: CancellationException) {
+                channel.close()
+                throw e
+            }
+        }
     }
 
     override fun close() {
@@ -99,6 +173,11 @@ internal class IosL2capListener : L2capListener {
             }
         }
 
+        acceptedChannels.close()
         scope.cancel()
+    }
+
+    private companion object {
+        val PUBLISH_TIMEOUT = 10.seconds
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.ios.kt
@@ -1,0 +1,3 @@
+package com.atruedev.kmpble.l2cap
+
+public actual fun L2capListener(): L2capListener = IosL2capListener()

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/l2cap/L2capListenerFactory.jvm.kt
@@ -1,0 +1,5 @@
+package com.atruedev.kmpble.l2cap
+
+import com.atruedev.kmpble.unsupportedBle
+
+public actual fun L2capListener(): L2capListener = unsupportedBle("L2capListener")


### PR DESCRIPTION
## Summary

Server-side counterpart to the existing client-side `Peripheral.openL2capChannel`. Lets a peripheral publish an L2CAP CoC PSM and accept stream-oriented connections from centrals, which is the right primitive for transferring typed payloads larger than a GATT MTU (Wi-Fi analytics, healthcare telemetry, agri sensor batches).

Pairs with the typed `Codec<T>` + length-prefix framing that landed in #170; together they let a peripheral stream framed CBOR / Protobuf / custom payloads to a phone, with byte-level transport handled by the library.

## API

```kotlin
val listener = L2capListener()
listener.open(secure = true)
val psm = listener.psm

// Expose PSM through a GATT characteristic so centrals can discover it
gattServer.notify(PSM_CHAR_UUID, null, BleData(psm.toUInt16LeBytes()))

listener.incoming.collect { channel ->
    scope.launch {
        channel.incoming.collect { bytes -> handle(bytes) }
    }
}

listener.close()
```

- `L2capListener` interface: `psm`, `isOpen: StateFlow<Boolean>`, `incoming: Flow<L2capChannel>`, suspending `open(secure)`, `close()`. One-shot lifecycle.
- `L2capListener()` `expect` factory; platform actuals for Android, iOS, JVM-stub.
- New `L2capException.PublishFailed` and `L2capException.InvalidState`.
- `FakeL2capListener` in `testing/` for unit tests.

## Platform notes

**Android (`AndroidL2capListener`)**
- Uses `BluetoothAdapter.listenUsingL2capChannel()` (secure) or `listenUsingInsecureL2capChannel()` (insecure).
- Accept loop runs on `Dispatchers.IO`. Each accepted `BluetoothSocket` is wrapped through the existing `BluetoothL2capSocket` -> `AndroidL2capChannel` pipeline (no duplication of read-loop / write-loop logic).
- Each accepted channel gets its own `CoroutineScope`, so `listener.close()` tears down only the accept loop and leaves in-flight channels for their consumers to close.

**iOS (`IosL2capListener`)**
- Uses the shared `PeripheralManagerProvider.manager`. `CBPeripheralManager` is shared with `GattServer` and `Advertiser` by platform necessity.
- `IosPeripheralManagerDelegate` gains three new callbacks (`onPublishL2cap`, `onOpenL2capChannel`, `onUnpublishL2cap`) and three delegate-method overrides. The two `CBL2CAPPSM`-typed methods need `@ObjCSignatureOverride` because Kotlin/Native erases their Kotlin signatures to the same shape.

**JVM stub** -> throws via `unsupportedBle`, matching `Advertiser` / `GattServer`.

## Sample

`ServerScreen` gets a new `L2capServerCard` next to the existing `GattServerCard`. Tap `Open Secure` to publish a listener; the assigned PSM is shown on the chip. Accepted channels echo any received bytes back, so the existing client-side `L2capController` in the same sample can drive a round-trip across two devices for manual verification.

## Test plan

- [x] `:jvmTest` — `FakeL2capListenerTest` (6 cases) covers state transitions, error paths (already-open, post-close), and incoming-channel emission. 301/301 module tests pass.
- [x] `compileKotlinIosSimulatorArm64` + `compileAndroidMain` — no platform-specific compile errors.
- [x] Sample compiles for both `sample:compileKotlinIosSimulatorArm64` and `sample-android:compileDebugKotlin`.
- [x] Typography check: ASCII-only.
- [ ] On-device round trip: open echo server on Android phone A, connect from Android phone B via `L2capController`, verify echo.
- [ ] On-device round trip: same but A = Android, B = iOS (and vice versa).

## Out of scope

- No CBOR / Protobuf codec integration into the sample; that lands in a follow-up that combines the new `Codec<T>` API with `L2capListener`.
- No documentation changes to `ARCHITECTURE.md` or `MIGRATION.md`; this PR is additive and discoverable from the existing L2CAP docs. Will batch with the Phase 2 follow-up.