### PR TITLE
feat(codec): add framed L2CAP convenience extensions

### DIFF
--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
@@ -11,3 +11,36 @@ public fun <T> L2capChannel.incoming(decoder: BleDecoder<T>): Flow<T> =
 /** Encode a value and write it to the L2CAP channel. */
 public suspend fun <T> L2capChannel.write(value: T, encoder: BleEncoder<T>): Unit =
     write(encoder.encode(value))
+
+/**
+ * Decode framed payloads from the L2CAP incoming stream.
+ *
+ * Pairs with [writeFramed]. The remote side frames each logical message with
+ * [framer], and this side recovers the framed bytes back to typed values.
+ * Use when one L2CAP packet does not correspond 1:1 to one logical message -
+ * for example continuous telemetry streams where the OS may coalesce or
+ * split frames at the transport layer.
+ *
+ * Decoder failures on individual frames are routed to [onDecodeFailure] and
+ * dropped from the output stream. A malformed length prefix
+ * ([FrameTooLargeException]) terminates the flow; wrap with `.catch { }` to
+ * recover.
+ */
+public fun <T> L2capChannel.framedIncoming(
+    decoder: BleDecoder<T>,
+    framer: Framer = LengthPrefixFramer(),
+    onDecodeFailure: (ByteArray) -> Unit = {},
+): Flow<T> = incoming.decodeFramed(decoder, framer, onDecodeFailure)
+
+/**
+ * Encode a value, frame the bytes, and write the framed packet.
+ *
+ * Pairs with [framedIncoming]. The framer prefixes the encoded payload with
+ * a length header so the receiver can recover boundaries independent of how
+ * the transport delivers chunks.
+ */
+public suspend fun <T> L2capChannel.writeFramed(
+    value: T,
+    encoder: BleEncoder<T>,
+    framer: Framer = LengthPrefixFramer(),
+): Unit = write(framer.frame(encoder.encode(value)))

--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
@@ -21,6 +21,10 @@ public suspend fun <T> L2capChannel.write(value: T, encoder: BleEncoder<T>): Uni
  * for example continuous telemetry streams where the OS may coalesce or
  * split frames at the transport layer.
  *
+ * The framer configuration (especially `maxFrameSize`) must match the
+ * producer's; a sender that frames a 100 KiB payload against a receiver
+ * holding the default 64 KiB cap raises [FrameTooLargeException] here.
+ *
  * Decoder failures on individual frames are routed to [onDecodeFailure] and
  * dropped from the output stream. A malformed length prefix
  * ([FrameTooLargeException]) terminates the flow; wrap with `.catch { }` to
@@ -37,7 +41,8 @@ public fun <T> L2capChannel.framedIncoming(
  *
  * Pairs with [framedIncoming]. The framer prefixes the encoded payload with
  * a length header so the receiver can recover boundaries independent of how
- * the transport delivers chunks.
+ * the transport delivers chunks. Throws if the encoded payload exceeds the
+ * framer's `maxFrameSize`; no bytes are written in that case.
  */
 public suspend fun <T> L2capChannel.writeFramed(
     value: T,

--- a/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/L2capCodecTest.kt
+++ b/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/L2capCodecTest.kt
@@ -3,6 +3,9 @@
 package com.atruedev.kmpble.codec
 
 import com.atruedev.kmpble.testing.FakeL2capChannel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -10,6 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class L2capCodecTest {
 
@@ -72,5 +76,130 @@ class L2capCodecTest {
 
         assertIs<IllegalArgumentException>(caughtException)
         job.cancel()
+    }
+
+    @Test
+    fun writeFramedPrefixesLengthHeader() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+
+        channel.writeFramed("hi", TestStringEncoder)
+
+        val written = channel.getWrittenData()
+        assertEquals(1, written.size)
+        val expected = byteArrayOf(0x02, 0x00, 0x00, 0x00) + "hi".encodeToByteArray()
+        assertContentEquals(expected, written[0])
+    }
+
+    @Test
+    fun framedIncomingDecodesMultiFrameStream() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+        val framer = LengthPrefixFramer()
+        val received = mutableListOf<String>()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel.framedIncoming(TestStringDecoder, framer).collect { received.add(it) }
+        }
+
+        channel.emitIncoming(framer.frame("alpha".encodeToByteArray()))
+        channel.emitIncoming(framer.frame("beta".encodeToByteArray()))
+        channel.emitIncoming(framer.frame("gamma".encodeToByteArray()))
+
+        assertEquals(listOf("alpha", "beta", "gamma"), received)
+        job.cancel()
+    }
+
+    @Test
+    fun framedIncomingRoutesDecodeFailureToCallback() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+        val framer = LengthPrefixFramer()
+        val failures = mutableListOf<ByteArray>()
+        val received = mutableListOf<Int>()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel
+                .framedIncoming(TestIntDecoder, framer, onDecodeFailure = { failures.add(it) })
+                .collect { received.add(it) }
+        }
+
+        channel.emitIncoming(framer.frame(TestIntEncoder.encode(0x1234)))
+        channel.emitIncoming(framer.frame(byteArrayOf(0x01)))
+        channel.emitIncoming(framer.frame(TestIntEncoder.encode(0x5678)))
+
+        assertEquals(listOf(0x1234, 0x5678), received)
+        assertEquals(1, failures.size)
+        assertContentEquals(byteArrayOf(0x01), failures[0])
+        job.cancel()
+    }
+
+    @Test
+    fun framedIncomingPropagatesFrameTooLargeException() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+        val framer = LengthPrefixFramer(maxFrameSize = 2)
+        var caught: Throwable? = null
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            channel
+                .framedIncoming(TestStringDecoder, framer)
+                .catch { caught = it }
+                .collect {}
+        }
+
+        channel.emitIncoming(
+            byteArrayOf(0x03, 0x00, 0x00, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()),
+        )
+
+        assertIs<FrameTooLargeException>(caught)
+        assertEquals(3L, (caught as FrameTooLargeException).size)
+        assertEquals(2, (caught as FrameTooLargeException).maxSize)
+        job.cancel()
+    }
+
+    @Test
+    fun writeFramedRoundTripsThroughFramedIncoming() = runTest {
+        val sender = FakeL2capChannel(psm = 0x25)
+        val receiver = FakeL2capChannel(psm = 0x25)
+        val framer = LengthPrefixFramer()
+        val values = listOf("one", "two", "three")
+
+        values.forEach { sender.writeFramed(it, TestStringEncoder, framer) }
+        sender.getWrittenData().forEach { receiver.emitIncoming(it) }
+        receiver.close()
+
+        val decoded = receiver.framedIncoming(TestStringDecoder, framer).toList()
+
+        assertEquals(values, decoded)
+    }
+
+    @Test
+    fun framedIncomingHandlesPacketBoundariesDifferentFromFrameBoundaries() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+        val framer = LengthPrefixFramer()
+        val full = framer.frame("payload".encodeToByteArray())
+
+        val firstHalf = full.copyOfRange(0, 5)
+        val secondHalf = full.copyOfRange(5, full.size)
+
+        channel.emitIncoming(firstHalf)
+        channel.emitIncoming(secondHalf)
+        channel.close()
+
+        val received = channel.framedIncoming(TestStringDecoder, framer).take(1).toList()
+        assertEquals(1, received.size)
+        assertEquals("payload", received[0])
+    }
+
+    @Test
+    fun writeFramedAndFramedIncomingDefaultToLengthPrefixFramer() = runTest {
+        val sender = FakeL2capChannel(psm = 0x25)
+        val receiver = FakeL2capChannel(psm = 0x25)
+
+        sender.writeFramed(0x4242, TestIntEncoder)
+        sender.getWrittenData().forEach { receiver.emitIncoming(it) }
+        receiver.close()
+
+        val decoded = receiver.framedIncoming(TestIntDecoder).toList()
+        assertEquals(1, decoded.size)
+        assertEquals(0x4242, decoded[0])
+        assertTrue(sender.getWrittenData()[0].size > 2, "framed payload includes length header")
     }
 }

--- a/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/L2capCodecTest.kt
+++ b/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/L2capCodecTest.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 class L2capCodecTest {
 
@@ -200,6 +200,20 @@ class L2capCodecTest {
         val decoded = receiver.framedIncoming(TestIntDecoder).toList()
         assertEquals(1, decoded.size)
         assertEquals(0x4242, decoded[0])
-        assertTrue(sender.getWrittenData()[0].size > 2, "framed payload includes length header")
+
+        val written = sender.getWrittenData()[0]
+        assertEquals(6, written.size)
+        assertContentEquals(byteArrayOf(0x02, 0x00, 0x00, 0x00), written.copyOfRange(0, 4))
+    }
+
+    @Test
+    fun writeFramedPropagatesOversizePayloadException() = runTest {
+        val channel = FakeL2capChannel(psm = 0x25)
+        val tinyFramer = LengthPrefixFramer(maxFrameSize = 2)
+
+        assertFailsWith<IllegalArgumentException> {
+            channel.writeFramed("too long for cap", TestStringEncoder, tinyFramer)
+        }
+        assertEquals(0, channel.getWrittenData().size)
     }
 }


### PR DESCRIPTION
## Summary

Adds the framed counterparts of the existing `L2capChannel.incoming(decoder)` / `L2capChannel.write(value, encoder)` codec extensions:

- `L2capChannel.framedIncoming(decoder, framer, onDecodeFailure): Flow<T>`
- `L2capChannel.writeFramed(value, encoder, framer)`

Both default to `LengthPrefixFramer()`. Pure composition over the existing `decodeFramed` operator and `Framer.frame` primitive - no new state, no platform code.

## Motivation

The existing pair handles the 1-packet = 1-message case. Streaming workloads (telemetry, batched sensor events, structured payloads larger than a single L2CAP packet) need framing so the receiver can reassemble logical messages independently of how the transport delivers chunks. Today callers reach for `channel.incoming.decodeFramed(decoder, framer, onDecodeFailure)` manually; `framedIncoming` is a 1-line wrapper that keeps the call site readable.

## Behavior

- Decoder failures on a frame route to `onDecodeFailure` and are dropped; remaining frames continue.
- `FrameTooLargeException` (malformed length prefix) terminates the flow; consumers recover via `.catch { }`.
- Partial frames spanning packet boundaries are buffered transparently by the underlying `Unframer`.

## Tests

7 new cases in `L2capCodecTest.kt` (11/11 pass on jvmTest):

- `writeFramedPrefixesLengthHeader` - asserts the 4-byte LE length prefix.
- `framedIncomingDecodesMultiFrameStream` - 3 framed packets in, 3 typed values out.
- `framedIncomingRoutesDecodeFailureToCallback` - bad payload between two good ones, callback fires, stream continues.
- `framedIncomingPropagatesFrameTooLargeException` - oversize length prefix, caught via `.catch`.
- `writeFramedRoundTripsThroughFramedIncoming` - sender writes 3 values, receiver decodes 3 values.
- `framedIncomingHandlesPacketBoundariesDifferentFromFrameBoundaries` - frame split across two packets, decoded as one.
- `writeFramedAndFramedIncomingDefaultToLengthPrefixFramer` - default-framer round trip + header present.

## Verify

- `:kmp-ble-codec:jvmTest` 11/11 pass
- `:kmp-ble-codec:compileKotlinIosSimulatorArm64` clean
- `:kmp-ble-codec:compileAndroidMain` clean
- `ktlintCheck` across all modules clean
- ASCII-only typography check passes