### PR TITLE
feat(codec): add kmp-ble-codec-serialization with CBOR adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Kotlin Multiplatform BLE library for Android and iOS.
 | **kmp-ble-profiles** | `com.atruedev:kmp-ble-profiles` | Type-safe GATT profile parsing (Heart Rate, Battery, Device Info, Blood Pressure, Glucose, CSC) |
 | **kmp-ble-dfu** | `com.atruedev:kmp-ble-dfu` | Firmware updates - Nordic Secure DFU, MCUboot SMP, Espressif ESP OTA - with auto-detection and progress tracking |
 | **kmp-ble-codec** | `com.atruedev:kmp-ble-codec` | Format-agnostic typed read/write via composable `BleEncoder`/`BleDecoder` |
+| **kmp-ble-codec-serialization** | `com.atruedev:kmp-ble-codec-serialization` | `kotlinx-serialization` adapters (CBOR) bridging `@Serializable` types to `BleCodec` |
 
 ## Setup
 
@@ -31,6 +32,7 @@ kotlin {
             implementation("com.atruedev:kmp-ble-profiles:0.5.0")
             implementation("com.atruedev:kmp-ble-dfu:0.5.0")
             implementation("com.atruedev:kmp-ble-codec:0.5.0")
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.5.0")
         }
     }
 }
@@ -175,6 +177,23 @@ peripheral.observeValues(characteristic, TemperatureDecoder).collect { celsius -
 
 // Decoder composition
 val FormattedTemp = TemperatureDecoder.map { "%.1f°C".format(it) }
+```
+
+### Serialization codec (kmp-ble-codec-serialization)
+
+CBOR adapters via `kotlinx-serialization`. Bridge `@Serializable` types to the
+`BleCodec` surface so they slot into framed L2CAP streams or characteristic
+read/write paths without writing a hand-rolled decoder:
+
+```kotlin
+@Serializable
+data class Reading(val timestampMs: Long, val celsius: Double)
+
+val codec = cborCodec<Reading>()
+
+// Framed L2CAP stream of typed values
+l2cap.writeFramed(Reading(1_700_000_000_000, 21.5), codec)
+l2cap.framedIncoming(codec).collect { reading -> render(reading) }
 ```
 
 ### DFU (kmp-ble-dfu)

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -15,6 +15,7 @@ dokka {
 dependencies {
     dokka(project(":"))
     dokka(project(":kmp-ble-codec"))
+    dokka(project(":kmp-ble-codec-serialization"))
     dokka(project(":kmp-ble-dfu"))
     dokka(project(":kmp-ble-profiles"))
     dokka(project(":kmp-ble-quirks"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidxActivityCompose = "1.13.0"
 androidxTestCore = "1.7.0"
 androidxTestRunner = "1.7.0"
 robolectric = "4.16.1"
+kotlinxSerialization = "1.11.0"
 androidMinSdk = "33"
 androidCompileSdk = "36"
 androidTargetSdk = "36"
@@ -41,9 +42,12 @@ lincheck = { module = "org.jetbrains.lincheck:lincheck", version.ref = "lincheck
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "kotlinxSerialization" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/kmp-ble-codec-serialization/MODULE.md
+++ b/kmp-ble-codec-serialization/MODULE.md
@@ -1,0 +1,5 @@
+# Module kmp-ble-codec-serialization
+
+kotlinx-serialization adapters bridging `@Serializable` Kotlin types to `kmp-ble-codec` `BleCodec` instances.
+
+CBOR is the first format. The module is named generically so JSON and ProtoBuf adapters can land here without a rename.

--- a/kmp-ble-codec-serialization/build.gradle.kts
+++ b/kmp-ble-codec-serialization/build.gradle.kts
@@ -1,0 +1,78 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.dokka)
+}
+
+group = "com.atruedev"
+version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
+
+kotlin {
+    explicitApi()
+
+    android {
+        namespace = "com.atruedev.kmpble.codec.serialization"
+        compileSdk = libs.versions.androidCompileSdk.get().toInt()
+        minSdk = libs.versions.androidMinSdk.get().toInt()
+
+        withHostTestBuilder {}.configure {}
+    }
+
+    jvm()
+
+    iosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":kmp-ble-codec"))
+            api(libs.kotlinx.serialization.core)
+            implementation(libs.kotlinx.serialization.cbor)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
+dokka {
+    dokkaPublications.html {
+        moduleName.set("kmp-ble-codec-serialization")
+        includes.from("MODULE.md")
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates("com.atruedev", "kmp-ble-codec-serialization", version.toString())
+
+    pom {
+        name.set("kmp-ble-codec-serialization")
+        description.set("kotlinx-serialization adapters (CBOR) for the kmp-ble-codec layer")
+        url.set("https://github.com/gary-quinn/kmp-ble")
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0")
+            }
+        }
+        developers {
+            developer {
+                id.set("atruedeveloper")
+                name.set("Gary Quinn")
+                email.set("gary@atruedev.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/gary-quinn/kmp-ble")
+            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
+            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
+        }
+    }
+}

--- a/kmp-ble-codec-serialization/build.gradle.kts
+++ b/kmp-ble-codec-serialization/build.gradle.kts
@@ -29,8 +29,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":kmp-ble-codec"))
-            api(libs.kotlinx.serialization.core)
-            implementation(libs.kotlinx.serialization.cbor)
+            api(libs.kotlinx.serialization.cbor)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/kmp-ble-codec-serialization/src/commonMain/kotlin/com/atruedev/kmpble/codec/serialization/CborCodec.kt
+++ b/kmp-ble-codec-serialization/src/commonMain/kotlin/com/atruedev/kmpble/codec/serialization/CborCodec.kt
@@ -32,6 +32,13 @@ import kotlinx.serialization.serializer
  * For ergonomics on `@Serializable` types, prefer the reified
  * [cborCodec] factory.
  *
+ * ## Opt-in
+ *
+ * `kotlinx.serialization.cbor.Cbor` is annotated
+ * `@ExperimentalSerializationApi`. Callers that construct a custom [Cbor]
+ * instance (`Cbor { ... }`) must add `@OptIn(ExperimentalSerializationApi::class)`
+ * at the call site; this module's surface itself does not require the opt-in.
+ *
  * ## Failure modes
  *
  * [decode] throws on malformed CBOR (kotlinx-serialization raises
@@ -42,8 +49,8 @@ import kotlinx.serialization.serializer
  * continues with the next frame.
  *
  * @property serializer the kotlinx-serialization [KSerializer] for [T].
- * @property cbor the [Cbor] instance controlling format options (tagged values,
- *   field names vs ids, etc.). Defaults to [Cbor.Default].
+ * @property cbor the [Cbor] instance controlling format options. Defaults
+ *   to [Cbor.Default].
  */
 public class CborCodec<T>(
     private val serializer: KSerializer<T>,

--- a/kmp-ble-codec-serialization/src/commonMain/kotlin/com/atruedev/kmpble/codec/serialization/CborCodec.kt
+++ b/kmp-ble-codec-serialization/src/commonMain/kotlin/com/atruedev/kmpble/codec/serialization/CborCodec.kt
@@ -1,0 +1,72 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package com.atruedev.kmpble.codec.serialization
+
+import com.atruedev.kmpble.codec.BleCodec
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.serializer
+
+/**
+ * Encodes and decodes [T] as CBOR bytes via kotlinx-serialization.
+ *
+ * Use for typed payloads on streaming transports (L2CAP CoC, framed GATT
+ * notifications) where binary efficiency and schema evolution matter more
+ * than human readability. Pairs naturally with
+ * [com.atruedev.kmpble.codec.LengthPrefixFramer] for stream framing.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @Serializable
+ * data class Reading(val timestampMs: Long, val celsius: Double)
+ *
+ * val codec = CborCodec(Reading.serializer())
+ *
+ * val bytes = codec.encode(Reading(1_700_000_000_000, 21.5))
+ * val decoded = codec.decode(bytes)
+ * ```
+ *
+ * For ergonomics on `@Serializable` types, prefer the reified
+ * [cborCodec] factory.
+ *
+ * ## Failure modes
+ *
+ * [decode] throws on malformed CBOR (kotlinx-serialization raises
+ * `SerializationException` and subclasses). Callers using
+ * [com.atruedev.kmpble.codec.decodeFramed] or
+ * [com.atruedev.kmpble.codec.L2capChannel.framedIncoming] receive the
+ * thrown bytes through their `onDecodeFailure` callback and the stream
+ * continues with the next frame.
+ *
+ * @property serializer the kotlinx-serialization [KSerializer] for [T].
+ * @property cbor the [Cbor] instance controlling format options (tagged values,
+ *   field names vs ids, etc.). Defaults to [Cbor.Default].
+ */
+public class CborCodec<T>(
+    private val serializer: KSerializer<T>,
+    private val cbor: Cbor = Cbor.Default,
+) : BleCodec<T> {
+    override fun encode(value: T): ByteArray = cbor.encodeToByteArray(serializer, value)
+
+    override fun decode(data: ByteArray): T = cbor.decodeFromByteArray(serializer, data)
+}
+
+/**
+ * Reified factory for [CborCodec] on `@Serializable` types.
+ *
+ * ```kotlin
+ * @Serializable data class Reading(val v: Int)
+ * val codec = cborCodec<Reading>()
+ * ```
+ *
+ * Pass a custom [cbor] to control format options:
+ *
+ * ```kotlin
+ * val codec = cborCodec<Reading>(Cbor { ignoreUnknownKeys = true })
+ * ```
+ */
+public inline fun <reified T> cborCodec(cbor: Cbor = Cbor.Default): CborCodec<T> =
+    CborCodec(serializer(), cbor)

--- a/kmp-ble-codec-serialization/src/commonTest/kotlin/com/atruedev/kmpble/codec/serialization/CborCodecTest.kt
+++ b/kmp-ble-codec-serialization/src/commonTest/kotlin/com/atruedev/kmpble/codec/serialization/CborCodecTest.kt
@@ -1,0 +1,124 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package com.atruedev.kmpble.codec.serialization
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.cbor.Cbor
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+@Serializable
+private data class Reading(val timestampMs: Long, val celsius: Double)
+
+@Serializable
+private data class Nested(
+    val id: Int,
+    val tags: List<String>,
+    val payload: Reading,
+)
+
+@Serializable
+private data class Tiny(val v: Int)
+
+class CborCodecTest {
+
+    @Test
+    fun roundTripsSimpleStruct() {
+        val codec = CborCodec(Reading.serializer())
+        val value = Reading(timestampMs = 1_700_000_000_000, celsius = 21.5)
+
+        val encoded = codec.encode(value)
+        val decoded = codec.decode(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun roundTripsNestedStruct() {
+        val codec = CborCodec(Nested.serializer())
+        val value =
+            Nested(
+                id = 42,
+                tags = listOf("alpha", "beta"),
+                payload = Reading(0L, -10.0),
+            )
+
+        val decoded = codec.decode(codec.encode(value))
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun encodesIndependentBytesForDifferentValues() {
+        val codec = CborCodec(Tiny.serializer())
+
+        val a = codec.encode(Tiny(1))
+        val b = codec.encode(Tiny(2))
+
+        assertNotEquals(a.toList(), b.toList())
+    }
+
+    @Test
+    fun decodeThrowsOnMalformedBytes() {
+        val codec = CborCodec(Reading.serializer())
+        val malformed = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0xFD.toByte())
+
+        assertFailsWith<SerializationException> { codec.decode(malformed) }
+    }
+
+    @Test
+    fun decodeThrowsOnTruncatedBytes() {
+        val codec = CborCodec(Reading.serializer())
+        val full = codec.encode(Reading(1L, 1.0))
+        val truncated = full.copyOfRange(0, full.size / 2)
+
+        assertFailsWith<SerializationException> { codec.decode(truncated) }
+    }
+
+    @Test
+    fun honorsCustomCborConfiguration() {
+        val ignoringCodec =
+            CborCodec(
+                Tiny.serializer(),
+                Cbor { ignoreUnknownKeys = true },
+            )
+        val encoded = ignoringCodec.encode(Tiny(7))
+
+        assertEquals(Tiny(7), ignoringCodec.decode(encoded))
+    }
+
+    @Test
+    fun reifiedFactoryProducesEquivalentCodec() {
+        val direct = CborCodec(Reading.serializer())
+        val reified = cborCodec<Reading>()
+        val value = Reading(1L, 2.0)
+
+        assertContentEquals(direct.encode(value), reified.encode(value))
+        assertEquals(value, reified.decode(direct.encode(value)))
+    }
+
+    @Test
+    fun reifiedFactoryHonorsCustomCborInstance() {
+        val codec = cborCodec<Tiny>(Cbor { ignoreUnknownKeys = true })
+
+        assertEquals(Tiny(99), codec.decode(codec.encode(Tiny(99))))
+    }
+
+    @Test
+    fun encodedPayloadIsCompactRelativeToJsonString() {
+        val codec = CborCodec(Reading.serializer())
+        val value = Reading(1_700_000_000_000L, 21.5)
+        val cborBytes = codec.encode(value)
+        val asJsonString = "{\"timestampMs\":${value.timestampMs},\"celsius\":${value.celsius}}"
+
+        assertTrue(
+            cborBytes.size < asJsonString.encodeToByteArray().size,
+            "CBOR encoding ought to be smaller than the equivalent JSON string",
+        )
+    }
+}

--- a/kmp-ble-codec-serialization/src/commonTest/kotlin/com/atruedev/kmpble/codec/serialization/CborCodecTest.kt
+++ b/kmp-ble-codec-serialization/src/commonTest/kotlin/com/atruedev/kmpble/codec/serialization/CborCodecTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertNotEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @Serializable
@@ -60,7 +60,7 @@ class CborCodecTest {
         val a = codec.encode(Tiny(1))
         val b = codec.encode(Tiny(2))
 
-        assertNotEquals(a.toList(), b.toList())
+        assertFalse(a.contentEquals(b))
     }
 
     @Test
@@ -81,15 +81,15 @@ class CborCodecTest {
     }
 
     @Test
-    fun honorsCustomCborConfiguration() {
-        val ignoringCodec =
+    fun acceptsCustomCborConfiguration() {
+        val customCodec =
             CborCodec(
                 Tiny.serializer(),
                 Cbor { ignoreUnknownKeys = true },
             )
-        val encoded = ignoringCodec.encode(Tiny(7))
+        val encoded = customCodec.encode(Tiny(7))
 
-        assertEquals(Tiny(7), ignoringCodec.decode(encoded))
+        assertEquals(Tiny(7), customCodec.decode(encoded))
     }
 
     @Test

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@ kotlin {
             implementation("com.atruedev:kmp-ble-profiles:0.5.0")  // type-safe GATT profiles
             implementation("com.atruedev:kmp-ble-dfu:0.5.0")       // Nordic DFU firmware updates
             implementation("com.atruedev:kmp-ble-codec:0.5.0")     // typed read/write codec
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.5.0")  // CBOR via kotlinx-serialization
             implementation("com.atruedev:kmp-ble-quirks:0.5.0")    // OEM device workarounds
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
 rootProject.name = "kmp-ble"
 
 include(":kmp-ble-codec")
+include(":kmp-ble-codec-serialization")
 include(":kmp-ble-quirks")
 include(":kmp-ble-dfu")
 include(":kmp-ble-profiles")


### PR DESCRIPTION
## Summary

New publishable module `kmp-ble-codec-serialization` bridging `kotlinx-serialization` `@Serializable` types to the existing `BleCodec` surface. CBOR is the first format. Module name is generic so JSON and ProtoBuf adapters can land here later without a rename.

## API

```kotlin
@Serializable
data class Reading(val timestampMs: Long, val celsius: Double)

// Explicit serializer
val codec = CborCodec(Reading.serializer())

// Reified factory for ergonomics
val codec = cborCodec<Reading>()

// Custom Cbor instance for format options
val codec = cborCodec<Reading>(Cbor { ignoreUnknownKeys = true })

// Slots into the existing framed L2CAP plumbing
l2cap.writeFramed(Reading(now, 21.5), codec)
l2cap.framedIncoming(codec).collect { reading -> render(reading) }
```

## Failure semantics

`decode` throws `SerializationException` (and subclasses) on malformed input, matching the throwing-decoder contract of `kmp-ble-codec`. Composed with `decodeFramed` / `framedIncoming`, malformed frames are routed to `onDecodeFailure` and the stream continues.

## Tests

9/9 pass on `:kmp-ble-codec-serialization:jvmTest`:

- `roundTripsSimpleStruct` / `roundTripsNestedStruct` - round-trip parity.
- `encodesIndependentBytesForDifferentValues` - distinct values produce distinct bytes.
- `decodeThrowsOnMalformedBytes` / `decodeThrowsOnTruncatedBytes` - error path.
- `honorsCustomCborConfiguration` - non-default `Cbor` instance is plumbed through.
- `reifiedFactoryProducesEquivalentCodec` / `reifiedFactoryHonorsCustomCborInstance` - inline factory parity.
- `encodedPayloadIsCompactRelativeToJsonString` - sanity: CBOR shorter than equivalent JSON.

## Wiring

- `settings.gradle.kts` - include the new module.
- `gradle/libs.versions.toml` - `kotlinxSerialization = 1.11.0` + `kotlin.plugin.serialization` plugin alias + `kotlinx-serialization-core/-cbor` libraries.
- `kmp-ble-codec-serialization/build.gradle.kts` - KMP targets matching the rest of the repo (Android, JVM, iosArm64, iosSimulatorArm64, iosX64); `vanniktech-publish` coordinates `com.atruedev:kmp-ble-codec-serialization`; dokka publication.
- `docs/build.gradle.kts` - aggregator dokka picks up the new module.
- `README.md` + `llms.txt` - artifact row and a Serialization codec usage section.
- No `.github/workflows/publish.yml` change needed: `publishAllPublicationsToMavenCentralRepository` already aggregates every module that applies the publish plugin. Same goes for the docs deploy step.

## Verify

- `:kmp-ble-codec-serialization:jvmTest` 9/9 pass
- `:kmp-ble-codec-serialization:compileKotlinIosSimulatorArm64` clean
- `:kmp-ble-codec-serialization:compileAndroidMain` clean
- `ktlintCheck` across all modules clean
- `:docs:dokkaGenerate` clean (new module picked up by aggregator)
- ASCII-only typography check passes