### PR TITLE
fix(ci): bump-docs regex matches multi-segment module suffixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Update README.md
         run: |
           VERSION="${{ needs.publish.outputs.version }}"
-          sed -i -E "s|implementation\(\"com\.atruedev:kmp-ble(-[a-z]+)?:[^\"]*\"\)|implementation(\"com.atruedev:kmp-ble\1:$VERSION\")|g" README.md
+          sed -i -E "s|implementation\(\"com\.atruedev:(kmp-ble[a-z-]*):[^\"]*\"\)|implementation(\"com.atruedev:\1:$VERSION\")|g" README.md
 
       - name: Update CHANGELOG.md
         run: |
@@ -195,7 +195,7 @@ jobs:
       - name: Update llms.txt
         run: |
           VERSION="${{ needs.publish.outputs.version }}"
-          sed -i -E "s|implementation\(\"com\.atruedev:kmp-ble(-[a-z]+)?:[^\"]*\"\)|implementation(\"com.atruedev:kmp-ble\1:$VERSION\")|g" llms.txt
+          sed -i -E "s|implementation\(\"com\.atruedev:(kmp-ble[a-z-]*):[^\"]*\"\)|implementation(\"com.atruedev:\1:$VERSION\")|g" llms.txt
 
       - name: Create Pull Request
         id: create-pr

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ kotlin {
             implementation("com.atruedev:kmp-ble-profiles:0.6.0")
             implementation("com.atruedev:kmp-ble-dfu:0.6.0")
             implementation("com.atruedev:kmp-ble-codec:0.6.0")
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.5.0")
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.6.0")
         }
     }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ kotlin {
             implementation("com.atruedev:kmp-ble-profiles:0.6.0")  // type-safe GATT profiles
             implementation("com.atruedev:kmp-ble-dfu:0.6.0")       // Nordic DFU firmware updates
             implementation("com.atruedev:kmp-ble-codec:0.6.0")     // typed read/write codec
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.5.0")  // CBOR via kotlinx-serialization
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.6.0")  // CBOR via kotlinx-serialization
             implementation("com.atruedev:kmp-ble-quirks:0.6.0")    // OEM device workarounds
         }
     }


### PR DESCRIPTION
## Summary

The post-release `update-docs` job's sed expression captured only **one** optional `-[a-z]+` suffix segment:

```
sed -i -E "s|implementation\(\"com\.atruedev:kmp-ble(-[a-z]+)?:...
```

So it correctly bumped `kmp-ble`, `kmp-ble-codec`, `kmp-ble-dfu`, `kmp-ble-profiles`, `kmp-ble-quirks` but missed `kmp-ble-codec-serialization` (two suffix segments). After the v0.6.0 release ([PR #176](https://github.com/gary-quinn/kmp-ble/pull/176)), both `README.md:35` and `llms.txt:27` were left pinned at `kmp-ble-codec-serialization:0.5.0` while every other module showed `0.6.0`.

## Fix

- **Workflow regex:** capture the full module name with `(kmp-ble[a-z-]*)` so any number of hyphen-separated segments works.
- **Manual catch-up:** bump `kmp-ble-codec-serialization:0.5.0` -> `0.6.0` in both `README.md` and `llms.txt`. The next release will keep them in sync automatically.

## Test plan

- [x] Local regex test against all 5 production module names (kmp-ble, -profiles, -dfu, -codec, -codec-serialization) + hypothetical -quirks: all bump to target version
- [x] Typography scan: 0 forbidden codepoints on all 3 touched files
- [x] Diff stat: 3 files, +4 / -4
- [ ] CI typography-check passes
- [ ] Verify visually after the next release that all module versions update

## Notes

Independent of [PR #177](https://github.com/gary-quinn/kmp-ble/pull/177) (architecture docs). Either can merge first; no conflicts.