### PR TITLE
fix(sample): apply kotlinx-serialization plugin for CBOR codec

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)


### PR DESCRIPTION
## Summary
- `SensorReading` is annotated `@Serializable`, but the `:sample` module never applied the `kotlinx-serialization` Gradle plugin, so no compile-time `serializer()` was generated.
- At runtime, `cborCodec<SensorReading>()` falls back to a reflective `serializer<T>()` lookup, which raises `SerializationException` during the top-level init of `SensorReadingCodec`. The first frame written by `streamReadings()` crashes both the GATT server side and any client that touches the codec via `L2capController`.
- Apply `alias(libs.plugins.kotlin.serialization)` (already declared in `gradle/libs.versions.toml`) so the serializer is generated at compile time.

Stack trace before the fix:
```
java.lang.ExceptionInInitializerError
  at ServerViewModel.streamReadings(ServerViewModel.kt:213)
Caused by: kotlinx.serialization.SerializationException: Serializer for class 'SensorReading' is not found.
Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
  at SensorReadingKt.<clinit>(SensorReading.kt:24)
```

## Test plan
- [x] `./gradlew :sample:compileAndroidMain :sample:compileKotlinIosSimulatorArm64` passes locally
- [x] Reproduced the original crash by opening the L2CAP listener on the server and connecting from the client with pairing; after the fix, sensor frames stream without `ExceptionInInitializerError` on either side