### PR TITLE
feat(sample): pin and highlight kmp-ble servers in scanner

### DIFF
--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.sample
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,12 +15,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -60,7 +64,10 @@ private data class ScannedDevice(
     val isLegacy: Boolean,
     val isConnectable: Boolean,
     val phyInfo: String?,
+    val isSample: Boolean,
 )
+
+private fun Advertisement.isSampleServer(): Boolean = name?.startsWith(SAMPLE_NAME_PREFIX) == true
 
 @OptIn(ExperimentalUuidApi::class)
 private fun Advertisement.toScannedDevice() =
@@ -79,6 +86,7 @@ private fun Advertisement.toScannedDevice() =
             } else {
                 null
             },
+        isSample = isSampleServer(),
     )
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -117,7 +125,12 @@ fun ScannerScreen(
                     val snapshot =
                         withContext(scanContext) {
                             deviceMap.entries.removeAll { it.value.second.elapsedNow() > 10.seconds }
-                            deviceMap.values.map { it.first }.sortedByDescending { it.rssi }
+                            deviceMap.values
+                                .map { it.first }
+                                .sortedWith(
+                                    compareByDescending<Advertisement> { it.isSampleServer() }
+                                        .thenByDescending { it.rssi },
+                                )
                         }
                     advertisementLookup.clear()
                     snapshot.forEach { advertisementLookup[it.identifier.value] = it }
@@ -234,10 +247,38 @@ private fun DeviceCard(
     device: ScannedDevice,
     onClick: () -> Unit,
 ) {
+    val cardColors =
+        if (device.isSample) {
+            CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+        } else {
+            CardDefaults.cardColors()
+        }
+    val cardBorder =
+        if (device.isSample) {
+            BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+        } else {
+            null
+        }
     Card(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        colors = cardColors,
+        border = cardBorder,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
+            if (device.isSample) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    shape = RoundedCornerShape(4.dp),
+                ) {
+                    Text(
+                        text = "kmp-ble sample",
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+            }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
@@ -272,7 +272,7 @@ private fun DeviceCard(
                     shape = RoundedCornerShape(4.dp),
                 ) {
                     Text(
-                        text = "kmp-ble sample",
+                        text = "$SAMPLE_NAME_PREFIX sample",
                         style = MaterialTheme.typography.labelSmall,
                         modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
                     )

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
@@ -321,11 +321,11 @@ private fun ExtendedAdvertiserCard(
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(onClick = {
-                    vm.startExtendedSet(Phy.Le1M, Phy.Le2M, "kmp-ble Ext", AdvertiseInterval.Balanced)
+                    vm.startExtendedSet(Phy.Le1M, Phy.Le2M, "$SAMPLE_NAME_PREFIX Ext", AdvertiseInterval.Balanced)
                 }) { Text("Add Set (1M/2M)") }
 
                 Button(onClick = {
-                    vm.startExtendedSet(Phy.LeCoded, Phy.LeCoded, "kmp-ble LR", AdvertiseInterval.LowPower)
+                    vm.startExtendedSet(Phy.LeCoded, Phy.LeCoded, "$SAMPLE_NAME_PREFIX LR", AdvertiseInterval.LowPower)
                 }) { Text("Add Set (Coded)") }
             }
 

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -30,6 +30,12 @@ private val HEART_RATE_SERVICE = uuidFrom("180D")
 private val HEART_RATE_MEASUREMENT = uuidFrom("2A37")
 private const val STREAM_INTERVAL_MS = 100L
 
+/**
+ * Local name prefix used by every advertiser in this sample app so the
+ * scanner can pin matching devices to the top of the list.
+ */
+internal const val SAMPLE_NAME_PREFIX = "kmp-ble"
+
 @OptIn(ExperimentalBleApi::class)
 class ServerViewModel : ViewModel() {
     private val _heartRate = MutableStateFlow(72)
@@ -102,6 +108,7 @@ class ServerViewModel : ViewModel() {
         launchWithErrorHandling {
             advertiser.startAdvertising(
                 AdvertiseConfig(
+                    name = "$SAMPLE_NAME_PREFIX Sample",
                     serviceUuids = listOf(HEART_RATE_SERVICE),
                     connectable = true,
                 ),


### PR DESCRIPTION
## Summary
- Running the sample across two devices (one GATT server, one client) was annoying because the scanner list sorts by RSSI and re-snapshots every 250ms, so the demo peer keeps shuffling around with every nearby beacon.
- Stamp every advertiser this app starts with a `kmp-ble` local name prefix and teach `ScannerScreen` to recognize it. Matching advertisements jump to the top of the list with a primary-container background, a primary border, and a `kmp-ble sample` pill on the card, so the demo peer is the first thing you see.
- `SAMPLE_NAME_PREFIX` lives next to the advertiser config in `ServerViewModel` so the server and scanner share a single source of truth. The existing extended advertising sets (`kmp-ble Ext`, `kmp-ble LR`) already match the prefix; only the legacy `AdvertiseConfig` needed a name.

### How it looks
- Sample peer card: tinted background, accent border, `kmp-ble sample` pill above the name. Always at top of the list regardless of RSSI.
- Other devices: unchanged styling, still sorted by RSSI underneath.

## Test plan
- [x] `./gradlew :sample:ktlintCheck :sample:compileAndroidMain :sample:compileKotlinIosSimulatorArm64`
- [x] Manual two-device test on Android: launch the sample on both, start Legacy Advertiser on one, confirm the peer shows up at the top with the highlight and pill while other nearby BLE devices stay below.
- [ ] Same manual check with `Add Set (1M/2M)` and `Add Set (Coded)` from the Extended Advertiser card.