### PR TITLE
feat(codec): add L2capListener.framedConnections for typed server streams

### DIFF
--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/FlowFraming.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/FlowFraming.kt
@@ -31,6 +31,11 @@ public fun Flow<ByteArray>.unframedBy(framer: Framer): Flow<ByteArray> = flow {
  * Combines unframing and decoding into one operator: byte chunks in, typed
  * values out.
  *
+ * Each collection allocates its own fresh [Unframer] via [framer], so the
+ * same [Framer] instance is safe to share across multiple collectors and
+ * re-collecting the same returned [Flow] starts fresh (no leftover buffered
+ * tail from a prior collection).
+ *
  * A frame is sent through [decoder]. If the decoder throws (the
  * [BleDecoder] contract for parse failure), the frame's raw bytes are
  * routed to [onDecodeFailure] (default no-op) and dropped from the output
@@ -45,21 +50,19 @@ public fun <T> Flow<ByteArray>.decodeFramed(
     decoder: BleDecoder<T>,
     framer: Framer = LengthPrefixFramer(),
     onDecodeFailure: (ByteArray) -> Unit = {},
-): Flow<T> {
+): Flow<T> = flow {
     val unframer = framer.unframer()
-    return flow {
-        collect { chunk ->
-            for (frame in unframer.feed(chunk)) {
-                val decoded = try {
-                    decoder.decode(frame)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    onDecodeFailure(frame)
-                    continue
-                }
-                emit(decoded)
+    collect { chunk ->
+        for (frame in unframer.feed(chunk)) {
+            val decoded = try {
+                decoder.decode(frame)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                onDecodeFailure(frame)
+                continue
             }
+            emit(decoded)
         }
     }
 }

--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
@@ -62,8 +62,11 @@ public suspend fun <T> L2capChannel.writeFramed(
  * unframer; per-channel decoder failures route to [onDecodeFailure].
  *
  * Listener lifecycle is unchanged - this is a view over [L2capListener.incoming].
- * The returned flow re-emits as new clients are accepted; callers typically
- * launch a coroutine per typed channel to handle reads and writes.
+ *
+ * Returns a plain [Flow], not the [kotlinx.coroutines.flow.SharedFlow] that
+ * [L2capListener.incoming] exposes. Callers that need `subscriptionCount`
+ * or `onSubscription` for race-free wiring should collect
+ * [L2capListener.incoming] directly and wrap each channel themselves.
  */
 public fun <T> L2capListener.framedConnections(
     codec: BleCodec<T>,

--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/L2capCodec.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.codec
 
 import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.l2cap.L2capListener
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -49,3 +50,31 @@ public suspend fun <T> L2capChannel.writeFramed(
     encoder: BleEncoder<T>,
     framer: Framer = LengthPrefixFramer(),
 ): Unit = write(framer.frame(encoder.encode(value)))
+
+/**
+ * Accept incoming L2CAP connections and pre-wrap each one as a
+ * [TypedL2capChannel] using the supplied [codec] and [framer].
+ *
+ * Symmetric server-side counterpart to client-side [framedIncoming] +
+ * [writeFramed]: instead of accepting raw [L2capChannel] connections from
+ * [L2capListener.incoming] and wiring framing manually for each, callers
+ * receive ready-to-use typed channels. Each accepted channel runs its own
+ * unframer; per-channel decoder failures route to [onDecodeFailure].
+ *
+ * Listener lifecycle is unchanged - this is a view over [L2capListener.incoming].
+ * The returned flow re-emits as new clients are accepted; callers typically
+ * launch a coroutine per typed channel to handle reads and writes.
+ */
+public fun <T> L2capListener.framedConnections(
+    codec: BleCodec<T>,
+    framer: Framer = LengthPrefixFramer(),
+    onDecodeFailure: (ByteArray) -> Unit = {},
+): Flow<TypedL2capChannel<T>> =
+    incoming.map { channel ->
+        TypedL2capChannel(
+            channel = channel,
+            incoming = channel.framedIncoming(codec, framer, onDecodeFailure),
+            codec = codec,
+            framer = framer,
+        )
+    }

--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/TypedL2capChannel.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/TypedL2capChannel.kt
@@ -1,0 +1,43 @@
+package com.atruedev.kmpble.codec
+
+import com.atruedev.kmpble.l2cap.L2capChannel
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A typed, framed view over an [L2capChannel].
+ *
+ * Wraps an accepted L2CAP channel together with a [BleCodec] and a [Framer]
+ * so that callers read and write typed values directly. Pairs with
+ * [L2capListener.framedConnections]: the listener accepts raw channels and
+ * each accepted channel is wrapped into a [TypedL2capChannel].
+ *
+ * The underlying [channel] is exposed for callers that need raw access
+ * (custom byte writes, inspection). Properties [mtu], [psm], and [isOpen]
+ * forward to it for convenience. [close] closes the underlying channel.
+ */
+public class TypedL2capChannel<T> internal constructor(
+    public val channel: L2capChannel,
+    public val incoming: Flow<T>,
+    private val codec: BleCodec<T>,
+    private val framer: Framer,
+) : AutoCloseable {
+    /** MTU of the underlying L2CAP channel. */
+    public val mtu: Int get() = channel.mtu
+
+    /** PSM of the underlying L2CAP channel. */
+    public val psm: Int get() = channel.psm
+
+    /** Whether the underlying L2CAP channel is open. */
+    public val isOpen: Boolean get() = channel.isOpen
+
+    /**
+     * Encode [value] through the codec, frame the bytes, and write the
+     * framed packet on the underlying channel. Throws if the encoded
+     * payload exceeds the framer's `maxFrameSize`; no bytes are written
+     * in that case.
+     */
+    public suspend fun write(value: T): Unit = channel.writeFramed(value, codec, framer)
+
+    /** Close the underlying L2CAP channel. */
+    override fun close(): Unit = channel.close()
+}

--- a/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/TypedL2capChannel.kt
+++ b/kmp-ble-codec/src/commonMain/kotlin/com/atruedev/kmpble/codec/TypedL2capChannel.kt
@@ -11,33 +11,33 @@ import kotlinx.coroutines.flow.Flow
  * [L2capListener.framedConnections]: the listener accepts raw channels and
  * each accepted channel is wrapped into a [TypedL2capChannel].
  *
- * The underlying [channel] is exposed for callers that need raw access
- * (custom byte writes, inspection). Properties [mtu], [psm], and [isOpen]
- * forward to it for convenience. [close] closes the underlying channel.
+ * The underlying channel is intentionally not exposed. Collecting raw bytes
+ * from it alongside [incoming] would split the byte stream between two
+ * collectors and corrupt frames; writing raw bytes would bypass the framer
+ * and produce a stream the peer cannot decode. Use a separate
+ * [L2capListener.incoming] collection if raw access is required.
+ *
+ * `mtu`, `psm`, and `isOpen` forward to the underlying channel for
+ * convenience. [close] closes the underlying channel.
  */
 public class TypedL2capChannel<T> internal constructor(
-    public val channel: L2capChannel,
+    internal val channel: L2capChannel,
     public val incoming: Flow<T>,
     private val codec: BleCodec<T>,
     private val framer: Framer,
 ) : AutoCloseable {
-    /** MTU of the underlying L2CAP channel. */
     public val mtu: Int get() = channel.mtu
-
-    /** PSM of the underlying L2CAP channel. */
     public val psm: Int get() = channel.psm
-
-    /** Whether the underlying L2CAP channel is open. */
     public val isOpen: Boolean get() = channel.isOpen
 
     /**
      * Encode [value] through the codec, frame the bytes, and write the
-     * framed packet on the underlying channel. Throws if the encoded
-     * payload exceeds the framer's `maxFrameSize`; no bytes are written
-     * in that case.
+     * framed packet on the underlying channel.
+     *
+     * @throws FrameTooLargeException if the encoded payload exceeds the
+     *   framer's `maxFrameSize`. No bytes are written in that case.
      */
     public suspend fun write(value: T): Unit = channel.writeFramed(value, codec, framer)
 
-    /** Close the underlying L2CAP channel. */
     override fun close(): Unit = channel.close()
 }

--- a/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/FlowFramingTest.kt
+++ b/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/FlowFramingTest.kt
@@ -113,4 +113,18 @@ class FlowFramingTest {
         assertContentEquals(byteArrayOf(0x77), first.single())
         assertContentEquals(byteArrayOf(0x77), second.single())
     }
+
+    @Test
+    fun decodeFramedAllocatesFreshUnframerPerCollection() = runTest {
+        val framer = LengthPrefixFramer()
+        val complete = framer.frame(Uint16Codec.encode(0xAAAA))
+        val dangling = byteArrayOf(0x10, 0x00)
+        val flow = flowOf(complete + dangling).decodeFramed(Uint16Codec, framer)
+
+        val first = flow.toList()
+        assertEquals(listOf(0xAAAA), first)
+
+        val second = flow.toList()
+        assertEquals(listOf(0xAAAA), second)
+    }
 }

--- a/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/TypedL2capChannelTest.kt
+++ b/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/TypedL2capChannelTest.kt
@@ -1,0 +1,185 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.atruedev.kmpble.codec
+
+import com.atruedev.kmpble.testing.FakeL2capChannel
+import com.atruedev.kmpble.testing.FakeL2capListener
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+private val TestStringCodec = object : BleCodec<String> {
+    override fun encode(value: String): ByteArray = value.encodeToByteArray()
+
+    override fun decode(data: ByteArray): String = data.decodeToString()
+}
+
+private val FailingStringCodec = object : BleCodec<String> {
+    override fun encode(value: String): ByteArray = value.encodeToByteArray()
+
+    override fun decode(data: ByteArray): String = throw IllegalArgumentException("decode failed: ${data.size} bytes")
+}
+
+class TypedL2capChannelTest {
+
+    @Test
+    fun framedConnectionsEmitsTypedWrappersForAcceptedChannels() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80, mtu = 512)
+
+        val collected = mutableListOf<TypedL2capChannel<String>>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec).take(1).toList(collected)
+        }
+
+        listener.simulateIncoming(raw)
+
+        assertEquals(1, collected.size)
+        assertSame(raw, collected[0].channel)
+        job.cancel()
+    }
+
+    @Test
+    fun typedIncomingDecodesFramedBytes() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+        val framer = LengthPrefixFramer()
+
+        val received = mutableListOf<String>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            val typed = listener.framedConnections(TestStringCodec, framer).first()
+            typed.incoming.collect { received.add(it) }
+        }
+
+        listener.simulateIncoming(raw)
+        raw.emitIncoming(framer.frame("alpha".encodeToByteArray()))
+        raw.emitIncoming(framer.frame("beta".encodeToByteArray()))
+        raw.emitIncoming(framer.frame("gamma".encodeToByteArray()))
+
+        assertEquals(listOf("alpha", "beta", "gamma"), received)
+        job.cancel()
+    }
+
+    @Test
+    fun typedWriteEncodesAndFramesBytes() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+        val framer = LengthPrefixFramer()
+
+        val acceptJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            val typed = listener.framedConnections(TestStringCodec, framer).first()
+            typed.write("ping")
+        }
+        listener.simulateIncoming(raw)
+        acceptJob.join()
+
+        val written = raw.getWrittenData()
+        assertEquals(1, written.size)
+        assertContentEquals(framer.frame("ping".encodeToByteArray()), written[0])
+    }
+
+    @Test
+    fun typedChannelForwardsUnderlyingProperties() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x42, mtu = 1024)
+
+        val captured = mutableListOf<TypedL2capChannel<String>>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec).take(1).toList(captured)
+        }
+        listener.simulateIncoming(raw)
+
+        val wrapper = captured.single()
+        assertEquals(0x42, wrapper.psm)
+        assertEquals(1024, wrapper.mtu)
+        assertTrue(wrapper.isOpen)
+        job.cancel()
+    }
+
+    @Test
+    fun typedChannelCloseClosesUnderlying() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+
+        val captured = mutableListOf<TypedL2capChannel<String>>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec).take(1).toList(captured)
+        }
+        listener.simulateIncoming(raw)
+
+        val wrapper = captured.single()
+        assertTrue(raw.isOpen)
+        wrapper.close()
+        assertFalse(raw.isOpen)
+        job.cancel()
+    }
+
+    @Test
+    fun decoderFailuresRouteToCallback() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+        val framer = LengthPrefixFramer()
+        val failed = mutableListOf<ByteArray>()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            val typed = listener
+                .framedConnections(FailingStringCodec, framer, onDecodeFailure = { failed.add(it) })
+                .first()
+            typed.incoming.collect { }
+        }
+
+        listener.simulateIncoming(raw)
+        raw.emitIncoming(framer.frame("bad-frame".encodeToByteArray()))
+
+        assertEquals(1, failed.size)
+        assertContentEquals("bad-frame".encodeToByteArray(), failed[0])
+        job.cancel()
+    }
+
+    @Test
+    fun multipleAcceptedChannelsHaveIndependentUnframerState() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val channelA = FakeL2capChannel(psm = 0x80)
+        val channelB = FakeL2capChannel(psm = 0x80)
+        val framer = LengthPrefixFramer()
+
+        val receivedA = mutableListOf<String>()
+        val receivedB = mutableListOf<String>()
+        val typedFlow = listener.framedConnections(TestStringCodec, framer)
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            typedFlow.take(2).collect { typed ->
+                val sink = if (typed.channel === channelA) receivedA else receivedB
+                launch { typed.incoming.collect { sink.add(it) } }
+            }
+        }
+
+        listener.simulateIncoming(channelA)
+        listener.simulateIncoming(channelB)
+
+        val framedHello = framer.frame("hello".encodeToByteArray())
+        channelA.emitIncoming(framedHello.copyOfRange(0, 3))
+        channelB.emitIncoming(framer.frame("world".encodeToByteArray()))
+        channelA.emitIncoming(framedHello.copyOfRange(3, framedHello.size))
+
+        assertEquals(listOf("hello"), receivedA)
+        assertEquals(listOf("world"), receivedB)
+        job.cancel()
+    }
+}

--- a/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/TypedL2capChannelTest.kt
+++ b/kmp-ble-codec/src/commonTest/kotlin/com/atruedev/kmpble/codec/TypedL2capChannelTest.kt
@@ -5,6 +5,7 @@ package com.atruedev.kmpble.codec
 import com.atruedev.kmpble.testing.FakeL2capChannel
 import com.atruedev.kmpble.testing.FakeL2capListener
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -14,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -41,7 +43,6 @@ class TypedL2capChannelTest {
         val job = launch(UnconfinedTestDispatcher(testScheduler)) {
             listener.framedConnections(TestStringCodec).take(1).toList(collected)
         }
-
         listener.simulateIncoming(raw)
 
         assertEquals(1, collected.size)
@@ -152,6 +153,86 @@ class TypedL2capChannelTest {
     }
 
     @Test
+    fun rawChannelCloseCompletesTypedIncoming() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+
+        val captured = mutableListOf<TypedL2capChannel<String>>()
+        val acceptJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec).take(1).toList(captured)
+        }
+        listener.simulateIncoming(raw)
+        acceptJob.join()
+        val typed = captured.single()
+
+        var completed = false
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            typed.incoming.collect { }
+            completed = true
+        }
+
+        raw.close()
+
+        assertTrue(completed, "Closing the raw channel should complete typed.incoming")
+        collectJob.cancel()
+    }
+
+    @Test
+    fun typedIncomingPropagatesFrameTooLargeException() = runTest {
+        val listener = FakeL2capListener(assignedPsm = 0x80)
+        listener.open()
+        val raw = FakeL2capChannel(psm = 0x80)
+        val tightFramer = LengthPrefixFramer(maxFrameSize = 2)
+
+        val captured = mutableListOf<TypedL2capChannel<String>>()
+        val acceptJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec, tightFramer).take(1).toList(captured)
+        }
+        listener.simulateIncoming(raw)
+        acceptJob.join()
+        val typed = captured.single()
+
+        var caught: Throwable? = null
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            try {
+                typed.incoming.collect { }
+            } catch (e: FrameTooLargeException) {
+                caught = e
+            }
+        }
+        raw.emitIncoming(byteArrayOf(0x03, 0x00, 0x00, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte()))
+
+        assertIs<FrameTooLargeException>(caught)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun typedIncomingCanBeCollectedMultipleTimes() = runTest {
+        // L2capChannel.incoming on production platforms is hot and effectively
+        // single-shot in our fake, so the multi-collection contract for
+        // TypedL2capChannel.incoming is exercised by feeding a replayable Flow
+        // directly through the internal constructor. With a per-collection
+        // unframer the second collection sees the same output as the first;
+        // a shared unframer would leak the dangling tail bytes from the first
+        // collection and corrupt the length prefix parsing on the second.
+        val framer = LengthPrefixFramer()
+        val raw = FakeL2capChannel(psm = 0x80)
+        val complete = framer.frame("hello".encodeToByteArray())
+        val dangling = byteArrayOf(0x10, 0x00)
+        val source = flowOf(complete + dangling)
+        val typed = TypedL2capChannel(
+            channel = raw,
+            incoming = source.decodeFramed(TestStringCodec, framer),
+            codec = TestStringCodec,
+            framer = framer,
+        )
+
+        assertEquals(listOf("hello"), typed.incoming.toList())
+        assertEquals(listOf("hello"), typed.incoming.toList())
+    }
+
+    @Test
     fun multipleAcceptedChannelsHaveIndependentUnframerState() = runTest {
         val listener = FakeL2capListener(assignedPsm = 0x80)
         listener.open()
@@ -159,19 +240,24 @@ class TypedL2capChannelTest {
         val channelB = FakeL2capChannel(psm = 0x80)
         val framer = LengthPrefixFramer()
 
-        val receivedA = mutableListOf<String>()
-        val receivedB = mutableListOf<String>()
-        val typedFlow = listener.framedConnections(TestStringCodec, framer)
-
-        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
-            typedFlow.take(2).collect { typed ->
-                val sink = if (typed.channel === channelA) receivedA else receivedB
-                launch { typed.incoming.collect { sink.add(it) } }
-            }
+        val captured = mutableListOf<TypedL2capChannel<String>>()
+        val acceptJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            listener.framedConnections(TestStringCodec, framer).take(2).toList(captured)
         }
-
         listener.simulateIncoming(channelA)
         listener.simulateIncoming(channelB)
+        acceptJob.join()
+
+        val typedA = captured.first { it.channel === channelA }
+        val typedB = captured.first { it.channel === channelB }
+        val receivedA = mutableListOf<String>()
+        val receivedB = mutableListOf<String>()
+        val jobA = launch(UnconfinedTestDispatcher(testScheduler)) {
+            typedA.incoming.collect { receivedA.add(it) }
+        }
+        val jobB = launch(UnconfinedTestDispatcher(testScheduler)) {
+            typedB.incoming.collect { receivedB.add(it) }
+        }
 
         val framedHello = framer.frame("hello".encodeToByteArray())
         channelA.emitIncoming(framedHello.copyOfRange(0, 3))
@@ -180,6 +266,7 @@ class TypedL2capChannelTest {
 
         assertEquals(listOf("hello"), receivedA)
         assertEquals(listOf("world"), receivedB)
-        job.cancel()
+        jobA.cancel()
+        jobB.cancel()
     }
 }

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.atruedev.kmpble.BleData
 import com.atruedev.kmpble.ExperimentalBleApi
-import com.atruedev.kmpble.codec.writeFramed
+import com.atruedev.kmpble.codec.TypedL2capChannel
+import com.atruedev.kmpble.codec.framedConnections
 import com.atruedev.kmpble.connection.Phy
-import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capListener
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.server.AdvertiseConfig
@@ -165,7 +165,7 @@ class ServerViewModel : ViewModel() {
 
     private var l2capListener: L2capListener? = null
     private var l2capAcceptJob: Job? = null
-    private val _l2capChannels = MutableStateFlow<List<L2capChannel>>(emptyList())
+    private val _l2capChannels = MutableStateFlow<List<TypedL2capChannel<SensorReading>>>(emptyList())
 
     fun openL2capServer(secure: Boolean = true) {
         launchWithErrorHandling {
@@ -175,8 +175,8 @@ class ServerViewModel : ViewModel() {
             l2capAcceptJob?.cancel()
             l2capAcceptJob =
                 viewModelScope.launch {
-                    listener.incoming.collect { channel ->
-                        launch { streamReadings(channel) }
+                    listener.framedConnections(SensorReadingCodec).collect { typed ->
+                        launch { streamReadings(typed) }
                     }
                 }
             listener.open(secure)
@@ -198,19 +198,19 @@ class ServerViewModel : ViewModel() {
         appendL2capLog("Listener closed")
     }
 
-    private suspend fun streamReadings(channel: L2capChannel) {
-        _l2capChannels.update { it + channel }
-        appendL2capLog("Channel accepted (mtu=${channel.mtu}); streaming SensorReading")
+    private suspend fun streamReadings(typed: TypedL2capChannel<SensorReading>) {
+        _l2capChannels.update { it + typed }
+        appendL2capLog("Channel accepted (mtu=${typed.mtu}); streaming SensorReading")
         val start = TimeSource.Monotonic.markNow()
         try {
-            while (channel.isOpen) {
+            while (typed.isOpen) {
                 val reading =
                     SensorReading(
                         timestampMs = start.elapsedNow().inWholeMilliseconds,
                         celsius = 20.0 + Random.nextDouble(-2.0, 2.0),
                     )
                 try {
-                    channel.writeFramed(reading, SensorReadingCodec)
+                    typed.write(reading)
                     _l2capStreamedCount.update { it + 1 }
                 } catch (e: Exception) {
                     appendL2capLog("Stream write failed: ${e.message}")
@@ -219,7 +219,7 @@ class ServerViewModel : ViewModel() {
                 delay(STREAM_INTERVAL_MS)
             }
         } finally {
-            _l2capChannels.update { it - channel }
+            _l2capChannels.update { it - typed }
             appendL2capLog("Channel closed")
         }
     }


### PR DESCRIPTION
## Summary

Phase 4 of the typed L2CAP work: server-side counterpart to client-side `L2capChannel.framedIncoming` + `writeFramed`. Now incorporates PR review fixes including a pre-existing root-cause bug in `decodeFramed`.

```kotlin
public fun <T> L2capListener.framedConnections(
    codec: BleCodec<T>,
    framer: Framer = LengthPrefixFramer(),
    onDecodeFailure: (ByteArray) -> Unit = {},
): Flow<TypedL2capChannel<T>>
```

Each accepted `L2capChannel` is pre-wrapped into a `TypedL2capChannel<T>` carrying its own typed incoming `Flow<T>` and a typed `write(value: T)`. Server code goes from "accept raw channel, wire decoder + framer per connection" to "collect typed channels, handle reads/writes directly."

## Commits

1. **`feat(codec)`** - the initial API addition (`TypedL2capChannel`, `framedConnections`, 7 tests).
2. **`fix(codec)`** - decodeFramed root-cause: `val unframer = framer.unframer()` was outside the `flow { }` builder, so the same unframer instance was shared across all collections of the returned Flow. Pre-existing from #173; freezing the resulting Flow into `TypedL2capChannel.incoming` made the reuse pattern user-facing. Sibling `unframedBy` already does this correctly. Includes a regression test that exposes the bug via a complete frame + dangling-tail-bytes scenario.
3. **`refactor(codec)`** - tighten `TypedL2capChannel`:
   - Hide `.channel` (`public` -> `internal`). Public exposure undercut the typed contract by inviting raw-byte writes and side-collections that split the channel's single-shot incoming stream.
   - Drop tautology KDoc on forwarding properties.
   - Add `@throws FrameTooLargeException` on `write`.
   - Note in `framedConnections` KDoc that the return type is plain `Flow` (not the `SharedFlow` that `L2capListener.incoming` exposes); callers needing `subscriptionCount` / `onSubscription` should consume the listener directly.
   - Three new tests: multi-collect contract, raw-close lifecycle propagation, FrameTooLargeException propagation. Refactored the multi-channel test to use explicit launches and remove reliance on `UnconfinedTestDispatcher` inline scheduling.
4. **`refactor(sample)`** - migrate `ServerViewModel.streamReadings` from raw `listener.incoming` + `channel.writeFramed(value, codec)` to `listener.framedConnections(codec)` + `typed.write(value)`. Real-world ergonomic check of the new API.

## API shape

```kotlin
public class TypedL2capChannel<T> internal constructor(...) : AutoCloseable {
    internal val channel: L2capChannel      // hidden; tests in same module
    public val incoming: Flow<T>            // decoded via framedIncoming
    public val mtu: Int                     // forwarded
    public val psm: Int                     // forwarded
    public val isOpen: Boolean              // forwarded
    public suspend fun write(value: T)      // encodes + frames + writes
    override fun close()                    // closes underlying channel
}
```

## Tests

10 tests in `TypedL2capChannelTest` (was 7), 10 tests in `FlowFramingTest` (was 9).

New coverage:
- `decodeFramedAllocatesFreshUnframerPerCollection` - regression for the root-cause bug.
- `typedIncomingCanBeCollectedMultipleTimes` - typed-layer multi-collect.
- `rawChannelCloseCompletesTypedIncoming` - lifecycle propagation.
- `typedIncomingPropagatesFrameTooLargeException` - error propagation.
- `multipleAcceptedChannelsHaveIndependentUnframerState` refactored.

## Test plan

- [x] `./gradlew :kmp-ble-codec:jvmTest` - 10+10 tests pass, full codec suite green
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew :kmp-ble-codec:compileKotlinIosSimulatorArm64` passes
- [x] `./gradlew :sample:compileKotlinIosSimulatorArm64` passes (sample migration works)
- [x] Typography scan: 0 forbidden codepoints across all 6 touched files
- [ ] CI Android compile + tests pass (local worktree lacks Android SDK config)
- [ ] CI typography-check passes