### PR TITLE
fix(server): re-throw CancellationException in Android GATT handlers

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -21,6 +21,7 @@ import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import com.atruedev.kmpble.peripheral.toAndroidGattStatus
 import com.atruedev.kmpble.peripheral.toGattStatus
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
@@ -284,7 +285,7 @@ internal class AndroidGattServer(
                         )
                         sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
                     } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        if (e is CancellationException) throw e
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,
@@ -346,7 +347,7 @@ internal class AndroidGattServer(
                             sendResponseSafe(device, requestId, nativeStatus, offset, null)
                         }
                     } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        if (e is CancellationException) throw e
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -283,7 +283,8 @@ internal class AndroidGattServer(
                             ),
                         )
                         sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,
@@ -344,7 +345,8 @@ internal class AndroidGattServer(
                             val nativeStatus = status?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
                             sendResponseSafe(device, requestId, nativeStatus, offset, null)
                         }
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -284,8 +284,9 @@ internal class AndroidGattServer(
                             ),
                         )
                         sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,
@@ -346,8 +347,9 @@ internal class AndroidGattServer(
                             val nativeStatus = status?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
                             sendResponseSafe(device, requestId, nativeStatus, offset, null)
                         }
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
                         logEvent(
                             BleLogEvent.ServerRequest(
                                 deviceId,


### PR DESCRIPTION
## Summary

- The two `catch (_: Exception)` blocks in `AndroidGattServer.onCharacteristicReadRequest` (line 286) and `onCharacteristicWriteRequest` (line 347) swallowed `CancellationException`, breaking structured-concurrency cancellation when the server scope is cancelled while a handler is mid-flight.
- Switch both to `catch (e: Exception)` and re-throw on `CancellationException`, matching the existing pattern at line 934 of the same file.

## Why this matters

`scope.launch { ... }` blocks throw `CancellationException` at any suspension point when the scope is cancelled (e.g. `server.close()`). Catching and ignoring it lets the handler keep running, fire `sendResponseSafe(..., GATT_FAILURE, ...)` against a server that is being torn down, and emit a misleading `read-failed (handler threw)` / `write-failed (handler threw)` log line for what was actually a clean cancellation.

## Test plan

- [x] `./gradlew :compileAndroidMain` passes
- [x] `./gradlew :testAndroidHostTest` passes
- [ ] CI green