### PR TITLE
feat(sample): add L2CAP blob stream demo with 3-layer stats

### DIFF
--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BleViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BleViewModel.kt
@@ -71,6 +71,7 @@ class BleViewModel(
 
     val pairing = PairingCoordinator()
     val l2cap = L2capController(peripheral, viewModelScope)
+    val blob = BlobL2capController(peripheral, viewModelScope)
 
     private val _benchmarkResult = MutableStateFlow<String?>(null)
     val benchmarkResult: StateFlow<String?> = _benchmarkResult.asStateFlow()
@@ -249,6 +250,7 @@ class BleViewModel(
         dfuJob?.cancel()
         dfuController = null
         l2cap.close()
+        blob.close()
         peripheral.close()
     }
 

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
@@ -4,6 +4,7 @@ package com.atruedev.kmpble.sample
 
 import com.atruedev.kmpble.codec.serialization.cborCodec
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
 
 /**
  * Fragment of a larger blob being streamed over a framed L2CAP channel.
@@ -26,7 +27,7 @@ data class BlobChunk(
     val seq: Int,
     val totalBytes: Long,
     val eof: Boolean,
-    val bytes: ByteArray,
+    @ByteString val bytes: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
@@ -1,0 +1,49 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package com.atruedev.kmpble.sample
+
+import com.atruedev.kmpble.codec.serialization.cborCodec
+import kotlinx.serialization.Serializable
+
+/**
+ * Fragment of a larger blob being streamed over a framed L2CAP channel.
+ *
+ * Each [BlobChunk] is one CBOR-encoded, length-prefix-framed L2CAP message
+ * from the server. [totalBytes] is repeated in every chunk so the receiver
+ * can show progress without a separate header; [eof] flags the final chunk.
+ *
+ * The on-the-wire shape lets the demo expose three layers of fragmentation:
+ *
+ * - L2CAP SDU MTU (`channel.mtu`): negotiated by the controller; spec
+ *   ceiling 65535 octets, real phones often 672-2048.
+ * - OS read chunk size: the [ByteArray] sizes emitted by `channel.incoming`
+ *   before any app-level framing; reflects how the OS buffers wire SDUs.
+ * - App frame size: [bytes].size for each decoded [BlobChunk], i.e. the
+ *   producer's chosen chunk size capped by the framer's `maxFrameSize`.
+ */
+@Serializable
+data class BlobChunk(
+    val seq: Int,
+    val totalBytes: Long,
+    val eof: Boolean,
+    val bytes: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BlobChunk) return false
+        return seq == other.seq &&
+            totalBytes == other.totalBytes &&
+            eof == other.eof &&
+            bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        var result = seq
+        result = 31 * result + totalBytes.hashCode()
+        result = 31 * result + eof.hashCode()
+        result = 31 * result + bytes.contentHashCode()
+        return result
+    }
+}
+
+val BlobChunkCodec = cborCodec<BlobChunk>()

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
@@ -1,9 +1,13 @@
 package com.atruedev.kmpble.sample
 
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.codec.LengthPrefixFramer
 import com.atruedev.kmpble.codec.unframedBy
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +39,7 @@ import kotlin.time.TimeSource
  * 3. **App frame size** = the size of each decoded [BlobChunk.bytes]
  *    payload, equal to the producer's `frameBytes` setting.
  */
+@OptIn(ExperimentalBleApi::class)
 class BlobL2capController(
     private val peripheral: Peripheral,
     private val scope: CoroutineScope,
@@ -53,6 +58,10 @@ class BlobL2capController(
         val osChunkBytesTotal: Long = 0,
         val elapsedMs: Long = 0,
         val done: Boolean = false,
+        val priorityRequested: Boolean = false,
+        val priorityApplied: Boolean = false,
+        val phyApplied: PhyResult? = null,
+        val phySupported: Boolean = false,
     ) {
         val progressFraction: Float
             get() = if (expectedBytes > 0) (receivedBytes.toFloat() / expectedBytes.toFloat()).coerceIn(0f, 1f) else 0f
@@ -76,14 +85,46 @@ class BlobL2capController(
     fun open(
         psm: Int,
         secure: Boolean = true,
+        tunePriority: Boolean = true,
+        tunePhy: Boolean = true,
     ) {
         openJob?.cancel()
         openJob =
             scope.launch {
                 try {
+                    val priorityApplied =
+                        if (tunePriority) {
+                            val ok = peripheral.requestConnectionPriority(ConnectionPriority.High)
+                            appendLog(if (ok) "Priority HIGH requested" else "Priority not supported")
+                            ok
+                        } else {
+                            false
+                        }
+
+                    val phyResult =
+                        if (tunePhy) {
+                            val res = peripheral.setPreferredPhy(Phy.Le2M, Phy.Le2M)
+                            if (res != null) {
+                                appendLog("PHY set tx=${res.tx} rx=${res.rx}")
+                            } else {
+                                appendLog("PHY not supported / no-op")
+                            }
+                            res
+                        } else {
+                            null
+                        }
+
                     val ch = peripheral.openL2capChannel(psm, secure)
                     channel = ch
-                    _stats.value = Stats(isOpen = true, mtu = ch.mtu)
+                    _stats.value =
+                        Stats(
+                            isOpen = true,
+                            mtu = ch.mtu,
+                            priorityRequested = tunePriority,
+                            priorityApplied = priorityApplied,
+                            phyApplied = phyResult,
+                            phySupported = phyResult != null,
+                        )
                     appendLog("Opened (PSM=$psm, mtu=${ch.mtu})")
                     consume(ch)
                 } catch (e: CancellationException) {

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
@@ -1,0 +1,176 @@
+package com.atruedev.kmpble.sample
+
+import com.atruedev.kmpble.codec.LengthPrefixFramer
+import com.atruedev.kmpble.codec.unframedBy
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * Receive-side controller for the L2CAP blob-stream demo.
+ *
+ * The producer in [ServerViewModel.openBlobServer] streams a configurable
+ * total payload as length-prefix-framed [BlobChunk] messages. This controller
+ * splits the pipeline into three observable layers so the round-trip is
+ * visible end-to-end:
+ *
+ * 1. **L2CAP SDU MTU** = [L2capChannel.mtu]. Negotiated by the controllers
+ *    (LE Credit-Based Connection Request, see Core 5.x Vol 3 Part A); the
+ *    spec ceiling is 65535 octets, real phones often 672 to a few KiB.
+ * 2. **OS read chunk size** = the size of each [ByteArray] emitted from
+ *    [L2capChannel.incoming] before framing. Driven by the platform's
+ *    socket read buffer (e.g. Android's 4 KiB read buffer in
+ *    `AndroidL2capChannel`); does not preserve SDU boundaries.
+ * 3. **App frame size** = the size of each decoded [BlobChunk.bytes]
+ *    payload, equal to the producer's `frameBytes` setting.
+ */
+class BlobL2capController(
+    private val peripheral: Peripheral,
+    private val scope: CoroutineScope,
+) {
+    data class Stats(
+        val isOpen: Boolean = false,
+        val mtu: Int = 0,
+        val expectedBytes: Long = 0,
+        val receivedBytes: Long = 0,
+        val frameCount: Int = 0,
+        val frameBytesMin: Int = 0,
+        val frameBytesMax: Int = 0,
+        val osChunkCount: Int = 0,
+        val osChunkBytesMin: Int = 0,
+        val osChunkBytesMax: Int = 0,
+        val osChunkBytesTotal: Long = 0,
+        val elapsedMs: Long = 0,
+        val done: Boolean = false,
+    ) {
+        val progressFraction: Float
+            get() = if (expectedBytes > 0) (receivedBytes.toFloat() / expectedBytes.toFloat()).coerceIn(0f, 1f) else 0f
+
+        val throughputBytesPerSec: Double
+            get() = if (elapsedMs > 0) receivedBytes * 1000.0 / elapsedMs else 0.0
+
+        val osChunkBytesAvg: Double
+            get() = if (osChunkCount > 0) osChunkBytesTotal.toDouble() / osChunkCount else 0.0
+    }
+
+    private val _stats = MutableStateFlow(Stats())
+    val stats: StateFlow<Stats> = _stats.asStateFlow()
+
+    private val _log = MutableStateFlow(emptyList<String>())
+    val log: StateFlow<List<String>> = _log.asStateFlow()
+
+    private var openJob: Job? = null
+    private var channel: L2capChannel? = null
+
+    fun open(
+        psm: Int,
+        secure: Boolean = true,
+    ) {
+        openJob?.cancel()
+        openJob =
+            scope.launch {
+                try {
+                    val ch = peripheral.openL2capChannel(psm, secure)
+                    channel = ch
+                    _stats.value = Stats(isOpen = true, mtu = ch.mtu)
+                    appendLog("Opened (PSM=$psm, mtu=${ch.mtu})")
+                    consume(ch)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    appendLog("Open failed: ${e.message}")
+                    _stats.update { it.copy(isOpen = false) }
+                }
+            }
+    }
+
+    fun close() {
+        openJob?.cancel()
+        openJob = null
+        channel?.close()
+        channel = null
+        _stats.update { it.copy(isOpen = false) }
+        appendLog("Closed")
+    }
+
+    private suspend fun consume(ch: L2capChannel) {
+        val framer = LengthPrefixFramer()
+        val mark: TimeMark = TimeSource.Monotonic.markNow()
+        try {
+            ch.incoming
+                .onEach { osChunk -> recordOsChunk(osChunk.size, mark) }
+                .unframedBy(framer)
+                .onEach { frame -> recordFrame(frame.size) }
+                .map { BlobChunkCodec.decode(it) }
+                .collect { chunk -> recordChunk(chunk, mark) }
+            appendLog("Stream ended")
+            _stats.update { it.copy(isOpen = false) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            appendLog("Stream error: ${e.message}")
+            _stats.update { it.copy(isOpen = false) }
+        }
+    }
+
+    private fun recordOsChunk(
+        size: Int,
+        mark: TimeMark,
+    ) {
+        _stats.update { s ->
+            val min = if (s.osChunkCount == 0) size else minOf(s.osChunkBytesMin, size)
+            val max = maxOf(s.osChunkBytesMax, size)
+            s.copy(
+                osChunkCount = s.osChunkCount + 1,
+                osChunkBytesMin = min,
+                osChunkBytesMax = max,
+                osChunkBytesTotal = s.osChunkBytesTotal + size,
+                elapsedMs = mark.elapsedNow().inWholeMilliseconds,
+            )
+        }
+    }
+
+    private fun recordFrame(size: Int) {
+        _stats.update { s ->
+            val min = if (s.frameCount == 0) size else minOf(s.frameBytesMin, size)
+            val max = maxOf(s.frameBytesMax, size)
+            s.copy(
+                frameBytesMin = min,
+                frameBytesMax = max,
+            )
+        }
+    }
+
+    private fun recordChunk(
+        chunk: BlobChunk,
+        mark: TimeMark,
+    ) {
+        _stats.update { s ->
+            s.copy(
+                expectedBytes = if (s.expectedBytes == 0L) chunk.totalBytes else s.expectedBytes,
+                receivedBytes = s.receivedBytes + chunk.bytes.size,
+                frameCount = s.frameCount + 1,
+                done = chunk.eof,
+                elapsedMs = mark.elapsedNow().inWholeMilliseconds,
+            )
+        }
+        if (chunk.eof) {
+            appendLog("EOF @ seq=${chunk.seq}; ${_stats.value.receivedBytes}B in ${_stats.value.elapsedMs}ms")
+        }
+    }
+
+    private fun appendLog(msg: String) {
+        _log.update { (listOf(msg) + it).take(20) }
+    }
+}

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ByteFormat.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ByteFormat.kt
@@ -1,0 +1,21 @@
+package com.atruedev.kmpble.sample
+
+internal fun humanBytes(bytes: Long): String {
+    val absBytes = if (bytes < 0) -bytes else bytes
+    return when {
+        absBytes >= 1024L * 1024 -> {
+            val mib = absBytes.toDouble() / (1024.0 * 1024.0)
+            "${roundOne(mib)} MiB"
+        }
+        absBytes >= 1024L -> {
+            val kib = absBytes.toDouble() / 1024.0
+            "${roundOne(kib)} KiB"
+        }
+        else -> "$bytes B"
+    }
+}
+
+internal fun humanThroughput(kbps: Double): String =
+    if (kbps >= 1024.0) "${roundOne(kbps / 1024.0)} MiB/s" else "${roundOne(kbps)} KiB/s"
+
+internal fun roundOne(value: Double): Double = (value * 10.0).toLong() / 10.0

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -54,6 +55,12 @@ fun ServerScreen(onBack: () -> Unit) {
     val l2capPsm by vm.l2capPsm.collectAsState()
     val l2capLog by vm.l2capLog.collectAsState()
     val l2capStreamedCount by vm.l2capStreamedCount.collectAsState()
+    val blobOpen by vm.blobOpen.collectAsState()
+    val blobPsm by vm.blobPsm.collectAsState()
+    val blobLog by vm.blobLog.collectAsState()
+    val blobTotal by vm.blobTotalBytes.collectAsState()
+    val blobFrame by vm.blobFrameBytes.collectAsState()
+    val blobSendStats by vm.blobSendStats.collectAsState()
 
     LaunchedEffect(error) {
         error?.let {
@@ -84,6 +91,17 @@ fun ServerScreen(onBack: () -> Unit) {
                 item { ClientPreviewCard(heartRate, connectionLog.size) }
             }
             item { L2capServerCard(l2capOpen, l2capPsm, l2capLog, l2capStreamedCount, vm) }
+            item {
+                L2capBlobServerCard(
+                    open = blobOpen,
+                    psm = blobPsm,
+                    totalBytes = blobTotal,
+                    frameBytes = blobFrame,
+                    stats = blobSendStats,
+                    log = blobLog,
+                    vm = vm,
+                )
+            }
             item { LegacyAdvertiserCard(isAdvertising, vm) }
             item { ExtendedAdvertiserCard(activeSets, vm) }
             item { ConnectionLogCard(connectionLog) }
@@ -215,6 +233,138 @@ private fun L2capServerCard(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun L2capBlobServerCard(
+    open: Boolean,
+    psm: Int,
+    totalBytes: Long,
+    frameBytes: Int,
+    stats: BlobSendStats?,
+    log: List<String>,
+    vm: ServerViewModel,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("L2CAP Blob Stream", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Generic large-payload demo. On each accepted L2CAP channel, the server pushes " +
+                    "a configurable total (default 5 MiB) as length-prefix-framed BlobChunk " +
+                    "messages of the chosen frame size. Receiver shows MTU, OS read chunks, and " +
+                    "app frames side by side.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            FilterChip(
+                selected = open,
+                onClick = {},
+                label = { Text(if (open) "Open (PSM=$psm)" else "Closed") },
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text("Total payload", style = MaterialTheme.typography.labelMedium)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                for (bytes in BLOB_TOTAL_OPTIONS) {
+                    FilterChip(
+                        selected = totalBytes == bytes,
+                        onClick = { vm.setBlobTotalBytes(bytes) },
+                        enabled = !open,
+                        label = { Text(humanBytes(bytes)) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+
+            Text("Frame size (app)", style = MaterialTheme.typography.labelMedium)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                for (size in BLOB_FRAME_OPTIONS) {
+                    FilterChip(
+                        selected = frameBytes == size,
+                        onClick = { vm.setBlobFrameBytes(size) },
+                        enabled = !open,
+                        label = { Text(humanBytes(size.toLong())) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Default LengthPrefixFramer caps frames at 64 KiB; CBOR overhead leaves ~60 KiB " +
+                    "usable. Larger frames need a custom LengthPrefixFramer(maxFrameSize) on both ends.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = { vm.openBlobServer(secure = true) },
+                    enabled = !open,
+                ) { Text("Open Secure") }
+
+                OutlinedButton(
+                    onClick = { vm.closeBlobServer() },
+                    enabled = open,
+                ) { Text("Close") }
+            }
+
+            if (stats != null) {
+                Spacer(Modifier.height(8.dp))
+                BlobSendStatsBlock(stats)
+            }
+
+            if (log.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    log.take(8).forEach { line ->
+                        Text(
+                            line,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlobSendStatsBlock(stats: BlobSendStats) {
+    val progress =
+        if (stats.totalBytes > 0) {
+            (stats.bytesSent.toFloat() / stats.totalBytes.toFloat()).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+    val throughputKbps =
+        if (stats.elapsedMs > 0) (stats.bytesSent * 1000.0 / stats.elapsedMs / 1024.0) else 0.0
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            "Sent: ${humanBytes(stats.bytesSent)} / ${humanBytes(stats.totalBytes)} " +
+                "(${stats.framesSent} frames)",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            "Throughput: ${humanThroughput(throughputKbps)}  |  MTU: ${stats.mtu} B  |  " +
+                "Elapsed: ${stats.elapsedMs} ms  |  ${if (stats.done) "DONE" else "..."}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServerViewModel.kt
@@ -30,6 +30,22 @@ private val HEART_RATE_SERVICE = uuidFrom("180D")
 private val HEART_RATE_MEASUREMENT = uuidFrom("2A37")
 private const val STREAM_INTERVAL_MS = 100L
 
+private const val BLOB_DEFAULT_TOTAL_BYTES: Long = 5L * 1024 * 1024
+private const val BLOB_DEFAULT_FRAME_BYTES: Int = 4 * 1024
+const val BLOB_MAX_FRAME_BYTES: Int = 60 * 1024
+val BLOB_FRAME_OPTIONS: List<Int> = listOf(1024, 4 * 1024, 16 * 1024, BLOB_MAX_FRAME_BYTES)
+val BLOB_TOTAL_OPTIONS: List<Long> =
+    listOf(1L * 1024 * 1024, 5L * 1024 * 1024, 10L * 1024 * 1024, 25L * 1024 * 1024)
+
+data class BlobSendStats(
+    val bytesSent: Long,
+    val framesSent: Int,
+    val totalBytes: Long,
+    val mtu: Int,
+    val elapsedMs: Long,
+    val done: Boolean,
+)
+
 /**
  * Local name prefix used by every advertiser in this sample app so the
  * scanner can pin matching devices to the top of the list.
@@ -253,8 +269,128 @@ class ServerViewModel : ViewModel() {
             }
     }
 
+    // --- L2CAP blob stream (large transfer demo) ---
+    //
+    // On each accepted L2CAP channel, the server pushes a configurable total
+    // payload (default 5 MiB) as a sequence of length-prefix-framed BlobChunk
+    // messages of [_blobFrameBytes] each. The receiver (BlobL2capController)
+    // exposes the same stream split across three layers so the round-trip is
+    // observable: app frame size (this chunk size), OS read chunk size
+    // (channel.incoming ByteArray sizes), and L2CAP SDU MTU (channel.mtu).
+
+    private val _blobOpen = MutableStateFlow(false)
+    val blobOpen: StateFlow<Boolean> = _blobOpen.asStateFlow()
+
+    private val _blobPsm = MutableStateFlow(0)
+    val blobPsm: StateFlow<Int> = _blobPsm.asStateFlow()
+
+    private val _blobLog = MutableStateFlow(emptyList<String>())
+    val blobLog: StateFlow<List<String>> = _blobLog.asStateFlow()
+
+    private val _blobTotalBytes = MutableStateFlow(BLOB_DEFAULT_TOTAL_BYTES)
+    val blobTotalBytes: StateFlow<Long> = _blobTotalBytes.asStateFlow()
+
+    private val _blobFrameBytes = MutableStateFlow(BLOB_DEFAULT_FRAME_BYTES)
+    val blobFrameBytes: StateFlow<Int> = _blobFrameBytes.asStateFlow()
+
+    private val _blobSendStats = MutableStateFlow<BlobSendStats?>(null)
+    val blobSendStats: StateFlow<BlobSendStats?> = _blobSendStats.asStateFlow()
+
+    private var blobListener: L2capListener? = null
+    private var blobAcceptJob: Job? = null
+
+    fun setBlobTotalBytes(bytes: Long) {
+        _blobTotalBytes.value = bytes
+    }
+
+    fun setBlobFrameBytes(bytes: Int) {
+        _blobFrameBytes.value = bytes.coerceIn(64, BLOB_MAX_FRAME_BYTES)
+    }
+
+    fun openBlobServer(secure: Boolean = true) {
+        launchWithErrorHandling {
+            blobListener?.close()
+            val listener = L2capListener()
+            blobListener = listener
+            blobAcceptJob?.cancel()
+            blobAcceptJob =
+                viewModelScope.launch {
+                    listener.framedConnections(BlobChunkCodec).collect { typed ->
+                        launch { sendBlob(typed) }
+                    }
+                }
+            listener.open(secure)
+            _blobPsm.value = listener.psm
+            _blobOpen.value = true
+            appendBlobLog("Blob listener open (PSM=${listener.psm}, secure=$secure)")
+        }
+    }
+
+    fun closeBlobServer() {
+        blobAcceptJob?.cancel()
+        blobAcceptJob = null
+        blobListener?.close()
+        blobListener = null
+        _blobOpen.value = false
+        _blobSendStats.value = null
+        appendBlobLog("Blob listener closed")
+    }
+
+    private suspend fun sendBlob(typed: TypedL2capChannel<BlobChunk>) {
+        val totalBytes = _blobTotalBytes.value
+        val frameBytes = _blobFrameBytes.value
+        val pattern = ByteArray(frameBytes) { (it and 0xFF).toByte() }
+        val totalFrames = ((totalBytes + frameBytes - 1) / frameBytes).toInt()
+
+        appendBlobLog(
+            "Accepted (mtu=${typed.mtu}); sending ${totalBytes / 1024} KiB in " +
+                "$totalFrames frames of ${frameBytes / 1024} KiB",
+        )
+
+        val mark = TimeSource.Monotonic.markNow()
+        var bytesSent = 0L
+        var framesSent = 0
+        _blobSendStats.value = BlobSendStats(0, 0, totalBytes, typed.mtu, 0, false)
+
+        try {
+            while (typed.isOpen && bytesSent < totalBytes) {
+                val remaining = (totalBytes - bytesSent).toInt().coerceAtMost(frameBytes)
+                val chunk = if (remaining == frameBytes) pattern else pattern.copyOfRange(0, remaining)
+                val eof = bytesSent + chunk.size >= totalBytes
+                try {
+                    typed.write(BlobChunk(framesSent, totalBytes, eof, chunk))
+                } catch (e: Exception) {
+                    appendBlobLog("Send failed @ seq=$framesSent: ${e.message}")
+                    break
+                }
+                bytesSent += chunk.size
+                framesSent++
+                _blobSendStats.value =
+                    BlobSendStats(
+                        bytesSent = bytesSent,
+                        framesSent = framesSent,
+                        totalBytes = totalBytes,
+                        mtu = typed.mtu,
+                        elapsedMs = mark.elapsedNow().inWholeMilliseconds,
+                        done = eof,
+                    )
+            }
+            appendBlobLog(
+                "Send done: ${bytesSent}B in $framesSent frames over " +
+                    "${mark.elapsedNow().inWholeMilliseconds}ms",
+            )
+        } finally {
+            typed.close()
+        }
+    }
+
+    private fun appendBlobLog(msg: String) {
+        _blobLog.update { (listOf(msg) + it).take(20) }
+    }
+
     override fun onCleared() {
         closeL2capServer()
+        closeBlobServer()
         advertiser.close()
         extAdvertiser.close()
         server.close()

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
@@ -547,6 +547,21 @@ private fun BlobReceiveStatsBlock(stats: BlobL2capController.Stats) {
             "${stats.frameCount} frames  |  " +
                 "${stats.frameBytesMin}-${stats.frameBytesMax} B (encoded, incl. CBOR + length prefix)",
         )
+
+        Spacer(Modifier.height(6.dp))
+        Text("Connection tuning", style = MaterialTheme.typography.labelMedium)
+        LayerRow(
+            "Priority",
+            when {
+                !stats.priorityRequested -> "not requested"
+                stats.priorityApplied -> "HIGH (platform accepted)"
+                else -> "not supported"
+            },
+        )
+        LayerRow(
+            "PHY",
+            stats.phyApplied?.let { "tx=${it.tx} rx=${it.rx}" } ?: "not supported / 1M default",
+        )
     }
 }
 

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -63,6 +64,8 @@ fun ServiceExplorerScreen(
     val l2capChannel by vm.l2cap.channel.collectAsState()
     val l2capLog by vm.l2cap.log.collectAsState()
     val l2capReadings by vm.l2cap.readings.collectAsState()
+    val blobStats by vm.blob.stats.collectAsState()
+    val blobLog by vm.blob.log.collectAsState()
 
     Scaffold(
         topBar = {
@@ -99,6 +102,7 @@ fun ServiceExplorerScreen(
 
             item { BenchmarkSection(state, services, benchmarkResult, vm) }
             item { L2capSection(state, l2capChannel != null, l2capLog, l2capReadings, vm) }
+            item { L2capBlobSection(state, blobStats, blobLog, vm) }
             item { Spacer(Modifier.height(16.dp)) }
         }
     }
@@ -433,5 +437,134 @@ private fun L2capSection(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun L2capBlobSection(
+    state: State,
+    stats: BlobL2capController.Stats,
+    log: List<String>,
+    vm: BleViewModel,
+) {
+    var psmInput by remember { mutableStateOf("") }
+
+    CollapsibleCard("L2CAP Blob Stream") {
+        Column {
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                "Receives a multi-MiB stream from the server's L2CAP Blob listener. Stats split " +
+                    "into three layers: L2CAP SDU MTU (negotiated by controller), OS read chunk " +
+                    "size (channel.incoming ByteArray sizes), and app frame size (decoded " +
+                    "BlobChunk.bytes lengths).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            FilterChip(
+                selected = stats.isOpen,
+                onClick = {},
+                label = { Text(if (stats.isOpen) "Open" else "Closed") },
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = psmInput,
+                    onValueChange = { psmInput = it },
+                    label = { Text("PSM") },
+                    modifier = Modifier.width(80.dp),
+                    singleLine = true,
+                )
+                Button(
+                    onClick = { psmInput.toIntOrNull()?.let { vm.blob.open(it) } },
+                    enabled = state is State.Connected && !stats.isOpen,
+                ) { Text("Open") }
+                OutlinedButton(
+                    onClick = { vm.blob.close() },
+                    enabled = stats.isOpen,
+                ) { Text("Close") }
+            }
+
+            if (stats.frameCount > 0 || stats.osChunkCount > 0 || stats.isOpen) {
+                Spacer(Modifier.height(12.dp))
+                BlobReceiveStatsBlock(stats)
+            }
+
+            if (log.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                for (entry in log.take(8)) {
+                    Text(
+                        entry,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlobReceiveStatsBlock(stats: BlobL2capController.Stats) {
+    val throughputKbps = stats.throughputBytesPerSec / 1024.0
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            "Received: ${humanBytes(stats.receivedBytes)} / " +
+                "${if (stats.expectedBytes > 0) humanBytes(stats.expectedBytes) else "?"}  " +
+                "(${stats.frameCount} frames)",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        LinearProgressIndicator(
+            progress = { stats.progressFraction },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            "Throughput: ${humanThroughput(throughputKbps)}  |  Elapsed: ${stats.elapsedMs} ms  |  " +
+                if (stats.done) "DONE" else "...",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(6.dp))
+        Text("Layer breakdown", style = MaterialTheme.typography.labelMedium)
+        LayerRow("L2CAP SDU MTU", "${stats.mtu} B (negotiated, channel.mtu)")
+        LayerRow(
+            "OS read chunks",
+            "${stats.osChunkCount} chunks  |  " +
+                "${stats.osChunkBytesMin}-${stats.osChunkBytesMax} B  |  " +
+                "avg ${roundOne(stats.osChunkBytesAvg)} B",
+        )
+        LayerRow(
+            "App frames",
+            "${stats.frameCount} frames  |  " +
+                "${stats.frameBytesMin}-${stats.frameBytesMax} B (encoded, incl. CBOR + length prefix)",
+        )
+    }
+}
+
+@Composable
+private fun LayerRow(
+    label: String,
+    value: String,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            "$label:",
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.width(120.dp),
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -65,6 +65,12 @@ internal sealed interface GattCallbackEvent {
         val rssi: Int,
         val status: Int,
     ) : GattCallbackEvent
+
+    data class PhyUpdated(
+        val txPhy: Int,
+        val rxPhy: Int,
+        val status: Int,
+    ) : GattCallbackEvent
 }
 
 internal class AndroidGattBridge(
@@ -152,6 +158,15 @@ internal class AndroidGattBridge(
             ) {
                 onEvent?.invoke(GattCallbackEvent.ReadRemoteRssi(rssi, status))
             }
+
+            override fun onPhyUpdate(
+                gatt: BluetoothGatt,
+                txPhy: Int,
+                rxPhy: Int,
+                status: Int,
+            ) {
+                onEvent?.invoke(GattCallbackEvent.PhyUpdated(txPhy, rxPhy, status))
+            }
         }
 
     internal fun connect(options: ConnectionOptions): BluetoothGatt? {
@@ -182,6 +197,18 @@ internal class AndroidGattBridge(
     internal fun discoverServices(): Boolean = gatt?.discoverServices() ?: false
 
     internal fun requestMtu(mtu: Int): Boolean = gatt?.requestMtu(mtu) ?: false
+
+    internal fun requestConnectionPriority(priority: Int): Boolean = gatt?.requestConnectionPriority(priority) ?: false
+
+    internal fun setPreferredPhy(
+        txPhyMask: Int,
+        rxPhyMask: Int,
+        phyOptions: Int,
+    ): Boolean {
+        val g = gatt ?: return false
+        g.setPreferredPhy(txPhyMask, rxPhyMask, phyOptions)
+        return true
+    }
 
     internal fun readCharacteristic(characteristic: BluetoothGattCharacteristic): Boolean =
         gatt?.readCharacteristic(characteristic) ?: false

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -4,6 +4,7 @@ package com.atruedev.kmpble.peripheral
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothProfile
@@ -14,6 +15,8 @@ import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -39,6 +42,7 @@ import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
+import com.atruedev.kmpble.gatt.internal.PhyUpdateResult
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.BluetoothL2capSocket
 import com.atruedev.kmpble.l2cap.L2capChannel
@@ -345,7 +349,21 @@ public class AndroidPeripheral internal constructor(
                 is GattCallbackEvent.DescriptorWrite ->
                     pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
                 is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
+                is GattCallbackEvent.PhyUpdated -> handlePhyUpdated(event)
             }
+        }
+    }
+
+    private fun handlePhyUpdated(event: GattCallbackEvent.PhyUpdated) {
+        if (pendingOps.has(PendingOp.PhyUpdate)) {
+            pendingOps.complete(
+                PendingOp.PhyUpdate,
+                PhyUpdateResult(
+                    txPhyConstant = event.txPhy,
+                    rxPhyConstant = event.rxPhy,
+                    status = event.status.toGattStatus(),
+                ),
+            )
         }
     }
 
@@ -666,6 +684,59 @@ public class AndroidPeripheral internal constructor(
             pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
         }
     }
+
+    @ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        val androidPriority =
+            when (priority) {
+                ConnectionPriority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+                ConnectionPriority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+                ConnectionPriority.LowPower -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+            }
+        return peripheralContext.gattQueue.enqueue {
+            bridge.requestConnectionPriority(androidPriority)
+        }
+    }
+
+    @ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        val txMask = phyToMask(tx)
+        val rxMask = phyToMask(rx)
+        return peripheralContext.gattQueue.enqueue {
+            val result =
+                pendingOps.awaitGatt(PendingOp.PhyUpdate, "setPreferredPhy") {
+                    bridge.setPreferredPhy(
+                        txMask,
+                        rxMask,
+                        BluetoothDevice.PHY_OPTION_NO_PREFERRED,
+                    )
+                }
+            if (!result.status.isSuccess()) return@enqueue null
+            PhyResult(
+                tx = phyConstantToPhy(result.txPhyConstant),
+                rx = phyConstantToPhy(result.rxPhyConstant),
+            )
+        }
+    }
+
+    private fun phyToMask(phy: Phy): Int =
+        when (phy) {
+            Phy.Le1M -> BluetoothDevice.PHY_LE_1M_MASK
+            Phy.Le2M -> BluetoothDevice.PHY_LE_2M_MASK
+            Phy.LeCoded -> BluetoothDevice.PHY_LE_CODED_MASK
+        }
+
+    private fun phyConstantToPhy(value: Int): Phy =
+        when (value) {
+            BluetoothDevice.PHY_LE_2M -> Phy.Le2M
+            BluetoothDevice.PHY_LE_CODED -> Phy.LeCoded
+            else -> Phy.Le1M
+        }
 
     private val activeL2capChannels = MutableStateFlow<List<AndroidL2capChannel>>(emptyList())
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionPriority.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionPriority.kt
@@ -1,0 +1,22 @@
+package com.atruedev.kmpble.connection
+
+/**
+ * Connection priority hint requested from the central toward the peripheral.
+ *
+ * The hint translates to a request for new LE connection parameters (interval,
+ * latency, supervision timeout). The peripheral may accept, reject, or
+ * negotiate alternative values; there is no guarantee of a specific interval.
+ *
+ * Maps to `BluetoothGatt.CONNECTION_PRIORITY_*` on Android. iOS has no public
+ * CoreBluetooth API; calls are a no-op there and return `false`.
+ *
+ * - [Balanced]: ~30-50 ms interval. Android default.
+ * - [High]: ~11.25-15 ms interval. Highest throughput, highest power draw.
+ *   Recommended for short bursts (firmware updates, L2CAP blob transfers).
+ * - [LowPower]: ~100-125 ms interval. Lowest power, slow throughput.
+ */
+public enum class ConnectionPriority {
+    Balanced,
+    High,
+    LowPower,
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -32,7 +32,15 @@ internal sealed interface PendingOp<T> {
     data object RssiRead : PendingOp<Int>
 
     data object MtuRequest : PendingOp<Int>
+
+    data object PhyUpdate : PendingOp<PhyUpdateResult>
 }
+
+internal data class PhyUpdateResult(
+    val txPhyConstant: Int,
+    val rxPhyConstant: Int,
+    val status: com.atruedev.kmpble.error.GattStatus,
+)
 
 /**
  * Holds at most one [CompletableDeferred] per [PendingOp] type.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -5,6 +5,8 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -124,6 +126,54 @@ public interface Peripheral : AutoCloseable {
     public suspend fun readRssi(): Int
 
     public suspend fun requestMtu(mtu: Int): Int
+
+    /**
+     * Request a new connection priority (interval / latency / supervision timeout).
+     *
+     * On Android, maps to `BluetoothGatt.requestConnectionPriority`. Returns
+     * synchronously after the request is dispatched; the actual interval
+     * negotiation happens asynchronously and is not surfaced through this API.
+     *
+     * On iOS, this is a no-op and returns `false`. CoreBluetooth does not
+     * expose connection parameter negotiation through public API.
+     *
+     * Use [ConnectionPriority.High] before high-throughput operations
+     * (L2CAP bulk transfers, firmware updates) to drop the connection interval
+     * to ~11-15 ms. Reset to [ConnectionPriority.Balanced] when done to
+     * avoid sustained battery drain.
+     *
+     * @return `true` if the platform supports the request and it was dispatched
+     *         successfully; `false` on unsupported platforms or if the GATT
+     *         layer is not yet ready.
+     */
+    @ExperimentalBleApi
+    public suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean
+
+    /**
+     * Request preferred PHYs for the LE connection (BLE 5.0).
+     *
+     * On Android, maps to `BluetoothGatt.setPreferredPhy`. Suspends until the
+     * `onPhyUpdate` callback fires (or times out via `gattOperationTimeout`).
+     * The returned PHYs reflect the controller's choice, which may differ from
+     * what was requested.
+     *
+     * On iOS, this is a no-op and returns `null`. CoreBluetooth does not
+     * expose PHY negotiation through public API; the OS picks PHY based on
+     * device capability.
+     *
+     * Use `Phy.Le2M` for both directions to double over-the-air throughput on
+     * BLE 5.0 devices. Falls back to 1M silently on older devices.
+     *
+     * @param tx Preferred TX PHY.
+     * @param rx Preferred RX PHY.
+     * @return [PhyResult] reflecting the negotiated TX/RX PHYs, or `null` if
+     *         the platform does not support the operation.
+     */
+    @ExperimentalBleApi
+    public suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult?
 
     public val maximumWriteValueLength: StateFlow<Int>
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PhyResult.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PhyResult.kt
@@ -1,0 +1,14 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.Phy
+
+/**
+ * Result of a [Peripheral.setPreferredPhy] request.
+ *
+ * The negotiated [tx] / [rx] PHYs may differ from what was requested if the
+ * controller or peer device does not support the preferred PHY.
+ */
+public data class PhyResult(
+    val tx: Phy,
+    val rx: Phy,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -2,6 +2,8 @@ package com.atruedev.kmpble.testing
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.BleError
@@ -23,6 +25,7 @@ import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -282,6 +285,23 @@ public class FakePeripheral internal constructor(
         checkConnected()
         context.updateMtu(mtu)
         return mtu
+    }
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        checkConnected()
+        return true
+    }
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        checkConnected()
+        return PhyResult(tx, rx)
     }
 
     // --- Internal ---

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
@@ -1,5 +1,8 @@
 package com.atruedev.kmpble.peripheral
 
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.ConnectionLost
@@ -12,6 +15,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
@@ -177,5 +181,27 @@ class FakePeripheralTest {
 
             val s = peripheral.simulateEvent(ConnectionEvent.AdapterOff)
             assertIs<State.Disconnected.BySystemEvent>(s)
+        }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun requestConnectionPriorityReturnsTrueWhenConnected() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+            assertTrue(peripheral.requestConnectionPriority(ConnectionPriority.High))
+        }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun setPreferredPhyEchoesRequestedPhys() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+
+            val result = peripheral.setPreferredPhy(Phy.Le2M, Phy.Le2M)
+            assertNotNull(result)
+            assertEquals(Phy.Le2M, result.tx)
+            assertEquals(Phy.Le2M, result.rx)
         }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -7,6 +7,8 @@ import com.atruedev.kmpble.bleDataFromNSData
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -525,6 +527,21 @@ public class IosPeripheral(
                 .toInt() + ATT_HEADER_SIZE
         peripheralContext.updateMtu(actualMtu)
         return actualMtu
+    }
+
+    @ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        return false
+    }
+
+    @ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        return null
     }
 
     override suspend fun openL2capChannel(

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -4,6 +4,8 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -13,6 +15,7 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,6 +86,15 @@ internal class StubPeripheral(
     override suspend fun readRssi(): Int = unsupported()
 
     override suspend fun requestMtu(mtu: Int): Int = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? = unsupported()
 
     override suspend fun openL2capChannel(
         psm: Int,


### PR DESCRIPTION
## Summary

- Adds an L2CAP blob-stream demo on top of the existing sensor-stream sample: server publishes a second L2CAP listener that pushes a configurable total payload (1-25 MiB) as length-prefix-framed `BlobChunk` messages at a configurable frame size (1-60 KiB).
- Client controller taps the receive pipeline at three points and surfaces a layer breakdown so the round-trip is observable end-to-end:
  - L2CAP SDU MTU (`channel.mtu`, negotiated by the controller; spec ceiling 65535 octets)
  - OS read chunk sizes (`channel.incoming` ByteArray sizes, pre-framer)
  - App frame sizes (`LengthPrefixFramer` frames post-unframer, before CBOR decode)
- Live progress, throughput, MTU, and per-layer min/max/avg are rendered on both server and client screens.

## Files

- New: `BlobChunk.kt` (CBOR payload + codec), `BlobL2capController.kt` (receive-side with 3-layer stats), `ByteFormat.kt` (KiB/MiB helpers).
- Modified: `ServerViewModel.kt` (second L2CAP listener + producer), `ServerScreen.kt` (Blob Stream card), `BleViewModel.kt` (wire `blob` controller), `ServiceExplorerScreen.kt` (Blob Stream section with layer breakdown).

## Test plan

- [ ] `./gradlew :sample:compileKotlinIosArm64 :sample:compileAndroidMain` (verified locally)
- [ ] `./gradlew :sample:ktlintCheck` (verified locally)
- [ ] Two-phone manual: phone A opens GATT server, advertises, opens Blob Stream listener, picks total + frame size; phone B scans, connects, opens the Blob Stream section, enters PSM, opens channel; observe progress bar fills, throughput stabilises, MTU/OS/app columns populate.
- [ ] Verify EOF and `done` flag flip after expected total received; channel closes cleanly.
- [ ] Try frame sizes from 1 KiB up to 60 KiB; OS read chunk count should drop as frame size approaches negotiated MTU.