### PR TITLE
feat(peripheral): add connection priority and PHY tuning APIs

### DIFF
--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobChunk.kt
@@ -4,6 +4,7 @@ package com.atruedev.kmpble.sample
 
 import com.atruedev.kmpble.codec.serialization.cborCodec
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
 
 /**
  * Fragment of a larger blob being streamed over a framed L2CAP channel.
@@ -26,7 +27,7 @@ data class BlobChunk(
     val seq: Int,
     val totalBytes: Long,
     val eof: Boolean,
-    val bytes: ByteArray,
+    @ByteString val bytes: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/BlobL2capController.kt
@@ -1,9 +1,13 @@
 package com.atruedev.kmpble.sample
 
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.codec.LengthPrefixFramer
 import com.atruedev.kmpble.codec.unframedBy
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +39,7 @@ import kotlin.time.TimeSource
  * 3. **App frame size** = the size of each decoded [BlobChunk.bytes]
  *    payload, equal to the producer's `frameBytes` setting.
  */
+@OptIn(ExperimentalBleApi::class)
 class BlobL2capController(
     private val peripheral: Peripheral,
     private val scope: CoroutineScope,
@@ -53,6 +58,10 @@ class BlobL2capController(
         val osChunkBytesTotal: Long = 0,
         val elapsedMs: Long = 0,
         val done: Boolean = false,
+        val priorityRequested: Boolean = false,
+        val priorityApplied: Boolean = false,
+        val phyApplied: PhyResult? = null,
+        val phySupported: Boolean = false,
     ) {
         val progressFraction: Float
             get() = if (expectedBytes > 0) (receivedBytes.toFloat() / expectedBytes.toFloat()).coerceIn(0f, 1f) else 0f
@@ -76,14 +85,46 @@ class BlobL2capController(
     fun open(
         psm: Int,
         secure: Boolean = true,
+        tunePriority: Boolean = true,
+        tunePhy: Boolean = true,
     ) {
         openJob?.cancel()
         openJob =
             scope.launch {
                 try {
+                    val priorityApplied =
+                        if (tunePriority) {
+                            val ok = peripheral.requestConnectionPriority(ConnectionPriority.High)
+                            appendLog(if (ok) "Priority HIGH requested" else "Priority not supported")
+                            ok
+                        } else {
+                            false
+                        }
+
+                    val phyResult =
+                        if (tunePhy) {
+                            val res = peripheral.setPreferredPhy(Phy.Le2M, Phy.Le2M)
+                            if (res != null) {
+                                appendLog("PHY set tx=${res.tx} rx=${res.rx}")
+                            } else {
+                                appendLog("PHY not supported / no-op")
+                            }
+                            res
+                        } else {
+                            null
+                        }
+
                     val ch = peripheral.openL2capChannel(psm, secure)
                     channel = ch
-                    _stats.value = Stats(isOpen = true, mtu = ch.mtu)
+                    _stats.value =
+                        Stats(
+                            isOpen = true,
+                            mtu = ch.mtu,
+                            priorityRequested = tunePriority,
+                            priorityApplied = priorityApplied,
+                            phyApplied = phyResult,
+                            phySupported = phyResult != null,
+                        )
                     appendLog("Opened (PSM=$psm, mtu=${ch.mtu})")
                     consume(ch)
                 } catch (e: CancellationException) {

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ServiceExplorerScreen.kt
@@ -547,6 +547,21 @@ private fun BlobReceiveStatsBlock(stats: BlobL2capController.Stats) {
             "${stats.frameCount} frames  |  " +
                 "${stats.frameBytesMin}-${stats.frameBytesMax} B (encoded, incl. CBOR + length prefix)",
         )
+
+        Spacer(Modifier.height(6.dp))
+        Text("Connection tuning", style = MaterialTheme.typography.labelMedium)
+        LayerRow(
+            "Priority",
+            when {
+                !stats.priorityRequested -> "not requested"
+                stats.priorityApplied -> "HIGH (platform accepted)"
+                else -> "not supported"
+            },
+        )
+        LayerRow(
+            "PHY",
+            stats.phyApplied?.let { "tx=${it.tx} rx=${it.rx}" } ?: "not supported / 1M default",
+        )
     }
 }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -65,6 +65,12 @@ internal sealed interface GattCallbackEvent {
         val rssi: Int,
         val status: Int,
     ) : GattCallbackEvent
+
+    data class PhyUpdated(
+        val txPhy: Int,
+        val rxPhy: Int,
+        val status: Int,
+    ) : GattCallbackEvent
 }
 
 internal class AndroidGattBridge(
@@ -152,6 +158,15 @@ internal class AndroidGattBridge(
             ) {
                 onEvent?.invoke(GattCallbackEvent.ReadRemoteRssi(rssi, status))
             }
+
+            override fun onPhyUpdate(
+                gatt: BluetoothGatt,
+                txPhy: Int,
+                rxPhy: Int,
+                status: Int,
+            ) {
+                onEvent?.invoke(GattCallbackEvent.PhyUpdated(txPhy, rxPhy, status))
+            }
         }
 
     internal fun connect(options: ConnectionOptions): BluetoothGatt? {
@@ -182,6 +197,18 @@ internal class AndroidGattBridge(
     internal fun discoverServices(): Boolean = gatt?.discoverServices() ?: false
 
     internal fun requestMtu(mtu: Int): Boolean = gatt?.requestMtu(mtu) ?: false
+
+    internal fun requestConnectionPriority(priority: Int): Boolean = gatt?.requestConnectionPriority(priority) ?: false
+
+    internal fun setPreferredPhy(
+        txPhyMask: Int,
+        rxPhyMask: Int,
+        phyOptions: Int,
+    ): Boolean {
+        val g = gatt ?: return false
+        g.setPreferredPhy(txPhyMask, rxPhyMask, phyOptions)
+        return true
+    }
 
     internal fun readCharacteristic(characteristic: BluetoothGattCharacteristic): Boolean =
         gatt?.readCharacteristic(characteristic) ?: false

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -4,6 +4,7 @@ package com.atruedev.kmpble.peripheral
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothProfile
@@ -14,6 +15,8 @@ import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -39,6 +42,7 @@ import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
+import com.atruedev.kmpble.gatt.internal.PhyUpdateResult
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.BluetoothL2capSocket
 import com.atruedev.kmpble.l2cap.L2capChannel
@@ -345,7 +349,21 @@ public class AndroidPeripheral internal constructor(
                 is GattCallbackEvent.DescriptorWrite ->
                     pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
                 is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
+                is GattCallbackEvent.PhyUpdated -> handlePhyUpdated(event)
             }
+        }
+    }
+
+    private fun handlePhyUpdated(event: GattCallbackEvent.PhyUpdated) {
+        if (pendingOps.has(PendingOp.PhyUpdate)) {
+            pendingOps.complete(
+                PendingOp.PhyUpdate,
+                PhyUpdateResult(
+                    txPhyConstant = event.txPhy,
+                    rxPhyConstant = event.rxPhy,
+                    status = event.status.toGattStatus(),
+                ),
+            )
         }
     }
 
@@ -666,6 +684,59 @@ public class AndroidPeripheral internal constructor(
             pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
         }
     }
+
+    @ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        val androidPriority =
+            when (priority) {
+                ConnectionPriority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+                ConnectionPriority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+                ConnectionPriority.LowPower -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+            }
+        return peripheralContext.gattQueue.enqueue {
+            bridge.requestConnectionPriority(androidPriority)
+        }
+    }
+
+    @ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        val txMask = phyToMask(tx)
+        val rxMask = phyToMask(rx)
+        return peripheralContext.gattQueue.enqueue {
+            val result =
+                pendingOps.awaitGatt(PendingOp.PhyUpdate, "setPreferredPhy") {
+                    bridge.setPreferredPhy(
+                        txMask,
+                        rxMask,
+                        BluetoothDevice.PHY_OPTION_NO_PREFERRED,
+                    )
+                }
+            if (!result.status.isSuccess()) return@enqueue null
+            PhyResult(
+                tx = phyConstantToPhy(result.txPhyConstant),
+                rx = phyConstantToPhy(result.rxPhyConstant),
+            )
+        }
+    }
+
+    private fun phyToMask(phy: Phy): Int =
+        when (phy) {
+            Phy.Le1M -> BluetoothDevice.PHY_LE_1M_MASK
+            Phy.Le2M -> BluetoothDevice.PHY_LE_2M_MASK
+            Phy.LeCoded -> BluetoothDevice.PHY_LE_CODED_MASK
+        }
+
+    private fun phyConstantToPhy(value: Int): Phy =
+        when (value) {
+            BluetoothDevice.PHY_LE_2M -> Phy.Le2M
+            BluetoothDevice.PHY_LE_CODED -> Phy.LeCoded
+            else -> Phy.Le1M
+        }
 
     private val activeL2capChannels = MutableStateFlow<List<AndroidL2capChannel>>(emptyList())
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionPriority.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionPriority.kt
@@ -1,0 +1,22 @@
+package com.atruedev.kmpble.connection
+
+/**
+ * Connection priority hint requested from the central toward the peripheral.
+ *
+ * The hint translates to a request for new LE connection parameters (interval,
+ * latency, supervision timeout). The peripheral may accept, reject, or
+ * negotiate alternative values; there is no guarantee of a specific interval.
+ *
+ * Maps to `BluetoothGatt.CONNECTION_PRIORITY_*` on Android. iOS has no public
+ * CoreBluetooth API; calls are a no-op there and return `false`.
+ *
+ * - [Balanced]: ~30-50 ms interval. Android default.
+ * - [High]: ~11.25-15 ms interval. Highest throughput, highest power draw.
+ *   Recommended for short bursts (firmware updates, L2CAP blob transfers).
+ * - [LowPower]: ~100-125 ms interval. Lowest power, slow throughput.
+ */
+public enum class ConnectionPriority {
+    Balanced,
+    High,
+    LowPower,
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -32,7 +32,15 @@ internal sealed interface PendingOp<T> {
     data object RssiRead : PendingOp<Int>
 
     data object MtuRequest : PendingOp<Int>
+
+    data object PhyUpdate : PendingOp<PhyUpdateResult>
 }
+
+internal data class PhyUpdateResult(
+    val txPhyConstant: Int,
+    val rxPhyConstant: Int,
+    val status: com.atruedev.kmpble.error.GattStatus,
+)
 
 /**
  * Holds at most one [CompletableDeferred] per [PendingOp] type.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -5,6 +5,8 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -124,6 +126,54 @@ public interface Peripheral : AutoCloseable {
     public suspend fun readRssi(): Int
 
     public suspend fun requestMtu(mtu: Int): Int
+
+    /**
+     * Request a new connection priority (interval / latency / supervision timeout).
+     *
+     * On Android, maps to `BluetoothGatt.requestConnectionPriority`. Returns
+     * synchronously after the request is dispatched; the actual interval
+     * negotiation happens asynchronously and is not surfaced through this API.
+     *
+     * On iOS, this is a no-op and returns `false`. CoreBluetooth does not
+     * expose connection parameter negotiation through public API.
+     *
+     * Use [ConnectionPriority.High] before high-throughput operations
+     * (L2CAP bulk transfers, firmware updates) to drop the connection interval
+     * to ~11-15 ms. Reset to [ConnectionPriority.Balanced] when done to
+     * avoid sustained battery drain.
+     *
+     * @return `true` if the platform supports the request and it was dispatched
+     *         successfully; `false` on unsupported platforms or if the GATT
+     *         layer is not yet ready.
+     */
+    @ExperimentalBleApi
+    public suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean
+
+    /**
+     * Request preferred PHYs for the LE connection (BLE 5.0).
+     *
+     * On Android, maps to `BluetoothGatt.setPreferredPhy`. Suspends until the
+     * `onPhyUpdate` callback fires (or times out via `gattOperationTimeout`).
+     * The returned PHYs reflect the controller's choice, which may differ from
+     * what was requested.
+     *
+     * On iOS, this is a no-op and returns `null`. CoreBluetooth does not
+     * expose PHY negotiation through public API; the OS picks PHY based on
+     * device capability.
+     *
+     * Use `Phy.Le2M` for both directions to double over-the-air throughput on
+     * BLE 5.0 devices. Falls back to 1M silently on older devices.
+     *
+     * @param tx Preferred TX PHY.
+     * @param rx Preferred RX PHY.
+     * @return [PhyResult] reflecting the negotiated TX/RX PHYs, or `null` if
+     *         the platform does not support the operation.
+     */
+    @ExperimentalBleApi
+    public suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult?
 
     public val maximumWriteValueLength: StateFlow<Int>
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PhyResult.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PhyResult.kt
@@ -1,0 +1,14 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.Phy
+
+/**
+ * Result of a [Peripheral.setPreferredPhy] request.
+ *
+ * The negotiated [tx] / [rx] PHYs may differ from what was requested if the
+ * controller or peer device does not support the preferred PHY.
+ */
+public data class PhyResult(
+    val tx: Phy,
+    val rx: Phy,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -2,6 +2,8 @@ package com.atruedev.kmpble.testing
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.BleError
@@ -23,6 +25,7 @@ import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -282,6 +285,23 @@ public class FakePeripheral internal constructor(
         checkConnected()
         context.updateMtu(mtu)
         return mtu
+    }
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        checkConnected()
+        return true
+    }
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        checkConnected()
+        return PhyResult(tx, rx)
     }
 
     // --- Internal ---

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
@@ -1,5 +1,8 @@
 package com.atruedev.kmpble.peripheral
 
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.ConnectionLost
@@ -12,6 +15,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
@@ -177,5 +181,27 @@ class FakePeripheralTest {
 
             val s = peripheral.simulateEvent(ConnectionEvent.AdapterOff)
             assertIs<State.Disconnected.BySystemEvent>(s)
+        }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun requestConnectionPriorityReturnsTrueWhenConnected() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+            assertTrue(peripheral.requestConnectionPriority(ConnectionPriority.High))
+        }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun setPreferredPhyEchoesRequestedPhys() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+
+            val result = peripheral.setPreferredPhy(Phy.Le2M, Phy.Le2M)
+            assertNotNull(result)
+            assertEquals(Phy.Le2M, result.tx)
+            assertEquals(Phy.Le2M, result.rx)
         }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -7,6 +7,8 @@ import com.atruedev.kmpble.bleDataFromNSData
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -525,6 +527,21 @@ public class IosPeripheral(
                 .toInt() + ATT_HEADER_SIZE
         peripheralContext.updateMtu(actualMtu)
         return actualMtu
+    }
+
+    @ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
+        checkNotClosed()
+        return false
+    }
+
+    @ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        return null
     }
 
     override suspend fun openL2capChannel(

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -4,6 +4,8 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -13,6 +15,7 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.PhyResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,6 +86,15 @@ internal class StubPeripheral(
     override suspend fun readRssi(): Int = unsupported()
 
     override suspend fun requestMtu(mtu: Int): Int = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? = unsupported()
 
     override suspend fun openL2capChannel(
         psm: Int,


### PR DESCRIPTION
Stacked on top of #185.

## Why

The blob-stream demo introduced in #185 measured ~17-18 KB/s on a phone-to-phone pair (Android central, Android peripheral). That is consistent with default Android connection parameters: ~50 ms interval, 1M PHY, MPS around 672 B. A 4 KiB frame fragments into ~6 LE-frames, one per conn event = ~240 ms per frame = ~17 KB/s. Without exposing connection-parameter tuning, no app-level change can lift the ceiling.

## What this changes

Two `@ExperimentalBleApi` methods on `Peripheral`:

- `requestConnectionPriority(ConnectionPriority)` -- High / Balanced / LowPower. Maps to `BluetoothGatt.requestConnectionPriority` on Android (synchronous boolean: was the request dispatched?). iOS no-op returns `false`.
- `setPreferredPhy(tx, rx)` -- maps to `BluetoothGatt.setPreferredPhy` on Android; suspends on `onPhyUpdate` callback. Returns the negotiated `PhyResult`, or `null` if unsupported / failed. iOS no-op returns `null`.

Wiring:
- New `ConnectionPriority` enum in `connection/`
- New `PhyResult` data class in `peripheral/`
- New `PendingOp.PhyUpdate` + `PhyUpdateResult` internal
- New `GattCallbackEvent.PhyUpdated` + bridge methods + `BluetoothGattCallback.onPhyUpdate` override
- `FakePeripheral` echoes requested values (lets unit tests assert without hardware)
- `StubPeripheral` (Lincheck) throws unsupported on the new members
- Two new `FakePeripheralTest` cases

## Sample integration

`BlobL2capController.open()` now requests `HIGH` priority and `Le2M / Le2M` PHY before opening the L2CAP channel. The stats panel exposes:

- Priority: not requested / HIGH (platform accepted) / not supported
- PHY: tx=Le2M rx=Le2M / not supported / 1M default

Both calls are gated behind `tunePriority` / `tunePhy` parameters on `open()` so the slow baseline remains reachable for comparison.

## Test plan

- [x] `./gradlew jvmTest` -- new FakePeripheral tests pass; no regressions in existing tests
- [x] `./gradlew compileKotlinIosArm64 compileAndroidMain :sample:compileKotlinIosArm64 :sample:compileAndroidMain`
- [x] `./gradlew ktlintCheck`
- [x] Two-phone manual: open the blob-stream listener on phone A; on phone B open the section, verify "Priority: HIGH (platform accepted)" and "PHY: tx=Le2M rx=Le2M" show after Open. Throughput should jump from ~17 KB/s baseline to ~100+ KB/s.
- [x] iOS smoke: verify the "not supported" labels appear and the demo still runs.

## Merge order

This PR is stacked on `feat/sample-l2cap-blob-stream` (#185). Merge #185 first, then rebase or merge this onto `main`.