### PR TITLE
fix(deps): pin OpenTelemetry to 1.62.0 for CVE-2026-45292

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ val securityPatches: Action<DependencyResolveDetails> =
             "ch.qos.logback" -> useVersion(libs.versions.logback.get())
             "com.fasterxml.jackson.core" -> useVersion(libs.versions.jackson.get())
             "org.bouncycastle" -> useVersion(libs.versions.bouncycastle.get())
+            "io.opentelemetry" -> useVersion(libs.versions.opentelemetry.get())
         }
         when ("${requested.group}:${requested.name}") {
             "org.jdom:jdom2" -> useVersion(libs.versions.jdom2.get())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ jose4j = "0.9.6"
 commonsLang3 = "3.18.0"
 httpclient = "4.5.14"
 bouncycastle = "1.84"
+opentelemetry = "1.62.0"
 
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version = "1.18.0" }


### PR DESCRIPTION
## Summary
- Pins `io.opentelemetry` group to `1.62.0` via the existing `securityPatches` resolution strategy to remediate [GHSA-rcgg-9c38-7xpx](https://github.com/gary-quinn/kmp-ble/security/dependabot/28) / CVE-2026-45292 (unbounded memory allocation in W3C Baggage propagation, medium severity).
- The vulnerable `opentelemetry-api:1.41.0` is pulled in transitively by `org.jetbrains.kotlin:swift-export-embeddable:2.3.21` (Kotlin Multiplatform iOS Swift Export tooling), so a force-version override is the only path; the upstream Kotlin release would need to bump it otherwise.

## Test plan
- [x] `./gradlew :dependencies | grep opentelemetry` shows `1.41.0 -> 1.62.0` on the root project
- [x] Same override confirmed across `kmp-ble-codec`, `kmp-ble-codec-serialization`, `kmp-ble-dfu`, `kmp-ble-profiles`, `sample`
- [ ] CI green