### PR TITLE
fix(ios): open NSStreams before reading from L2CAP channel

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/l2cap/IosL2capChannel.kt
@@ -22,7 +22,6 @@ import platform.CoreBluetooth.CBL2CAPChannel
 import platform.Foundation.NSStreamStatusAtEnd
 import platform.Foundation.NSStreamStatusClosed
 import platform.Foundation.NSStreamStatusError
-import platform.Foundation.NSStreamStatusOpen
 import kotlin.coroutines.coroutineContext
 
 internal const val DEFAULT_L2CAP_MTU = 2048
@@ -47,11 +46,28 @@ internal class IosL2capChannel(
     internal suspend fun awaitClosed() = closedSignal.await()
 
     init {
-        val inputOk = cbChannel.inputStream?.streamStatus == NSStreamStatusOpen
-        val outputOk = cbChannel.outputStream?.streamStatus == NSStreamStatusOpen
-        if (!inputOk || !outputOk) {
+        // CoreBluetooth hands a CBL2CAPChannel to the central via
+        // peripheral(_:didOpen:error:) with its input and output NSStreams in
+        // NSStreamStatusNotOpen. Apple's BLE programming guide states the
+        // streams "must be opened by the application" before they become
+        // usable; CoreBluetooth itself does not open them, regardless of
+        // iOS version. Without this, the previous status check
+        // (streamStatus == NSStreamStatusOpen) always failed at init,
+        // closed the data channel, and made every L2CAP session emit zero
+        // bytes before reporting "channel ended".
+        //
+        // We don't schedule the streams in a run loop because readLoop polls
+        // hasBytesAvailable instead of relying on NSStreamDelegate events.
+        // Status transitions are observed via readLoop's existing
+        // AtEnd/Closed/Error checks.
+        val inputStream = cbChannel.inputStream
+        val outputStream = cbChannel.outputStream
+        if (inputStream == null || outputStream == null) {
             _isOpen.value = false
             dataChannel.close()
+        } else {
+            inputStream.open()
+            outputStream.open()
         }
 
         readJob =


### PR DESCRIPTION
## What

`IosL2capChannel.init` did not call `open()` on the input/output `NSStream`s of the `CBL2CAPChannel` that CoreBluetooth hands the central via `peripheral(_:didOpen:error:)`. It only checked `streamStatus == NSStreamStatusOpen` and bailed if either stream wasn't already open.

Per Apple's BLE programming guide:

> Before you can read or write data using the input and output streams, you must open them by calling the `open()` method on each stream.

CoreBluetooth never auto-opens them, so the check failed on every session: `_isOpen` was set to `false`, `dataChannel` was closed immediately, and `channel.incoming.collect { ... }` completed with zero records.

Reproducer (downstream app on real iPhone, paired peripheral on Android `gatt-server-sample`):

```
[Pulse] BLE PCAP peripheral found: ...
[Pulse] BLE PCAP peripheral connected
[Pulse] BLE PCAP PSM=157
[Pulse] BLE PCAP L2CAP channel open (mtu=2048)
[Pulse] BLE PCAP L2CAP channel ended          # 3 ms after "open"
```

Followed shortly by `CoreBluetooth: WARNING: Unknown error: 436 / No known channel matching peer ... with cid 72 / Cannot find l2CAP channel closed` as the peer's later events arrive against a channel that the central had already torn down.

## Fix

- Call `open()` on `inputStream` and `outputStream` from `init`.
- Drop the unused `NSStreamStatusOpen` import / check; terminal status (`AtEnd` / `Closed` / `Error`) is already handled by the existing `readLoop` polling.
- No run loop scheduling or `NSStreamDelegate` is added because `readLoop` polls `hasBytesAvailable`. Apple's docs note delegates / run loop scheduling are only needed if you want event-driven notification.

`IosL2capListener` constructs `IosL2capChannel` the same way, so the server-side accept path benefits automatically.

## Test plan

Unit tests stay green (the fake-based suite never exercised the iOS stream-open path).

End-to-end verification was done on a paired iPhone (iOS 18) talking to an Android `gatt-server-sample` peer that opens an L2CAP listener with `secure = true`. Before this change the central got "channel open / channel ended" 3 ms apart with zero bytes through. After this change frames flow continuously and the underlying CB error 436 no longer appears.

No API change.