### PR TITLE
feat!: surface scan failures as ScanEvent instead of crashing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,7 +404,9 @@ Every major component has a Fake* counterpart for unit testing without hardware:
 
 ## Scanner
 
-`Scanner.advertisements` is a **cold Flow**. Creating a `Scanner` starts nothing - no OS resources, no scanning. Scanning starts on first `collect()`, stops when the collector's coroutine is cancelled.
+`Scanner.scanEvents` is a **cold Flow**. Creating a `Scanner` starts nothing - no OS resources, no scanning. Scanning starts on first `collect()`, stops when the collector's coroutine is cancelled.
+
+Each emission is a [ScanEvent] - either `ScanEvent.Found` with a discovered advertisement or `ScanEvent.Failed` when the platform scan encounters a recoverable error. Consumers must handle both cases via exhaustive `when`.
 
 Multiple concurrent collectors share one underlying OS scan. This is standard structured concurrency - no `scanner.stop()` needed.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,7 +39,7 @@ No initialization needed. Add via SPM or use the XCFramework directly.
 | Concept | kmp-ble |
 |---------|---------|
 | Create scanner | `Scanner { filters { match { serviceUuid("180d") } } }` |
-| Scan results | `scanner.advertisements: Flow<Advertisement>` |
+| Scan results | `scanner.scanEvents: Flow<ScanEvent>` |
 | Stop scanning | Cancel the collecting coroutine or call `scanner.close()` |
 | Filter by name | `match { name("HeartSensor") }` |
 | Filter by service UUID | `match { serviceUuid(ServiceUuid.HEART_RATE) }` |

--- a/README.md
+++ b/README.md
@@ -82,8 +82,14 @@ val scanner = Scanner {
     }
 }
 
-scanner.advertisements.collect { ad ->
-    println("Found: ${ad.name} (${ad.identifier}) rssi=${ad.rssi}")
+scanner.scanEvents.collect { event ->
+    when (event) {
+        is ScanEvent.Found -> {
+            val ad = event.advertisement
+            println("Found: ${ad.name} (${ad.identifier}) rssi=${ad.rssi}")
+        }
+        is ScanEvent.Failed -> println("Scan failed: ${event.error.message}")
+    }
 }
 
 scanner.close()

--- a/llms.txt
+++ b/llms.txt
@@ -59,8 +59,11 @@ val scanner = Scanner {
         match { serviceUuid(ServiceUuid.HEART_RATE) }
     }
 }
-scanner.advertisements.collect { ad ->
-    println("Found: ${ad.name} rssi=${ad.rssi}")
+scanner.scanEvents.collect { event ->
+    when (event) {
+        is ScanEvent.Found -> println("Found: ${event.advertisement.name} rssi=${event.advertisement.rssi}")
+        is ScanEvent.Failed -> println("Scan failed: ${event.error.message}")
+    }
 }
 ```
 

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpble/sample/ScannerScreen.kt
@@ -43,10 +43,10 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.ServiceUuid
 import com.atruedev.kmpble.scanner.Advertisement
 import com.atruedev.kmpble.scanner.EmissionPolicy
+import com.atruedev.kmpble.scanner.ScanEvent
 import com.atruedev.kmpble.scanner.Scanner
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -96,6 +96,7 @@ fun ScannerScreen(
     onServerTapped: () -> Unit = {},
 ) {
     var devices by remember { mutableStateOf(emptyList<ScannedDevice>()) }
+    var scanError by remember { mutableStateOf<String?>(null) }
     // Safe without synchronization: both writer (snapshot coroutine) and reader (click handler)
     // run on Main dispatcher via rememberCoroutineScope / Compose click callback.
     val advertisementLookup = remember { HashMap<String, Advertisement>() }
@@ -116,8 +117,16 @@ fun ScannerScreen(
         val job =
             scope.launch {
                 launch(scanContext) {
-                    scanner.advertisements.conflate().collect {
-                        deviceMap[it.identifier] = it to TimeSource.Monotonic.markNow()
+                    scanner.scanEvents.collect { event ->
+                        when (event) {
+                            is ScanEvent.Found -> {
+                                deviceMap[event.advertisement.identifier] =
+                                    event.advertisement to TimeSource.Monotonic.markNow()
+                            }
+                            is ScanEvent.Failed -> {
+                                scanError = "Scan failed (code ${event.error.errorCode})"
+                            }
+                        }
                     }
                 }
                 while (isActive) {
@@ -192,6 +201,20 @@ fun ScannerScreen(
                         selected = serviceFilter == name,
                         onClick = { serviceFilter = if (serviceFilter == name) null else name },
                         label = { Text(name, style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+            }
+
+            scanError?.let { error ->
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                ) {
+                    Text(
+                        text = error,
+                        modifier = Modifier.padding(12.dp),
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodyMedium,
                     )
                 }
             }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -8,20 +8,14 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.ParcelUuid
-import com.atruedev.kmpble.scanner.internal.applyEmissionPolicy
-import com.atruedev.kmpble.scanner.internal.matchesFilters
+import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.takeWhile
-import kotlin.time.TimeSource
 import kotlin.uuid.ExperimentalUuidApi
 
 public class AndroidScanner(
@@ -31,25 +25,7 @@ public class AndroidScanner(
     private val config = ScannerConfig().apply(configure)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    private val sharedScanFlow =
-        createRawScanFlow()
-            .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
-
-    override val advertisements: Flow<Advertisement> =
-        run {
-            var flow: Flow<Advertisement> =
-                sharedScanFlow
-                    .filter { it.matchesFilters(config.filterGroups) }
-                    .applyEmissionPolicy(config.emission)
-
-            val timeout = config.timeout
-            if (timeout != null) {
-                val mark = TimeSource.Monotonic.markNow()
-                flow = flow.takeWhile { mark.elapsedNow() < timeout }
-            }
-
-            flow
-        }
+    override val scanEvents: Flow<ScanEvent> = createRawScanFlow().toScanEvents(config, scope)
 
     override fun close() {
         scope.cancel()
@@ -148,7 +124,3 @@ public class AndroidScanner(
         }
     }
 }
-
-public class ScanFailedException(
-    errorCode: Int,
-) : Exception("BLE scan failed with error code: $errorCode")

--- a/src/commonMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/permissions/BlePermissions.kt
@@ -9,7 +9,7 @@ package com.atruedev.kmpble.permissions
  *
  * ```kotlin
  * when (val result = checkBlePermissions()) {
- *     is PermissionResult.Granted -> scanner.advertisements.collect { ... }
+ *     is PermissionResult.Granted -> scanner.scanEvents.collect { ... }
  *     is PermissionResult.Denied -> showPermissionRationale(result.permissions)
  *     is PermissionResult.PermanentlyDenied -> showSettingsPrompt(result.permissions)
  * }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanEvent.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanEvent.kt
@@ -1,0 +1,30 @@
+package com.atruedev.kmpble.scanner
+
+/**
+ * Result of a BLE scan operation.
+ *
+ * Each emission is either a discovered [Advertisement] or a platform failure.
+ * Consumers must handle both cases via exhaustive `when`:
+ *
+ * ```
+ * scanner.scanEvents.collect { event ->
+ *     when (event) {
+ *         is ScanEvent.Found -> handleAdvertisement(event.advertisement)
+ *         is ScanEvent.Failed -> handleError(event.error)
+ *     }
+ * }
+ * ```
+ */
+public sealed interface ScanEvent {
+    public data class Found(
+        val advertisement: Advertisement,
+    ) : ScanEvent
+
+    public data class Failed(
+        val error: ScanFailedException,
+    ) : ScanEvent
+}
+
+public class ScanFailedException(
+    public val errorCode: Int,
+) : Exception("BLE scan failed with error code: $errorCode")

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Scanner.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/Scanner.kt
@@ -5,9 +5,12 @@ import kotlinx.coroutines.flow.Flow
 /**
  * BLE scanner that discovers nearby advertising devices.
  *
- * [advertisements] is a **cold Flow**. Creating a Scanner starts nothing - no OS
+ * [scanEvents] is a **cold Flow**. Creating a Scanner starts nothing - no OS
  * resources allocated. Scanning starts on first `collect()`, stops when the collector's
  * coroutine is cancelled. Multiple concurrent collectors share one underlying OS scan.
+ *
+ * Each emission is a [ScanEvent] - either [ScanEvent.Found] with a discovered
+ * [Advertisement] or [ScanEvent.Failed] when the platform scan encounters an error.
  *
  * Call [close] when the scanner is no longer needed to release internal resources.
  *
@@ -16,5 +19,5 @@ import kotlinx.coroutines.flow.Flow
  * - iOS: `IosScanner { filters { ... } }`
  */
 public interface Scanner : AutoCloseable {
-    public val advertisements: Flow<Advertisement>
+    public val scanEvents: Flow<ScanEvent>
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,14 +1,23 @@
 package com.atruedev.kmpble.scanner
 
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Collect [Scanner.advertisements], return the first matching [predicate], or null after [timeout].
+ * Collect [Scanner.scanEvents], return the first matching [predicate], or null after [timeout].
  *
- * Since [Scanner.advertisements] is a cold flow, scanning starts when this function
+ * **Warning:** [ScanEvent.Failed] events are silently skipped. If the scan hardware fails,
+ * this returns null - indistinguishable from timeout or no matching device. Callers that
+ * need to differentiate "timed out" from "scan failed" should use [firstOrThrow] or collect
+ * [Scanner.scanEvents] directly to handle [ScanEvent.Failed] explicitly.
+ *
+ * Since [Scanner.scanEvents] is a cold flow, scanning starts when this function
  * begins collecting and stops automatically when a match is found or the timeout expires.
  *
  * ```
@@ -20,5 +29,37 @@ public suspend fun Scanner.firstOrNull(
     predicate: (Advertisement) -> Boolean = { true },
 ): Advertisement? =
     withTimeoutOrNull(timeout) {
-        advertisements.firstOrNull(predicate)
+        scanEvents
+            .mapNotNull { event -> (event as? ScanEvent.Found)?.advertisement }
+            .firstOrNull(predicate)
+    }
+
+/**
+ * Collect [Scanner.scanEvents], return the first matching [predicate], or throw after [timeout].
+ *
+ * Unlike [firstOrNull], this surfaces [ScanEvent.Failed] as an exception so callers can
+ * distinguish "timed out" from "scan hardware failed":
+ *
+ * ```
+ * try {
+ *     val ad = scanner.firstOrThrow(timeout = 10.seconds) { it.name == "HeartSensor" }
+ * } catch (e: ScanFailedException) {
+ *     // back off and retry
+ * } catch (e: TimeoutCancellationException) {
+ *     // no device found in time
+ * }
+ * ```
+ */
+public suspend fun Scanner.firstOrThrow(
+    timeout: Duration = 30.seconds,
+    predicate: (Advertisement) -> Boolean = { true },
+): Advertisement =
+    withTimeout(timeout) {
+        scanEvents
+            .map { event ->
+                when (event) {
+                    is ScanEvent.Found -> event.advertisement
+                    is ScanEvent.Failed -> throw event.error
+                }
+            }.first(predicate)
     }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/EmissionPolicyFilter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/EmissionPolicyFilter.kt
@@ -3,29 +3,37 @@ package com.atruedev.kmpble.scanner.internal
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.scanner.Advertisement
 import com.atruedev.kmpble.scanner.EmissionPolicy
+import com.atruedev.kmpble.scanner.ScanEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.math.abs
 import kotlin.uuid.ExperimentalUuidApi
 
 /**
- * Applies [EmissionPolicy] deduplication to an advertisement flow.
+ * Applies [EmissionPolicy] deduplication to a scan event flow.
+ * Only [ScanEvent.Found] events are deduplicated; [ScanEvent.Failed] events pass through unchanged.
  */
-internal fun Flow<Advertisement>.applyEmissionPolicy(policy: EmissionPolicy): Flow<Advertisement> =
+internal fun Flow<ScanEvent>.applyEmissionPolicy(policy: EmissionPolicy): Flow<ScanEvent> =
     when (policy) {
         is EmissionPolicy.All -> this
         is EmissionPolicy.FirstThenChanges -> firstThenChanges(policy.rssiThreshold)
     }
 
 @OptIn(ExperimentalUuidApi::class)
-private fun Flow<Advertisement>.firstThenChanges(rssiThreshold: Int): Flow<Advertisement> =
+private fun Flow<ScanEvent>.firstThenChanges(rssiThreshold: Int): Flow<ScanEvent> =
     flow {
         val seen = mutableMapOf<Identifier, AdvertisementSnapshot>()
-        collect { ad ->
-            val previous = seen[ad.identifier]
-            if (previous == null || hasChanged(previous, ad, rssiThreshold)) {
-                seen[ad.identifier] = ad.snapshot()
-                emit(ad)
+        collect { event ->
+            when (event) {
+                is ScanEvent.Found -> {
+                    val ad = event.advertisement
+                    val previous = seen[ad.identifier]
+                    if (previous == null || hasChanged(previous, ad, rssiThreshold)) {
+                        seen[ad.identifier] = ad.snapshot()
+                        emit(event)
+                    }
+                }
+                is ScanEvent.Failed -> emit(event)
             }
         }
     }
@@ -62,7 +70,6 @@ private fun hasChanged(
     if (previous.name != current.name) return true
     if (previous.serviceUuids != current.serviceUuids) return true
     if (abs(previous.rssi - current.rssi) > rssiThreshold) return true
-    // Check data content changes via hash
     val currentSnapshot = current.snapshot()
     if (previous.manufacturerDataHash != currentSnapshot.manufacturerDataHash) return true
     if (previous.serviceDataHash != currentSnapshot.serviceDataHash) return true

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/ScannerPipeline.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/internal/ScannerPipeline.kt
@@ -1,0 +1,58 @@
+package com.atruedev.kmpble.scanner.internal
+
+import com.atruedev.kmpble.scanner.Advertisement
+import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.ScanFailedException
+import com.atruedev.kmpble.scanner.ScannerConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.transform
+import kotlin.time.TimeSource
+
+/**
+ * Converts a raw advertisement flow into a shared [ScanEvent] flow with filtering,
+ * emission policy, and timeout applied.
+ *
+ * Both [AndroidScanner] and [IosScanner] use this as their scan pipeline.
+ * Platform-specific code only needs to produce a [Flow]<[Advertisement]> and
+ * pass it here.
+ */
+internal fun Flow<Advertisement>.toScanEvents(
+    config: ScannerConfig,
+    scope: CoroutineScope,
+): Flow<ScanEvent> {
+    val shared =
+        map { ScanEvent.Found(it) as ScanEvent }
+            .catch { e ->
+                when (e) {
+                    is ScanFailedException -> emit(ScanEvent.Failed(e))
+                    else -> throw e
+                }
+            }.shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
+
+    var flow: Flow<ScanEvent> =
+        shared
+            .transform { event ->
+                when (event) {
+                    is ScanEvent.Found -> {
+                        if (event.advertisement.matchesFilters(config.filterGroups)) {
+                            emit(event)
+                        }
+                    }
+                    is ScanEvent.Failed -> emit(event)
+                }
+            }.applyEmissionPolicy(config.emission)
+
+    val timeout = config.timeout
+    if (timeout != null) {
+        val mark = TimeSource.Monotonic.markNow()
+        flow = flow.takeWhile { mark.elapsedNow() < timeout }
+    }
+
+    return flow
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeScanner.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeScanner.kt
@@ -5,6 +5,8 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.scanner.Advertisement
 import com.atruedev.kmpble.scanner.DataStatus
+import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.ScanFailedException
 import com.atruedev.kmpble.scanner.Scanner
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.flow.Flow
@@ -30,26 +32,36 @@ import kotlin.uuid.Uuid
  *     }
  * }
  *
- * scanner.advertisements.collect { ad -> ... }
+ * scanner.scanEvents.collect { event ->
+ *     when (event) {
+ *         is ScanEvent.Found -> handleAd(event.advertisement)
+ *         is ScanEvent.Failed -> handleError(event.error)
+ *     }
+ * }
  * ```
  */
 @OptIn(ExperimentalUuidApi::class)
 public class FakeScanner internal constructor(
     private val fakeAdvertisements: List<Advertisement>,
 ) : Scanner {
-    private val dynamicAdvertisements = MutableSharedFlow<Advertisement>(extraBufferCapacity = 64)
+    private val dynamicEvents = MutableSharedFlow<ScanEvent>(replay = 2, extraBufferCapacity = 64)
 
-    override val advertisements: Flow<Advertisement> =
+    override val scanEvents: Flow<ScanEvent> =
         flow {
             for (ad in fakeAdvertisements) {
-                emit(ad)
+                emit(ScanEvent.Found(ad))
             }
-            dynamicAdvertisements.collect { emit(it) }
+            dynamicEvents.collect { emit(it) }
         }
 
     /** Emit an advertisement dynamically after construction. */
     public fun emit(advertisement: Advertisement) {
-        dynamicAdvertisements.tryEmit(advertisement)
+        dynamicEvents.tryEmit(ScanEvent.Found(advertisement))
+    }
+
+    /** Emit a scan failure for testing error handling paths. */
+    public fun emitScanFailed(errorCode: Int) {
+        dynamicEvents.tryEmit(ScanEvent.Failed(ScanFailedException(errorCode)))
     }
 
     override fun close() {

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/EmissionPolicyFilterTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/EmissionPolicyFilterTest.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.scanner
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.scanner.internal.applyEmissionPolicy
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -27,12 +28,14 @@ class EmissionPolicyFilterTest {
         timestampNanos = 0L,
     )
 
+    private fun found(ad: Advertisement) = ScanEvent.Found(ad)
+
     @Test
     fun allPolicyEmitsEverything() =
         runTest {
             val ads = listOf(ad(), ad(), ad())
             val result =
-                flowOf(*ads.toTypedArray())
+                flowOf(*ads.map { found(it) }.toTypedArray())
                     .applyEmissionPolicy(EmissionPolicy.All)
                     .toList()
             assertEquals(3, result.size)
@@ -43,11 +46,12 @@ class EmissionPolicyFilterTest {
         runTest {
             val result =
                 flowOf(
-                    ad(identifier = "device-1"),
-                    ad(identifier = "device-2"),
+                    found(ad(identifier = "device-1")),
+                    found(ad(identifier = "device-2")),
                     // duplicate, same data
-                    ad(identifier = "device-1"),
+                    found(ad(identifier = "device-1")),
                 ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges())
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .toList()
 
             assertEquals(2, result.size)
@@ -60,12 +64,13 @@ class EmissionPolicyFilterTest {
         runTest {
             val result =
                 flowOf(
-                    ad(identifier = "device-1", rssi = -60),
+                    found(ad(identifier = "device-1", rssi = -60)),
                     // within threshold (5)
-                    ad(identifier = "device-1", rssi = -62),
+                    found(ad(identifier = "device-1", rssi = -62)),
                     // exceeds threshold from -60
-                    ad(identifier = "device-1", rssi = -66),
+                    found(ad(identifier = "device-1", rssi = -66)),
                 ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges(rssiThreshold = 5))
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .toList()
 
             assertEquals(2, result.size)
@@ -78,12 +83,13 @@ class EmissionPolicyFilterTest {
         runTest {
             val result =
                 flowOf(
-                    ad(identifier = "device-1", name = "Sensor"),
+                    found(ad(identifier = "device-1", name = "Sensor")),
                     // same
-                    ad(identifier = "device-1", name = "Sensor"),
+                    found(ad(identifier = "device-1", name = "Sensor")),
                     // name changed
-                    ad(identifier = "device-1", name = "Sensor-v2"),
+                    found(ad(identifier = "device-1", name = "Sensor-v2")),
                 ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges())
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .toList()
 
             assertEquals(2, result.size)
@@ -99,30 +105,35 @@ class EmissionPolicyFilterTest {
 
             val result =
                 flowOf(
-                    Advertisement(
-                        identifier = Identifier("device-1"),
-                        name = null,
-                        rssi = -60,
-                        txPower = null,
-                        isConnectable = true,
-                        serviceUuids = listOf(uuid1),
-                        manufacturerData = emptyMap(),
-                        serviceData = emptyMap(),
-                        timestampNanos = 0L,
+                    found(
+                        Advertisement(
+                            identifier = Identifier("device-1"),
+                            name = null,
+                            rssi = -60,
+                            txPower = null,
+                            isConnectable = true,
+                            serviceUuids = listOf(uuid1),
+                            manufacturerData = emptyMap(),
+                            serviceData = emptyMap(),
+                            timestampNanos = 0L,
+                        ),
                     ),
-                    Advertisement(
-                        identifier = Identifier("device-1"),
-                        name = null,
-                        rssi = -60,
-                        txPower = null,
-                        isConnectable = true,
-                        // added a UUID
-                        serviceUuids = listOf(uuid1, uuid2),
-                        manufacturerData = emptyMap(),
-                        serviceData = emptyMap(),
-                        timestampNanos = 0L,
+                    found(
+                        Advertisement(
+                            identifier = Identifier("device-1"),
+                            name = null,
+                            rssi = -60,
+                            txPower = null,
+                            isConnectable = true,
+                            // added a UUID
+                            serviceUuids = listOf(uuid1, uuid2),
+                            manufacturerData = emptyMap(),
+                            serviceData = emptyMap(),
+                            timestampNanos = 0L,
+                        ),
                     ),
                 ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges())
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .toList()
 
             assertEquals(2, result.size)
@@ -133,16 +144,47 @@ class EmissionPolicyFilterTest {
         runTest {
             val result =
                 flowOf(
-                    ad(identifier = "device-1", rssi = -60),
+                    found(ad(identifier = "device-1", rssi = -60)),
                     // within threshold of 10
-                    ad(identifier = "device-1", rssi = -69),
+                    found(ad(identifier = "device-1", rssi = -69)),
                     // exceeds threshold from -60
-                    ad(identifier = "device-1", rssi = -71),
+                    found(ad(identifier = "device-1", rssi = -71)),
                 ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges(rssiThreshold = 10))
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .toList()
 
             assertEquals(2, result.size)
             assertEquals(-60, result[0].rssi)
             assertEquals(-71, result[1].rssi)
+        }
+
+    @Test
+    fun failedEventsPassThroughUnchanged() =
+        runTest {
+            val error = ScanFailedException(2)
+            val result =
+                flowOf(
+                    ScanEvent.Failed(error),
+                    found(ad()),
+                    ScanEvent.Failed(error),
+                ).applyEmissionPolicy(EmissionPolicy.FirstThenChanges())
+                    .toList()
+
+            assertEquals(3, result.size)
+            assertEquals(ScanEvent.Failed(error), result[0])
+            assertEquals(ScanEvent.Failed(error), result[2])
+        }
+
+    @Test
+    fun failedEventsPassThroughAllPolicy() =
+        runTest {
+            val error = ScanFailedException(1)
+            val result =
+                flowOf(ScanEvent.Failed(error))
+                    .applyEmissionPolicy(EmissionPolicy.All)
+                    .toList()
+
+            assertEquals(1, result.size)
+            assertEquals(ScanEvent.Failed(error), result.first())
         }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -1,0 +1,107 @@
+package com.atruedev.kmpble.scanner
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.testing.FakeScanner
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+
+class ScannerExtensionsTest {
+    private fun ad(
+        identifier: String = "a",
+        name: String? = "Sensor",
+    ) = Advertisement(
+        identifier = Identifier(identifier),
+        name = name,
+        rssi = -60,
+        txPower = null,
+        isConnectable = true,
+        serviceUuids = emptyList(),
+        manufacturerData = emptyMap(),
+        serviceData = emptyMap(),
+        timestampNanos = 0L,
+    )
+
+    @Test
+    fun firstOrNullMatchesPredicate() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                    advertisement { name("B") }
+                }
+            val result = scanner.firstOrNull(timeout = 500.milliseconds) { it.name == "B" }
+            assertNotNull(result)
+            assertEquals("B", result.name)
+        }
+
+    @Test
+    fun firstOrNullReturnsNullOnTimeout() =
+        runTest {
+            val scanner = FakeScanner {}
+            val result = scanner.firstOrNull(timeout = 10.milliseconds)
+            assertNull(result)
+        }
+
+    @Test
+    fun firstOrNullReturnsNullWhenNoMatch() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                }
+            val result = scanner.firstOrNull(timeout = 50.milliseconds) { it.name == "Z" }
+            assertNull(result)
+        }
+
+    @Test
+    fun firstOrThrowMatchesPredicate() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                    advertisement { name("Target") }
+                }
+            val result = scanner.firstOrThrow(timeout = 500.milliseconds) { it.name == "Target" }
+            assertEquals("Target", result.name)
+        }
+
+    @Test
+    fun firstOrThrowThrowsOnTimeout() =
+        runTest {
+            val scanner = FakeScanner {}
+            assertFailsWith<TimeoutCancellationException> {
+                scanner.firstOrThrow(timeout = 10.milliseconds)
+            }
+        }
+
+    @Test
+    fun firstOrThrowRethrowsScanFailed() =
+        runTest {
+            val scanner = FakeScanner {}
+            scanner.emitScanFailed(2)
+
+            val ex =
+                assertFailsWith<ScanFailedException> {
+                    scanner.firstOrThrow(timeout = 500.milliseconds)
+                }
+            assertEquals(2, ex.errorCode)
+        }
+
+    @Test
+    fun firstOrThrowThrowsTimeoutWhenNoMatch() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                }
+            assertFailsWith<TimeoutCancellationException> {
+                scanner.firstOrThrow(timeout = 50.milliseconds) { it.name == "Z" }
+            }
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
@@ -2,7 +2,9 @@ package com.atruedev.kmpble.testing
 
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.scanner.DataStatus
+import com.atruedev.kmpble.scanner.ScanEvent
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -32,7 +34,11 @@ class FakeScannerTest {
                     }
                 }
 
-            val results = scanner.advertisements.take(2).toList()
+            val results =
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
+                    .take(2)
+                    .toList()
             assertEquals(2, results.size)
             assertEquals("HeartSensor", results[0].name)
             assertEquals(-55, results[0].rssi)
@@ -57,7 +63,8 @@ class FakeScannerTest {
                 }
 
             val ad =
-                scanner.advertisements
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .take(1)
                     .toList()
                     .first()
@@ -78,7 +85,8 @@ class FakeScannerTest {
                 }
 
             val ad =
-                scanner.advertisements
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .take(1)
                     .toList()
                     .first()
@@ -100,7 +108,8 @@ class FakeScannerTest {
                 }
 
             val ad =
-                scanner.advertisements
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .take(1)
                     .toList()
                     .first()
@@ -115,7 +124,8 @@ class FakeScannerTest {
                     advertisement {}
                 }
             val ad =
-                scanner.advertisements
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .take(1)
                     .toList()
                     .first()
@@ -143,7 +153,8 @@ class FakeScannerTest {
                     }
                 }
             val ad =
-                scanner.advertisements
+                scanner.scanEvents
+                    .mapNotNull { (it as? ScanEvent.Found)?.advertisement }
                     .take(1)
                     .toList()
                     .first()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/scanner/IosScanner.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/scanner/IosScanner.kt
@@ -2,24 +2,18 @@ package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.adapter.BluetoothAdapterState
 import com.atruedev.kmpble.internal.CentralManagerProvider
-import com.atruedev.kmpble.scanner.internal.applyEmissionPolicy
-import com.atruedev.kmpble.scanner.internal.matchesFilters
+import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import platform.CoreBluetooth.CBCentralManagerScanOptionAllowDuplicatesKey
 import platform.CoreBluetooth.CBUUID
-import kotlin.time.TimeSource
 import kotlin.uuid.ExperimentalUuidApi
 
 public class IosScanner(
@@ -28,25 +22,7 @@ public class IosScanner(
     private val config: ScannerConfig = ScannerConfig().apply(configure)
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    private val sharedScanFlow: Flow<Advertisement> =
-        createRawScanFlow()
-            .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
-
-    override val advertisements: Flow<Advertisement> =
-        run {
-            var flow: Flow<Advertisement> =
-                sharedScanFlow
-                    .filter { it.matchesFilters(config.filterGroups) }
-                    .applyEmissionPolicy(config.emission)
-
-            val timeout = config.timeout
-            if (timeout != null) {
-                val mark = TimeSource.Monotonic.markNow()
-                flow = flow.takeWhile { mark.elapsedNow() < timeout }
-            }
-
-            flow
-        }
+    override val scanEvents: Flow<ScanEvent> = createRawScanFlow().toScanEvents(config, scope)
 
     override fun close() {
         scope.cancel()


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** `Scanner.advertisements: Flow<Advertisement>` → `Scanner.scanEvents: Flow<ScanEvent>`. Consumers must handle `ScanEvent.Found` and `ScanEvent.Failed` via exhaustive `when`.

Android BLE scan failures (`onScanFailed`) previously crashed the host app because the exception from `callbackFlow.close()` propagated into `shareIn`'s internal coroutine on a scope without `CoroutineExceptionHandler`, reaching the thread's uncaught handler. `SharedFlow` never delivers upstream errors to subscribers, so consumers had no way to observe or handle the failure.

## Changes

- **ScanEvent.kt** (new): sealed interface `Found(Advertisement) | Failed(ScanFailedException)`. `ScanFailedException` moved to commonMain with `public val errorCode`.
- **ScannerPipeline.kt** (new): shared `toScanEvents()` extension extracts the `.map/.catch/.shareIn/.transform/.applyEmissionPolicy/timeout` pipeline, eliminating ~80 duplicate lines between AndroidScanner and IosScanner.
- **Scanner.scanEvents**: `Flow<ScanEvent>` replaces `advertisements: Flow<Advertisement>`
- **AndroidScanner**: `.catch` before `shareIn` converts terminal exceptions into emitted error events
- **IosScanner**: same `.catch` pattern with defensive comment (CoreBluetooth doesn't report scan failures)
- **FakeScanner**: added `emitScanFailed(errorCode)` for testing error paths
- **ScannerExtensions**: added `firstOrThrow()` that surfaces scan errors as exceptions, letting callers distinguish timeout from hardware failure
- **EmissionPolicyFilter**: updated to `Flow<ScanEvent>`, only deduplicates `Found`, passes `Failed` through (with test coverage)
- **New tests**: `ScannerExtensionsTest` (7 tests), `EmissionPolicyFilterTest` (2 new tests for Failed pass-through)
- **Sample app**: scan errors surface in UI via `errorContainer` banner instead of `println`

## Consumer API

```kotlin
scanner.scanEvents.collect { event ->
    when (event) {
        is ScanEvent.Found -> handleAd(event.advertisement)
        is ScanEvent.Failed -> retryWithBackoff(event.error)
    }
}
```

Closes #194