### PR TITLE
feat: clear Android GATT cache before refreshServices()

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -295,6 +295,12 @@ public class AndroidPeripheral internal constructor(
     override suspend fun refreshServices(): List<DiscoveredService> {
         checkNotClosed()
         return withContext(peripheralContext.dispatcher) {
+            // Invalidate the Android GATT cache before discovery so the platform
+            // performs a fresh radio-level service discovery instead of returning
+            // cached data instantly. Best-effort: refreshDeviceCache() uses
+            // reflection on the hidden BluetoothGatt.refresh() method and may
+            // fail silently on some OEMs.
+            bridge.refreshDeviceCache()
             val deferred = slots.armDiscovery()
             if (!bridge.discoverServices()) {
                 slots.clearDiscovery()


### PR DESCRIPTION
## Summary

`refreshServices()` now calls `BluetoothGatt.refresh()` (via reflection) to invalidate the platform's GATT cache before triggering a new discovery.

## Problem

Android's `BluetoothGatt.discoverServices()` returns cached service data instantly on subsequent calls. Consumers calling `refreshServices()` to re-discover services (e.g. after bonding or reconnect) get stale data with no way to force a fresh radio-level discovery. The only workaround is a blind delay.

## Fix

Call `bridge.refreshDeviceCache()` before `discoverServices()` in `refreshServices()`. This invokes the hidden `BluetoothGatt.refresh()` method (already used internally for OEM quirks on OnePlus/Xiaomi) to clear the Android GATT cache.

The call is best-effort -- the hidden API is unavailable on some devices and fails silently. On devices that support it, the next `discoverServices()` performs a fresh radio-level discovery.

## Impact

- One-line change to `AndroidPeripheral.refreshServices()`
- No API change -- method signature unchanged
- `refreshDeviceCache()` is already battle-tested via `RefreshServicesOnBond` quirk
- Consumers can drop `delay()` workarounds after `refreshServices()`