### PR TITLE
fix(shared): rethrow CancellationException in catch blocks

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
@@ -46,7 +46,8 @@ internal class ReconnectionHandler(
                         try {
                             connectAction(opts)
                             attempt = 0
-                        } catch (_: Exception) {
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
                             // Will re-enter this collector on next Disconnected state
                         }
                     } else if (state is State.Connected.Ready) {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
@@ -25,7 +25,8 @@ internal object PeripheralRegistry {
             current[identifier]?.let {
                 try {
                     peripheral.close()
-                } catch (_: Exception) {
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
                 }
                 return it
             }


### PR DESCRIPTION
## Problem

CancellationException extends Exception in Kotlin. Generic `catch(Exception)` blocks silently swallow coroutine cancellation signals, breaking structured concurrency guarantees.

Two locations affected:
- `ReconnectionHandler.kt:49` — `connectAction()` called inside coroutine scope
- `PeripheralRegistry.kt:28` — `close()` on duplicate peripheral during CAS retry

## Approach

Add explicit `if (e is CancellationException) throw e` before the catch body. Uses qualified name `kotlinx.coroutines.CancellationException` to avoid adding coroutine imports where not already present.

## Trade-offs

- PeripheralRegistry may not always be called from coroutine context, but the check is defensive and zero-cost when CancellationException is not thrown.
- Using qualified name instead of import keeps the file's dependency surface explicit.

Closes #199