### PR TITLE
fix(shared): use import for CancellationException instead of qualified name

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/internal/ReconnectionHandler.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.connection.internal
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -47,7 +48,7 @@ internal class ReconnectionHandler(
                             connectAction(opts)
                             attempt = 0
                         } catch (e: Exception) {
-                            if (e is kotlinx.coroutines.CancellationException) throw e
+                            if (e is CancellationException) throw e
                             // Will re-enter this collector on next Disconnected state
                         }
                     } else if (state is State.Connected.Ready) {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
@@ -2,6 +2,7 @@ package com.atruedev.kmpble.peripheral.internal
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CancellationException
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -26,7 +27,7 @@ internal object PeripheralRegistry {
                 try {
                     peripheral.close()
                 } catch (e: Exception) {
-                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    if (e is CancellationException) throw e
                 }
                 return it
             }


### PR DESCRIPTION
## Problem

PR #204 used fully-qualified name `kotlinx.coroutines.CancellationException` in catch blocks. Kotlin convention is to import types properly and use the short name. Qualified names should only be used to resolve ambiguity between identically-named imports.

## Approach

Add `import kotlinx.coroutines.CancellationException` in both files and use the short name `CancellationException` in catch blocks.

## Files changed
- `ReconnectionHandler.kt`: add import, use short name
- `PeripheralRegistry.kt`: add import, use short name

Ref: PR #204