### PR TITLE
fix(shared): require serial dispatcher for ObservationManager

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -96,7 +96,7 @@ public class AndroidPeripheral internal constructor(
     private val bridge = AndroidGattBridge(device, context)
 
     private val pendingOps = PendingOperations()
-    private val observationManager = ObservationManager()
+    private val observationManager = ObservationManager(peripheralContext.dispatcher)
     private val slots = LifecycleSlots()
 
     private val nativeCharMap = mutableMapOf<Characteristic, BluetoothGattCharacteristic>()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationManager.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationManager.kt
@@ -2,7 +2,6 @@ package com.atruedev.kmpble.gatt.internal
 
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -71,7 +70,7 @@ internal data class TrackedObservation(
  */
 @OptIn(ExperimentalUuidApi::class)
 internal class ObservationManager(
-    dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
+    dispatcher: CoroutineDispatcher,
 ) {
     /**
      * Optional callback invoked when the set of active observations changes.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -23,6 +23,7 @@ import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.L2capChannel
+import kotlinx.coroutines.Dispatchers
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
@@ -51,7 +52,7 @@ public class FakePeripheral internal constructor(
     private val onL2capHandler: L2capHandler?,
 ) : Peripheral {
     private val context = PeripheralContext(identifier)
-    private val observationManager = ObservationManager()
+    private val observationManager = ObservationManager(Dispatchers.Default.limitedParallelism(1))
     private var closed = false
     private val cccdWritesState = MutableStateFlow(emptyList<CccdWrite>())
 

--- a/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceCallbackTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceCallbackTest.kt
@@ -4,6 +4,7 @@ import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.internal.ObservationKey
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PersistedObservation
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `callback fires on subscribe with correct keys and backpressure`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             val received = mutableListOf<Set<PersistedObservation>>()
             manager.onObservationsChanged = { obs -> received.add(obs) }
 
@@ -41,7 +42,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `callback preserves buffer backpressure strategy`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             val received = mutableListOf<Set<PersistedObservation>>()
             manager.onObservationsChanged = { obs -> received.add(obs) }
 
@@ -55,7 +56,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `callback fires on unsubscribe`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             val received = mutableListOf<Set<PersistedObservation>>()
 
             manager.subscribe(serviceUuid, charUuid, BackpressureStrategy.Latest)
@@ -70,7 +71,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `callback includes all active observations`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             val received = mutableListOf<Set<PersistedObservation>>()
             manager.onObservationsChanged = { obs -> received.add(obs) }
 
@@ -90,7 +91,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `no callback when callback is null`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             // Should not throw - callback is null by default
             manager.subscribe(serviceUuid, charUuid, BackpressureStrategy.Latest)
             manager.unsubscribe(serviceUuid, charUuid)
@@ -99,7 +100,7 @@ class ObservationPersistenceCallbackTest {
     @Test
     fun `no callback when key set unchanged on duplicate subscribe`() =
         runTest {
-            val manager = ObservationManager()
+            val manager = ObservationManager(Dispatchers.Unconfined)
             manager.subscribe(serviceUuid, charUuid, BackpressureStrategy.Latest)
 
             val received = mutableListOf<Set<PersistedObservation>>()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -87,7 +87,7 @@ public class IosPeripheral(
     private val centralDelegate = CentralManagerProvider.scanDelegate
 
     private val pendingOps = PendingOperations()
-    private val observationManager = ObservationManager()
+    private val observationManager = ObservationManager(peripheralContext.dispatcher)
     private val slots = LifecycleSlots()
 
     private val nativeCharMap = mutableMapOf<Characteristic, CBCharacteristic>()


### PR DESCRIPTION
## Problem

ObservationManager defaulted to Dispatchers.Unconfined, relying on the caller to provide external serialization. AndroidPeripheral and IosPeripheral never passed their limitedParallelism(1) dispatcher, leaving mutable state unprotected against concurrent access.

## Approach

- Make dispatcher parameter required (remove Dispatchers.Unconfined default)
- Pass peripheralContext.dispatcher from AndroidPeripheral and IosPeripheral
- Pass Dispatchers.Default.limitedParallelism(1) from FakePeripheral
- Pass Dispatchers.Unconfined from tests (compatible with runTest)
- Remove unused Dispatchers import from ObservationManager

## Files

- ObservationManager.kt: remove default dispatcher
- AndroidPeripheral.kt: pass peripheralContext.dispatcher  
- IosPeripheral.kt: pass peripheralContext.dispatcher
- FakePeripheral.kt: pass limitedParallelism(1) dispatcher
- ObservationPersistenceCallbackTest.kt: pass Unconfined dispatcher

Closes #KMP-300