### PR TITLE
refactor(testing): decompose FakePeripheral into FakeConnectionSimulator + FakeGattResponder

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -26,6 +26,7 @@ import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
 import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.error.StaleGattHandle
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.Descriptor
@@ -531,12 +532,10 @@ public class AndroidPeripheral internal constructor(
 
     private fun requireNativeChar(c: Characteristic): BluetoothGattCharacteristic =
         nativeCharMap[c]
-            ?: throw IllegalArgumentException(
-                "Characteristic not found in current GATT profile. Re-acquire from services after connect.",
-            )
+            ?: throw BleException(StaleGattHandle("characteristic", c.uuid.toString()))
 
     private fun requireNativeDesc(d: Descriptor): BluetoothGattDescriptor =
-        nativeDescMap[d] ?: throw IllegalArgumentException("Descriptor not found in current GATT profile.")
+        nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
 
     override suspend fun read(characteristic: Characteristic): ByteArray {
         checkNotClosed()
@@ -824,7 +823,7 @@ public class AndroidPeripheral internal constructor(
                 throw e
             } catch (e: CancellationException) {
                 socket.closeQuietly()
-                throw L2capException.OpenFailed(psm, "Connection timed out", e)
+                throw e
             } catch (e: IOException) {
                 socket.closeQuietly()
                 throw L2capException.OpenFailed(psm, e.message ?: "Unknown error", e)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
@@ -68,6 +68,12 @@ public data class MtuExceeded(
     val maximum: Int,
 ) : OperationConstraintError
 
+/** A GATT characteristic or descriptor handle is stale — the peer disconnected or services were invalidated. */
+public data class StaleGattHandle(
+    val handleType: String,
+    val uuid: String,
+) : GattOperationError
+
 /** A catch-all for operation failures that don't fit a more specific category. */
 public data class OperationFailed(
     val message: String,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeConnectionSimulator.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeConnectionSimulator.kt
@@ -1,0 +1,170 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.error.BleError
+import com.atruedev.kmpble.error.ConnectionLost
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.peripheral.internal.PeripheralContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+internal class FakeConnectionSimulator(
+    private val context: PeripheralContext,
+    private val observationManager: ObservationManager,
+    private var fakeServices: List<DiscoveredService>,
+    private val cccdWritesState: MutableStateFlow<List<FakePeripheral.CccdWrite>>,
+    private val closedFlag: () -> Boolean,
+) {
+    /** Drives the state machine with a [ConnectionEvent]. */
+    internal suspend fun simulateEvent(event: ConnectionEvent): State {
+        checkNotClosed()
+        return context.processEvent(event)
+    }
+
+    /**
+     * Drives the state machine from [State.Connected.Ready] to
+     * [State.Connected.BondingChange].
+     */
+    public suspend fun simulateBondStateChange() {
+        checkNotClosed()
+        context.processEvent(ConnectionEvent.BondStateChanged)
+    }
+
+    /**
+     * Drives the state machine from [State.Connected.Ready] to
+     * [State.Connected.ServiceChanged]. Services remain populated (now stale)
+     * until rediscovery completes.
+     */
+    public suspend fun simulateServiceChangedIndication() {
+        checkNotClosed()
+        context.processEvent(ConnectionEvent.ServiceChangedIndication)
+    }
+
+    /**
+     * Drives the state machine from [State.Connected.ServiceChanged] back to
+     * [State.Connected.Ready].
+     */
+    public suspend fun simulateRediscoverySucceeded() {
+        checkNotClosed()
+        context.processEvent(ConnectionEvent.RediscoverySucceeded)
+    }
+
+    /**
+     * Simulate a disconnect event. This will emit [com.atruedev.kmpble.gatt.Observation.Disconnected]
+     * to all active observations but NOT complete them - they persist for reconnection.
+     */
+    public suspend fun simulateDisconnect(error: BleError = ConnectionLost("Simulated disconnect")) {
+        checkNotClosed()
+        context.processEvent(ConnectionEvent.ConnectionLost(error))
+        observationManager.onDisconnect()
+    }
+
+    /**
+     * Simulate a reconnection. This will:
+     * 1. Transition through connecting states
+     * 2. Re-discover services
+     * 3. Re-enable CCCD for all active observations
+     */
+    public suspend fun simulateReconnect(newServices: List<DiscoveredService>? = null) {
+        checkNotClosed()
+        if (newServices != null) {
+            fakeServices = newServices
+        }
+
+        context.processEvent(ConnectionEvent.ConnectRequested)
+        context.gattQueue.start()
+        context.processEvent(ConnectionEvent.LinkEstablished)
+        context.processEvent(ConnectionEvent.ServicesDiscovered)
+        context.updateServices(fakeServices)
+
+        resubscribeObservations()
+
+        context.processEvent(ConnectionEvent.ConfigurationComplete)
+    }
+
+    private suspend fun resubscribeObservations() {
+        val toResubscribe = observationManager.getObservationsToResubscribe()
+        for (key in toResubscribe) {
+            val char = findCharacteristic(key.serviceUuid, key.charUuid)
+            if (char != null) {
+                recordCccdWrite(key.serviceUuid, key.charUuid, enabled = true)
+            } else {
+                observationManager.completeObservation(key)
+            }
+        }
+    }
+
+    private fun findCharacteristic(
+        serviceUuid: Uuid,
+        characteristicUuid: Uuid,
+    ): com.atruedev.kmpble.gatt.Characteristic? =
+        context.services.value
+            ?.firstOrNull { it.uuid == serviceUuid }
+            ?.characteristics
+            ?.firstOrNull { it.uuid == characteristicUuid }
+
+    /**
+     * Simulate permanent disconnect (max reconnection attempts exhausted).
+     * This will complete all observation flows.
+     */
+    public suspend fun simulatePermanentDisconnect() {
+        checkNotClosed()
+        context.processEvent(
+            ConnectionEvent.ConnectionLost(ConnectionLost("Max attempts exhausted"))
+        )
+        observationManager.onPermanentDisconnect()
+    }
+
+    /** Simulate a characteristic notification by emitting [value] to active observers. */
+    public suspend fun emitObservationValue(
+        serviceUuid: Uuid,
+        charUuid: Uuid,
+        value: ByteArray,
+    ) {
+        checkNotClosed()
+        observationManager.emitValue(serviceUuid, charUuid, value)
+    }
+
+    /** Convenience overload accepting short or full UUID strings. */
+    public suspend fun emitObservationValue(
+        serviceUuid: String,
+        charUuid: String,
+        value: ByteArray,
+    ) {
+        emitObservationValue(
+            com.atruedev.kmpble.scanner.uuidFrom(serviceUuid),
+            com.atruedev.kmpble.scanner.uuidFrom(charUuid),
+            value,
+        )
+    }
+
+    /** Returns `true` if there are active collectors for the given characteristic. */
+    public suspend fun hasCollectors(
+        serviceUuid: Uuid,
+        charUuid: Uuid,
+    ): Boolean = observationManager.hasCollectors(serviceUuid, charUuid)
+
+    private fun recordCccdWrite(
+        serviceUuid: Uuid,
+        charUuid: Uuid,
+        enabled: Boolean,
+    ) {
+        cccdWritesState.update { it + FakePeripheral.CccdWrite(serviceUuid, charUuid, enabled) }
+    }
+
+    private fun checkNotClosed() {
+        check(!closedFlag()) { "Peripheral is closed" }
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
@@ -1,0 +1,248 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.error.BleError
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.gatt.BackpressureStrategy
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.Descriptor
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.Observation
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.gatt.internal.ObservationEvent
+import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.gatt.internal.applyBackpressure
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.l2cap.L2capException
+import com.atruedev.kmpble.peripheral.PhyResult
+import com.atruedev.kmpble.peripheral.internal.PeripheralContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlin.time.Duration
+import kotlin.uuid.Uuid
+
+internal class FakeGattResponder(
+    private val context: PeripheralContext,
+    private val observationManager: ObservationManager,
+    private val characteristicConfigs: List<FakeCharacteristicConfig>,
+    private val onL2capHandler: L2capHandler?,
+    private val cccdWritesState: MutableStateFlow<List<FakePeripheral.CccdWrite>>,
+    private val closedFlag: () -> Boolean,
+) {
+    private fun checkNotClosed() {
+        check(!closedFlag()) { "Peripheral is closed" }
+    }
+
+    private fun checkConnected() {
+        check(context.state.value is State.Connected) {
+            "Peripheral is not connected (state: ${context.state.value})"
+        }
+    }
+
+    private suspend fun applyDelay(config: FakeCharacteristicConfig?) {
+        val duration = config?.respondAfterDuration ?: return
+        if (duration > Duration.ZERO) {
+            delay(duration)
+        }
+    }
+
+    private fun checkFailWith(config: FakeCharacteristicConfig?) {
+        val error = config?.failWithError ?: return
+        throw BleException(error)
+    }
+
+    private fun <T> failWithFlow(config: FakeCharacteristicConfig?): Flow<T>? {
+        val error = config?.failWithError ?: return null
+        return flow { throw BleException(error) }
+    }
+
+    private fun findConfig(characteristic: Characteristic): FakeCharacteristicConfig? =
+        characteristicConfigs.firstOrNull {
+            it.characteristic.serviceUuid == characteristic.serviceUuid &&
+                it.characteristic.uuid == characteristic.uuid
+        }
+
+    private fun recordCccdWrite(
+        serviceUuid: Uuid,
+        charUuid: Uuid,
+        enabled: Boolean,
+    ) {
+        cccdWritesState.update { it + FakePeripheral.CccdWrite(serviceUuid, charUuid, enabled) }
+    }
+
+    suspend fun read(characteristic: Characteristic): ByteArray {
+        checkNotClosed()
+        checkConnected()
+        val config = findConfig(characteristic)
+        applyDelay(config)
+        checkFailWith(config)
+        val handler = config?.readHandler
+            ?: throw UnsupportedOperationException("No onRead handler for ${characteristic.uuid}")
+        return handler()
+    }
+
+    suspend fun write(
+        characteristic: Characteristic,
+        data: ByteArray,
+        writeType: WriteType,
+    ) {
+        checkNotClosed()
+        checkConnected()
+        val config = findConfig(characteristic)
+        applyDelay(config)
+        checkFailWith(config)
+        val handler = config?.writeHandler
+        if (handler != null) {
+            handler(data, writeType)
+        } else {
+            val hasWriteProperty =
+                characteristic.properties.write ||
+                    characteristic.properties.writeWithoutResponse ||
+                    characteristic.properties.signedWrite
+            if (!hasWriteProperty) {
+                throw BleException(
+                    GattError("write", GattStatus.WriteNotPermitted),
+                )
+            }
+        }
+    }
+
+    fun observe(
+        characteristic: Characteristic,
+        backpressure: BackpressureStrategy,
+    ): Flow<Observation> {
+        checkNotClosed()
+        val config = findConfig(characteristic)
+        failWithFlow<Observation>(config)?.let { return it }
+        val handler = config?.observeHandler
+        if (handler != null) {
+            val flow: Flow<ByteArray> = handler()
+            return flow
+                .map { Observation.Value(it) }
+                .applyBackpressure(backpressure)
+        }
+        return observeInternal(characteristic, backpressure) { event ->
+            when (event) {
+                is ObservationEvent.Value -> emit(Observation.Value(event.data))
+                is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
+                is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
+            }
+        }
+    }
+
+    fun observeValues(
+        characteristic: Characteristic,
+        backpressure: BackpressureStrategy,
+    ): Flow<ByteArray> {
+        checkNotClosed()
+        val config = findConfig(characteristic)
+        failWithFlow<ByteArray>(config)?.let { return it }
+        val handler = config?.observeHandler
+        return if (handler != null) {
+            handler().applyBackpressure(backpressure)
+        } else {
+            observeInternal(characteristic, backpressure) { event ->
+                when (event) {
+                    is ObservationEvent.Value -> emit(event.data)
+                    // Transparent reconnection - ObservationManager re-subscribes on reconnect
+                    is ObservationEvent.Disconnected -> Unit
+                    is ObservationEvent.PermanentlyDisconnected -> Unit
+                }
+            }
+        }
+    }
+
+    private fun <T> observeInternal(
+        characteristic: Characteristic,
+        backpressure: BackpressureStrategy,
+        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
+    ): Flow<T> {
+        val serviceUuid = characteristic.serviceUuid
+        val charUuid = characteristic.uuid
+
+        return flow {
+            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
+            eventFlow.collect { event -> mapper(event) }
+        }.onStart {
+            if (context.state.value is State.Connected.Ready) {
+                recordCccdWrite(serviceUuid, charUuid, enabled = true)
+            }
+        }.applyBackpressure(backpressure)
+            .onCompletion {
+                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
+                if (wasLastCollector && context.state.value is State.Connected) {
+                    recordCccdWrite(serviceUuid, charUuid, enabled = false)
+                }
+            }
+    }
+
+    suspend fun readDescriptor(descriptor: Descriptor): ByteArray {
+        checkNotClosed()
+        checkConnected()
+        return byteArrayOf()
+    }
+
+    suspend fun writeDescriptor(
+        descriptor: Descriptor,
+        data: ByteArray,
+    ) {
+        checkNotClosed()
+        checkConnected()
+    }
+
+    suspend fun openL2capChannel(
+        psm: Int,
+        secure: Boolean,
+        mtu: Int?,
+    ): L2capChannel {
+        checkNotClosed()
+        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
+        if (context.state.value !is State.Connected) {
+            throw L2capException.NotConnected("Peripheral is not connected (state: ${context.state.value})")
+        }
+        val handler = onL2capHandler
+            ?: throw L2capException.NotSupported("No onOpenL2capChannel handler configured")
+        return handler(psm, mtu)
+    }
+
+    suspend fun readRssi(): Int {
+        checkNotClosed()
+        checkConnected()
+        return -50
+    }
+
+    suspend fun requestMtu(mtu: Int): Int {
+        checkNotClosed()
+        checkConnected()
+        context.updateMtu(mtu)
+        return mtu
+    }
+
+    suspend fun requestConnectionPriority(
+        priority: ConnectionPriority,
+    ): Boolean {
+        checkNotClosed()
+        checkConnected()
+        return true
+    }
+
+    suspend fun setPreferredPhy(
+        tx: Phy,
+        rx: Phy,
+    ): PhyResult? {
+        checkNotClosed()
+        checkConnected()
+        return PhyResult(tx, rx)
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -23,11 +23,11 @@ import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
 import com.atruedev.kmpble.l2cap.L2capChannel
-import kotlinx.coroutines.Dispatchers
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -54,18 +54,35 @@ public class FakePeripheral internal constructor(
     private val context = PeripheralContext(identifier)
     private val observationManager = ObservationManager(Dispatchers.Default.limitedParallelism(1))
     private var closed = false
-    private val cccdWritesState = MutableStateFlow(emptyList<CccdWrite>())
+    private val cccdWritesState = MutableStateFlow<List<CccdWrite>>(emptyList())
 
-    override val state: StateFlow<State> get() = context.state
-    override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = context.bondState
-    override val services: StateFlow<List<DiscoveredService>?> get() = context.services
-    override val maximumWriteValueLength: StateFlow<Int> get() = context.maximumWriteValueLength
+    private val connectionSimulator = FakeConnectionSimulator(
+        context = context,
+        observationManager = observationManager,
+        fakeServices = fakeServices,
+        cccdWritesState = cccdWritesState,
+        closedFlag = { closed },
+    )
+
+    private val gattResponder = FakeGattResponder(
+        context = context,
+        observationManager = observationManager,
+        characteristicConfigs = characteristicConfigs,
+        onL2capHandler = onL2capHandler,
+        cccdWritesState = cccdWritesState,
+        closedFlag = { closed },
+    )
 
     public data class CccdWrite(
         val serviceUuid: Uuid,
         val charUuid: Uuid,
         val enabled: Boolean,
     )
+
+    override val state: StateFlow<State> get() = context.state
+    override val bondState: StateFlow<com.atruedev.kmpble.bonding.BondState> get() = context.bondState
+    override val services: StateFlow<List<DiscoveredService>?> get() = context.services
+    override val maximumWriteValueLength: StateFlow<Int> get() = context.maximumWriteValueLength
 
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
@@ -88,8 +105,7 @@ public class FakePeripheral internal constructor(
     }
 
     internal suspend fun simulateEvent(event: ConnectionEvent): State {
-        checkNotClosed()
-        return context.processEvent(event)
+        return connectionSimulator.simulateEvent(event)
     }
 
     /**
@@ -97,8 +113,7 @@ public class FakePeripheral internal constructor(
      * [State.Connected.BondingChange].
      */
     public suspend fun simulateBondStateChange() {
-        checkNotClosed()
-        context.processEvent(ConnectionEvent.BondStateChanged)
+        connectionSimulator.simulateBondStateChange()
     }
 
     /**
@@ -107,8 +122,7 @@ public class FakePeripheral internal constructor(
      * until rediscovery completes.
      */
     public suspend fun simulateServiceChangedIndication() {
-        checkNotClosed()
-        context.processEvent(ConnectionEvent.ServiceChangedIndication)
+        connectionSimulator.simulateServiceChangedIndication()
     }
 
     /**
@@ -116,8 +130,7 @@ public class FakePeripheral internal constructor(
      * [State.Connected.Ready].
      */
     public suspend fun simulateRediscoverySucceeded() {
-        checkNotClosed()
-        context.processEvent(ConnectionEvent.RediscoverySucceeded)
+        connectionSimulator.simulateRediscoverySucceeded()
     }
 
     override suspend fun disconnect() {
@@ -164,228 +177,63 @@ public class FakePeripheral internal constructor(
         return char.descriptors.firstOrNull { it.uuid == descriptorUuid }
     }
 
-    // --- GATT Operations ---
+    // --- GATT Operations (delegated to FakeGattResponder) ---
 
-    override suspend fun read(characteristic: Characteristic): ByteArray {
-        checkNotClosed()
-        checkConnected()
-        val config = findConfig(characteristic)
-        applyDelay(config)
-        checkFailWith(config)
-        val handler =
-            config?.readHandler
-                ?: throw UnsupportedOperationException("No onRead handler for ${characteristic.uuid}")
-        return handler()
-    }
+    override suspend fun read(characteristic: Characteristic): ByteArray =
+        gattResponder.read(characteristic)
 
     override suspend fun write(
         characteristic: Characteristic,
         data: ByteArray,
         writeType: WriteType,
-    ) {
-        checkNotClosed()
-        checkConnected()
-        val config = findConfig(characteristic)
-        applyDelay(config)
-        checkFailWith(config)
-        val handler = config?.writeHandler
-        if (handler != null) {
-            handler(data, writeType)
-        } else {
-            val hasWriteProperty =
-                characteristic.properties.write ||
-                    characteristic.properties.writeWithoutResponse ||
-                    characteristic.properties.signedWrite
-            if (!hasWriteProperty) {
-                throw BleException(
-                    GattError("write", GattStatus.WriteNotPermitted),
-                )
-            }
-        }
-    }
+    ): Unit = gattResponder.write(characteristic, data, writeType)
 
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> {
-        checkNotClosed()
-        val config = findConfig(characteristic)
-        failWithFlow<Observation>(config)?.let { return it }
-        val handler = config?.observeHandler
-        return if (handler != null) {
-            handler()
-                .map<ByteArray, Observation> { Observation.Value(it) }
-                .applyBackpressure(backpressure)
-        } else {
-            observeInternal(characteristic, backpressure) { event ->
-                when (event) {
-                    is ObservationEvent.Value -> emit(Observation.Value(event.data))
-                    is ObservationEvent.Disconnected -> emit(Observation.Disconnected)
-                    is ObservationEvent.PermanentlyDisconnected -> emit(Observation.Disconnected)
-                }
-            }
-        }
-    }
+    ): Flow<Observation> = gattResponder.observe(characteristic, backpressure)
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> {
-        checkNotClosed()
-        val config = findConfig(characteristic)
-        failWithFlow<ByteArray>(config)?.let { return it }
-        val handler = config?.observeHandler
-        return if (handler != null) {
-            handler().applyBackpressure(backpressure)
-        } else {
-            observeInternal(characteristic, backpressure) { event ->
-                when (event) {
-                    is ObservationEvent.Value -> emit(event.data)
-                    // Transparent reconnection - ObservationManager re-subscribes on reconnect
-                    is ObservationEvent.Disconnected -> Unit
-                    is ObservationEvent.PermanentlyDisconnected -> Unit
-                }
-            }
-        }
-    }
+    ): Flow<ByteArray> = gattResponder.observeValues(characteristic, backpressure)
 
-    private fun <T> observeInternal(
-        characteristic: Characteristic,
-        backpressure: BackpressureStrategy,
-        mapper: suspend FlowCollector<T>.(ObservationEvent) -> Unit,
-    ): Flow<T> {
-        val serviceUuid = characteristic.serviceUuid
-        val charUuid = characteristic.uuid
-
-        return flow {
-            val eventFlow = observationManager.subscribe(serviceUuid, charUuid, backpressure)
-            eventFlow.collect { event -> mapper(event) }
-        }.onStart {
-            if (context.state.value is State.Connected.Ready) {
-                recordCccdWrite(serviceUuid, charUuid, enabled = true)
-            }
-        }.applyBackpressure(backpressure)
-            .onCompletion {
-                val wasLastCollector = observationManager.unsubscribe(serviceUuid, charUuid)
-                if (wasLastCollector && context.state.value is State.Connected) {
-                    recordCccdWrite(serviceUuid, charUuid, enabled = false)
-                }
-            }
-    }
-
-    override suspend fun readDescriptor(descriptor: Descriptor): ByteArray {
-        checkNotClosed()
-        checkConnected()
-        return byteArrayOf()
-    }
+    override suspend fun readDescriptor(descriptor: Descriptor): ByteArray =
+        gattResponder.readDescriptor(descriptor)
 
     override suspend fun writeDescriptor(
         descriptor: Descriptor,
         data: ByteArray,
-    ) {
-        checkNotClosed()
-        checkConnected()
-    }
+    ): Unit = gattResponder.writeDescriptor(descriptor, data)
 
     override suspend fun openL2capChannel(
         psm: Int,
         secure: Boolean,
         mtu: Int?,
-    ): L2capChannel {
-        checkNotClosed()
-        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
-        if (context.state.value !is State.Connected) {
-            throw L2capException.NotConnected("Peripheral is not connected (state: ${context.state.value})")
-        }
-        val handler =
-            onL2capHandler
-                ?: throw L2capException.NotSupported("No onOpenL2capChannel handler configured")
-        return handler(psm, mtu)
-    }
+    ): L2capChannel = gattResponder.openL2capChannel(psm, secure, mtu)
 
-    override suspend fun readRssi(): Int {
-        checkNotClosed()
-        checkConnected()
-        return -50
-    }
+    override suspend fun readRssi(): Int = gattResponder.readRssi()
 
-    override suspend fun requestMtu(mtu: Int): Int {
-        checkNotClosed()
-        checkConnected()
-        context.updateMtu(mtu)
-        return mtu
-    }
+    override suspend fun requestMtu(mtu: Int): Int = gattResponder.requestMtu(mtu)
 
     @com.atruedev.kmpble.ExperimentalBleApi
-    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
-        checkNotClosed()
-        checkConnected()
-        return true
-    }
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean =
+        gattResponder.requestConnectionPriority(priority)
 
     @com.atruedev.kmpble.ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
-    ): PhyResult? {
-        checkNotClosed()
-        checkConnected()
-        return PhyResult(tx, rx)
-    }
+    ): PhyResult? = gattResponder.setPreferredPhy(tx, rx)
 
-    // --- Internal ---
-
-    private suspend fun applyDelay(config: FakeCharacteristicConfig?) {
-        val duration = config?.respondAfterDuration ?: return
-        if (duration > Duration.ZERO) {
-            delay(duration)
-        }
-    }
-
-    private fun checkFailWith(config: FakeCharacteristicConfig?) {
-        val error = config?.failWithError ?: return
-        throw BleException(error)
-    }
-
-    private fun <T> failWithFlow(config: FakeCharacteristicConfig?): Flow<T>? {
-        val error = config?.failWithError ?: return null
-        return flow { throw BleException(error) }
-    }
-
-    private fun findConfig(characteristic: Characteristic): FakeCharacteristicConfig? =
-        characteristicConfigs.firstOrNull {
-            it.characteristic.serviceUuid == characteristic.serviceUuid &&
-                it.characteristic.uuid == characteristic.uuid
-        }
-
-    private fun recordCccdWrite(
-        serviceUuid: Uuid,
-        charUuid: Uuid,
-        enabled: Boolean,
-    ) {
-        cccdWritesState.update { it + CccdWrite(serviceUuid, charUuid, enabled) }
-    }
-
-    private fun checkNotClosed() {
-        check(!closed) { "Peripheral is closed" }
-    }
-
-    private fun checkConnected() {
-        check(context.state.value is State.Connected) {
-            "Peripheral is not connected (state: ${context.state.value})"
-        }
-    }
-
-    // --- Test Simulation Methods ---
+    // --- Test Simulation Methods (delegated to FakeConnectionSimulator) ---
 
     /**
      * Simulate a disconnect event. This will emit [Observation.Disconnected] to all active
      * observations but NOT complete them - they persist for reconnection.
      */
     public suspend fun simulateDisconnect(error: BleError = ConnectionLost("Simulated disconnect")) {
-        checkNotClosed()
-        context.processEvent(ConnectionEvent.ConnectionLost(error))
-        observationManager.onDisconnect()
+        connectionSimulator.simulateDisconnect(error)
     }
 
     /**
@@ -395,32 +243,7 @@ public class FakePeripheral internal constructor(
      * 3. Re-enable CCCD for all active observations
      */
     public suspend fun simulateReconnect(newServices: List<DiscoveredService>? = null) {
-        checkNotClosed()
-        if (newServices != null) {
-            fakeServices = newServices
-        }
-
-        context.processEvent(ConnectionEvent.ConnectRequested)
-        context.gattQueue.start()
-        context.processEvent(ConnectionEvent.LinkEstablished)
-        context.processEvent(ConnectionEvent.ServicesDiscovered)
-        context.updateServices(fakeServices)
-
-        resubscribeObservations()
-
-        context.processEvent(ConnectionEvent.ConfigurationComplete)
-    }
-
-    private suspend fun resubscribeObservations() {
-        val toResubscribe = observationManager.getObservationsToResubscribe()
-        for (key in toResubscribe) {
-            val char = findCharacteristic(key.serviceUuid, key.charUuid)
-            if (char != null) {
-                recordCccdWrite(key.serviceUuid, key.charUuid, enabled = true)
-            } else {
-                observationManager.completeObservation(key)
-            }
-        }
+        connectionSimulator.simulateReconnect(newServices)
     }
 
     /**
@@ -428,9 +251,7 @@ public class FakePeripheral internal constructor(
      * This will complete all observation flows.
      */
     public suspend fun simulatePermanentDisconnect() {
-        checkNotClosed()
-        context.processEvent(ConnectionEvent.ConnectionLost(ConnectionLost("Max attempts exhausted")))
-        observationManager.onPermanentDisconnect()
+        connectionSimulator.simulatePermanentDisconnect()
     }
 
     /** Simulate a characteristic notification by emitting [value] to active observers. */
@@ -439,8 +260,7 @@ public class FakePeripheral internal constructor(
         charUuid: Uuid,
         value: ByteArray,
     ) {
-        checkNotClosed()
-        observationManager.emitValue(serviceUuid, charUuid, value)
+        connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
     }
 
     /** Convenience overload accepting short or full UUID strings. */
@@ -449,13 +269,7 @@ public class FakePeripheral internal constructor(
         charUuid: String,
         value: ByteArray,
     ) {
-        emitObservationValue(
-            com.atruedev.kmpble.scanner
-                .uuidFrom(serviceUuid),
-            com.atruedev.kmpble.scanner
-                .uuidFrom(charUuid),
-            value,
-        )
+        connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
     }
 
     /** Returns all CCCD writes recorded during observation setup/teardown. */
@@ -470,5 +284,9 @@ public class FakePeripheral internal constructor(
     public suspend fun hasCollectors(
         serviceUuid: Uuid,
         charUuid: Uuid,
-    ): Boolean = observationManager.hasCollectors(serviceUuid, charUuid)
+    ): Boolean = connectionSimulator.hasCollectors(serviceUuid, charUuid)
+
+    private fun checkNotClosed() {
+        check(!closed) { "Peripheral is closed" }
+    }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/error/BleErrorTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/error/BleErrorTest.kt
@@ -1,0 +1,31 @@
+package com.atruedev.kmpble.error
+
+import com.atruedev.kmpble.error.StaleGattHandle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BleErrorTest {
+
+    @Test
+    fun staleGattHandleCanBeCreatedAndThrown() {
+        val error = StaleGattHandle("characteristic", "00002a19-0000-1000-8000-00805f9b34fb")
+        assertEquals("characteristic", error.handleType)
+        assertEquals("00002a19-0000-1000-8000-00805f9b34fb", error.uuid)
+    }
+
+    @Test
+    fun staleGattHandleWrappedInBleException() {
+        val ex = assertFailsWith<BleException> {
+            throw BleException(StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"))
+        }
+        assertEquals(StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"), ex.error)
+    }
+
+    @Test
+    fun staleGattHandleImplementsGattOperationError() {
+        val error = StaleGattHandle("characteristic", "00002a19-0000-1000-8000-00805f9b34fb")
+        // StaleGattHandle implements GattOperationError via sealed interface hierarchy
+        assertEquals(true, error is GattOperationError)
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/StateRestorationHandler.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/StateRestorationHandler.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import com.atruedev.kmpble.peripheral.IosPeripheral
 import com.atruedev.kmpble.peripheral.internal.PeripheralRegistry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -101,6 +102,8 @@ internal class StateRestorationHandler(
                     try {
                         peripheral.restoreFromStateRestoration(savedObservations)
                         logEvent(BleLogEvent.StateRestoration(identifier, "restored successfully"))
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logEvent(BleLogEvent.Error(identifier, "StateRestoration: failed to restore", e))
                     }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -18,6 +18,7 @@ import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
 import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.error.StaleGattHandle
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.Descriptor
@@ -47,6 +48,7 @@ import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
 import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
@@ -393,10 +395,10 @@ public class IosPeripheral(
 
     private fun requireNativeCbChar(c: Characteristic): CBCharacteristic =
         nativeCharMap[c]
-            ?: throw IllegalArgumentException("Characteristic not found. Re-acquire from services after connect.")
+            ?: throw BleException(StaleGattHandle("characteristic", c.uuid.toString()))
 
     private fun requireNativeCbDesc(d: Descriptor): CBDescriptor =
-        nativeDescMap[d] ?: throw IllegalArgumentException("Descriptor not found.")
+        nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
 
     private fun ByteArray.toNSData(): NSData = BleData(this).nsData
 
@@ -572,6 +574,9 @@ public class IosPeripheral(
                 pendingL2capChannel = null
                 throw L2capException.OpenFailed(psm, "Timeout waiting for L2CAP channel")
             } catch (e: L2capException) {
+                pendingL2capChannel = null
+                throw e
+            } catch (e: CancellationException) {
                 pendingL2capChannel = null
                 throw e
             } catch (e: Exception) {


### PR DESCRIPTION
## Problem

FakePeripheral.kt was 473 lines - the largest file in the shared module. It mixed connection state simulation, GATT response handling, and observation management in a single class, violating SRP and making test maintenance difficult as the file grew.

## Approach

Decomposed FakePeripheral into three focused components:

1. **FakePeripheral** (291 lines) - Thin facade implementing Peripheral interface, delegates to:
   - **FakeConnectionSimulator** (169 lines) - Connection state machine, disconnect/reconnect flow, CCCD resubscription, observation value emission
   - **FakeGattResponder** (247 lines) - GATT read/write/observe operations, L2CAP, MTU, Phy, RSSI, descriptor operations, handler-based test configuration

Each component receives the same , , and shared state (, ) to maintain coordination.

## Testing

All existing JVM tests pass. The decomposition preserves exact same public API on FakePeripheral including all test simulation methods (, , , , , , etc.).

Closes #202