### PR TITLE
fix: resolve CI failures from PR #208 merge

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/error/BleError.kt
@@ -68,7 +68,7 @@ public data class MtuExceeded(
     val maximum: Int,
 ) : OperationConstraintError
 
-/** A GATT characteristic or descriptor handle is stale — the peer disconnected or services were invalidated. */
+/** A GATT characteristic or descriptor handle is stale - the peer disconnected or services were invalidated. */
 public data class StaleGattHandle(
     val handleType: String,
     val uuid: String,

--- a/src/commonTest/kotlin/com/atruedev/kmpble/error/BleErrorTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/error/BleErrorTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class BleErrorTest {
-
     @Test
     fun staleGattHandleCanBeCreatedAndThrown() {
         val error = StaleGattHandle("characteristic", "00002a19-0000-1000-8000-00805f9b34fb")
@@ -16,10 +15,16 @@ class BleErrorTest {
 
     @Test
     fun staleGattHandleWrappedInBleException() {
-        val ex = assertFailsWith<BleException> {
-            throw BleException(StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"))
-        }
-        assertEquals(StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"), ex.error)
+        val ex =
+            assertFailsWith<BleException> {
+                throw BleException(
+                    StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"),
+                )
+            }
+        assertEquals(
+            StaleGattHandle("descriptor", "00002902-0000-1000-8000-00805f9b34fb"),
+            ex.error,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Fixes CI failures introduced by PR #208 merge

### Typography check
- Replace em-dash (—) with hyphen (-) in StaleGattHandle KDoc (BleError.kt:71)

### ktlint fixes (commonMain)
- **FakeConnectionSimulator.kt**: Remove unused imports (Flow, FlowCollector, flow, map, onCompletion, onStart, delay), add missing newline at EOF
- **FakeGattResponder.kt**: Add missing newline at EOF
- **FakePeripheral.kt**: Remove unused imports (map, onCompletion, onStart, update, Duration), format long function body to multiline, add missing newline at EOF
- **ObservationRegistry.kt**: Remove unused import (transformWhile), add missing newline at EOF
- **ObservationManager.kt**: Fix property setter formatting (newlines after { and before }), put body expressions on same line where they fit, add missing newline at EOF
- **ObservationEmitter.kt**: Add missing newline at EOF

### ktlint fixes (commonTest)
- **BleErrorTest.kt**: Format multiline expressions with proper line breaks and trailing commas for StaleGattHandle constructor calls and assertFailsWith/assertEquals calls

All ktlint and typography checks should now pass.