### PR TITLE
fix: pass null to scanForPeripheralsWithServices, not service filter UUIDs

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/scanner/IosScanner.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/scanner/IosScanner.kt
@@ -66,7 +66,7 @@ public class IosScanner(
                 }
 
             manager.scanForPeripheralsWithServices(
-                serviceUUIDs = serviceUuids,
+                serviceUUIDs = null,
                 options =
                     mapOf<Any?, Any?>(
                         CBCentralManagerScanOptionAllowDuplicatesKey to true,


### PR DESCRIPTION
CoreBluetooth's `scanForPeripheralsWithServices` performs hardware-level filtering — it only discovers peripherals advertising those specific service UUIDs in their advertisement packet. Some peripherals advertise via name but don't include service UUIDs in the advertisement data.

## Problem
Passing scan filter service UUIDs to `scanForPeripheralsWithServices` causes CoreBluetooth to silently ignore peripherals that don't advertise those UUIDs, even if they match the name prefix filter.

## Fix
Pass `null` to `scanForPeripheralsWithServices` so CoreBluetooth reports all peripherals. Service UUIDs are still used for:
- `retrieveConnectedPeripheralsWithServices` (bonded peripheral discovery)
- Post-filter matching in `toScanEvents`