### PR TITLE
fix(ios): prevent CoreBluetooth crash on repeated service discovery

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -199,15 +199,10 @@ public class IosPeripheral(
         closeL2capChannels()
         centralDelegate.unregisterConnectionCallback(identifier.value)
 
-        // Quiesce pending CoreBluetooth operations to prevent callbacks on reused CBPeripheral.
-        // Increment generation to discard any in-flight discovery cycle callbacks.
+        // Invalidate in-flight discovery cycle callbacks before teardown.
         discoveryGeneration++
         currentDiscovery = null
-        // Give CoreBluetooth a moment to drain any queued callbacks before tearing down the delegate.
-        peripheralContext.scope.launch {
-            kotlinx.coroutines.delay(50) // Minimal quiesce window
-            bridge.close()
-        }
+        bridge.close()
 
         observationManager.onObservationsChanged = null
         observationManager.clear()


### PR DESCRIPTION
## Summary

Fixes issue #218: iOS repeat service discovery (refreshServices / fast reconnect) crashes CoreBluetooth with unrecognized selector `handleCharacteristicsDiscovered:`.

## Root Causes Addressed

1. **Stale CBService handles** captured across async boundary. A second `discoverServices()` makes CoreBluetooth replace CBService objects; in-flight `discoverCharacteristics(staleService)` references freed/reused handle -> crash.

2. **Unguarded shared state**: `pendingCharacteristicDiscovery` plain mutable counter with no per-cycle scoping; overlapping discovery cycles clobber it.

3. **No serialization / re-entrancy guard**: Nothing prevents new discovery cycle while prior cycle's characteristic callbacks still draining.

4. **Teardown vs pending callbacks**: `close()` tears down bridge/delegate but CoreBluetooth returns same CBPeripheral instance; queued callbacks fire against reused peripheral.

## Solution

### ApplePeripheralBridge
- `discoverCharacteristics(serviceUuid: String)` now re-fetches fresh CBService from `cbPeripheral.services` at call time instead of accepting stale CBService handle.
- `AppleCallbackEvent.DidDiscoverCharacteristics` carries service UUID instead of CBService.

### IosPeripheral
- **Discovery generation counter** (`discoveryGeneration` @Volatile): increments on every new discovery cycle; stale callbacks check `cycle.generation != discoveryGeneration` and are silently dropped.
- **DiscoveryCycle data class**: holds per-cycle state (generation, pending service UUIDs) confined to peripheral's serial dispatcher (`limitedParallelism(1)`).
- **Native handle cleanup**: `nativeCharMap` and `nativeDescMap` cleared at start of each discovery cycle to prevent StaleGattHandle exceptions.
- **Close teardown**: increments generation, clears `currentDiscovery`, calls `bridge.close()` *synchronously* before `peripheralContext.close()`. The previous `launch { delay(50); bridge.close() }` on the peripheral scope was dead code — cancelled by `scope.cancel()` in `peripheralContext.close()` before it could run.
- **Re-entrancy**: `LifecycleSlots.armDiscovery()` already guards concurrent `refreshServices()` calls; generation counter handles the connect + refreshServices race.

## Commits

1. `fix(ios): prevent CoreBluetooth crash on repeated service discovery` — main fix
2. `fix(ios): remove dead quiesce code in close()` — cleanup

## Verification

- `./gradlew ktlintFormat ktlintCheck` — passes
- `./gradlew compileKotlinIosSimulatorArm64` — compiles
- `./gradlew iosSimulatorArm64Test` — builds
- `./gradlew jvmTest` — all tests pass