### PR TITLE
fix(ios): conditionally implement willRestoreState only when state restoration enabled

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegate.kt
@@ -1,0 +1,30 @@
+package com.atruedev.kmpble.internal
+
+import com.atruedev.kmpble.adapter.BluetoothAdapterState
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSError
+
+/**
+ * Interface for accessing delegate functionality without Kotlin/ObjC mixing issues.
+ * Implemented by both delegate wrappers.
+ */
+internal interface CentralDelegate {
+    val adapterStateFlow: StateFlow<BluetoothAdapterState>
+    val scanResults: SharedFlow<RawScanResult>
+    val restoredPeripherals: SharedFlow<List<CBPeripheral>>
+    val isRestorationEnabled: Boolean
+
+    fun registerConnectionCallback(
+        peripheralId: String,
+        callback: (connected: Boolean, error: NSError?) -> Unit,
+    )
+
+    fun unregisterConnectionCallback(peripheralId: String)
+
+    fun handleConnectionFailure(
+        peripheralId: String,
+        error: NSError?,
+    )
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateImpl.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateImpl.kt
@@ -1,0 +1,61 @@
+package com.atruedev.kmpble.internal
+
+import com.atruedev.kmpble.adapter.BluetoothAdapterState
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSError
+import platform.Foundation.NSNumber
+
+/**
+ * Kotlin implementation of CentralDelegate interface.
+ * This can be wrapped by NSObject delegates for CoreBluetooth.
+ */
+internal class CentralDelegateImpl(
+    private val state: CentralDelegateState = CentralDelegateState(),
+    override val isRestorationEnabled: Boolean = false,
+) : CentralDelegate {
+    override val adapterStateFlow: StateFlow<BluetoothAdapterState> = state.adapterStateFlow
+    override val scanResults: SharedFlow<RawScanResult> = state.scanResults
+    override val restoredPeripherals: SharedFlow<List<CBPeripheral>> = state.restoredPeripherals
+
+    override fun registerConnectionCallback(
+        peripheralId: String,
+        callback: (connected: Boolean, error: NSError?) -> Unit,
+    ) = state.registerConnectionCallback(peripheralId, callback)
+
+    override fun unregisterConnectionCallback(peripheralId: String) = state.unregisterConnectionCallback(peripheralId)
+
+    override fun handleConnectionFailure(
+        peripheralId: String,
+        error: platform.Foundation.NSError?,
+    ) = state.handleConnectionFailure(peripheralId, error)
+
+    internal fun handleAdapterStateUpdate(central: CBCentralManager) {
+        state.handleAdapterStateUpdate(central)
+    }
+
+    internal fun handleScanResult(
+        cbPeripheral: CBPeripheral,
+        advertisementData: Map<Any?, *>,
+        rssi: NSNumber,
+    ) {
+        state.handleScanResult(cbPeripheral, advertisementData, rssi)
+    }
+
+    internal fun handleConnect(cbPeripheral: CBPeripheral) {
+        state.handleConnect(cbPeripheral)
+    }
+
+    internal fun handleDisconnect(
+        cbPeripheral: CBPeripheral,
+        error: NSError?,
+    ) {
+        state.handleDisconnect(cbPeripheral, error)
+    }
+
+    internal fun handleRestoredPeripherals(peripherals: List<CBPeripheral>) {
+        state.handleRestoredPeripherals(peripherals)
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateState.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateState.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import platform.CoreBluetooth.CBCentralManager
-import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
-import platform.CoreBluetooth.CBCentralManagerRestoredStatePeripheralsKey
 import platform.CoreBluetooth.CBCentralManagerStatePoweredOff
 import platform.CoreBluetooth.CBCentralManagerStatePoweredOn
 import platform.CoreBluetooth.CBCentralManagerStateResetting
@@ -19,33 +17,13 @@ import platform.CoreBluetooth.CBCentralManagerStateUnsupported
 import platform.CoreBluetooth.CBPeripheral
 import platform.Foundation.NSError
 import platform.Foundation.NSNumber
-import platform.darwin.NSObject
 import kotlin.concurrent.Volatile
 
 /**
- * Raw scan result from CoreBluetooth delegate callback.
+ * Shared state and logic for CBCentralManager delegates.
+ * Extracted to avoid Kotlin/Native restriction on subclassing Objective-C classes.
  */
-internal data class RawScanResult(
-    val peripheral: CBPeripheral,
-    val advertisementData: Map<Any?, *>,
-    val rssi: NSNumber,
-)
-
-/**
- * Unified CBCentralManager delegate handling adapter state, scan results,
- * and state restoration.
- *
- * State restoration flow:
- * 1. iOS terminates the app (low memory, etc.)
- * 2. A BLE event occurs (peripheral reconnects, data arrives)
- * 3. iOS relaunches the app in the background
- * 4. [centralManager:willRestoreState:] is called with previously connected peripherals
- * 5. [centralManagerDidUpdateState:] follows with current adapter state
- * 6. kmp-ble reconstructs Peripheral wrappers and re-subscribes observations
- */
-internal class KmpBleCentralDelegate :
-    NSObject(),
-    CBCentralManagerDelegateProtocol {
+internal class CentralDelegateState {
     private val _adapterStateFlow = MutableStateFlow<BluetoothAdapterState>(BluetoothAdapterState.Unavailable)
     internal val adapterStateFlow: StateFlow<BluetoothAdapterState> = _adapterStateFlow.asStateFlow()
 
@@ -57,7 +35,7 @@ internal class KmpBleCentralDelegate :
      * Replay = 1 ensures the restoration event is not lost if observers register late
      * (after willRestoreState fires but before the consumer collects).
      */
-    private val _restoredPeripherals = MutableSharedFlow<List<CBPeripheral>>(replay = 1)
+    internal val _restoredPeripherals = MutableSharedFlow<List<CBPeripheral>>(replay = 1)
     internal val restoredPeripherals: SharedFlow<List<CBPeripheral>> = _restoredPeripherals.asSharedFlow()
 
     // Copy-on-write map - reads from CoreBluetooth queue, writes from Kotlin coroutines.
@@ -76,7 +54,7 @@ internal class KmpBleCentralDelegate :
         connectionCallbacks = connectionCallbacks - peripheralId
     }
 
-    override fun centralManagerDidUpdateState(central: CBCentralManager) {
+    internal fun handleAdapterStateUpdate(central: CBCentralManager) {
         _adapterStateFlow.value =
             when (central.state) {
                 CBCentralManagerStatePoweredOn -> BluetoothAdapterState.On
@@ -90,52 +68,30 @@ internal class KmpBleCentralDelegate :
             }
     }
 
-    /**
-     * Called by iOS during state restoration before [centralManagerDidUpdateState].
-     * Provides the list of CBPeripherals that were connected or pending connection
-     * at the time the app was terminated.
-     */
-    override fun centralManager(
-        central: CBCentralManager,
-        willRestoreState: Map<Any?, *>,
-    ) {
-        val peripherals =
-            (willRestoreState[CBCentralManagerRestoredStatePeripheralsKey] as? List<*>)
-                ?.filterIsInstance<CBPeripheral>()
-        if (!peripherals.isNullOrEmpty()) {
-            _restoredPeripherals.tryEmit(peripherals)
-        }
-    }
-
-    override fun centralManager(
-        central: CBCentralManager,
-        didDiscoverPeripheral: CBPeripheral,
+    internal fun handleScanResult(
+        cbPeripheral: CBPeripheral,
         advertisementData: Map<Any?, *>,
-        RSSI: NSNumber,
+        rssi: NSNumber,
     ) {
         _scanResults.tryEmit(
             RawScanResult(
-                peripheral = didDiscoverPeripheral,
+                peripheral = cbPeripheral,
                 advertisementData = advertisementData,
-                rssi = RSSI,
+                rssi = rssi,
             ),
         )
     }
 
-    override fun centralManager(
-        central: CBCentralManager,
-        didConnectPeripheral: CBPeripheral,
-    ) {
-        val id = didConnectPeripheral.identifier.UUIDString
+    internal fun handleConnect(cbPeripheral: CBPeripheral) {
+        val id = cbPeripheral.identifier.UUIDString
         connectionCallbacks[id]?.invoke(true, null)
     }
 
-    override fun centralManager(
-        central: CBCentralManager,
-        didDisconnectPeripheral: CBPeripheral,
+    internal fun handleDisconnect(
+        cbPeripheral: CBPeripheral,
         error: NSError?,
     ) {
-        val id = didDisconnectPeripheral.identifier.UUIDString
+        val id = cbPeripheral.identifier.UUIDString
         connectionCallbacks[id]?.invoke(false, error)
     }
 
@@ -149,4 +105,17 @@ internal class KmpBleCentralDelegate :
     ) {
         connectionCallbacks[peripheralId]?.invoke(false, error)
     }
+
+    internal fun handleRestoredPeripherals(peripherals: List<CBPeripheral>) {
+        _restoredPeripherals.tryEmit(peripherals)
+    }
 }
+
+/**
+ * Raw scan result from CoreBluetooth delegate callback.
+ */
+internal data class RawScanResult(
+    val peripheral: CBPeripheral,
+    val advertisementData: Map<Any?, *>,
+    val rssi: NSNumber,
+)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralManagerProvider.kt
@@ -8,34 +8,76 @@ import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import kotlinx.coroutines.flow.StateFlow
 import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
 import platform.CoreBluetooth.CBCentralManagerOptionRestoreIdentifierKey
 import platform.darwin.dispatch_queue_create
 import kotlin.concurrent.Volatile
 
 internal object CentralManagerProvider {
     private val queue = dispatch_queue_create("com.atruedev.kmpble", null)
-    private val delegate = KmpBleCentralDelegate()
 
-    // ObjC proxy handles didFailToConnectPeripheral (K/N can't override it due to
-    // signature collision with didDisconnectPeripheral). All other delegate methods
-    // forward to the Kotlin delegate via ObjC message forwarding.
-    private val delegateProxy =
-        KmpBleDelegateProxy(target = delegate).apply {
-            onConnectionFailure = { peripheral, error ->
-                val id = peripheral?.identifier?.UUIDString
-                if (id != null) {
-                    delegate.handleConnectionFailure(id, error)
-                } else {
-                    logEvent(
-                        BleLogEvent.Error(
-                            identifier = null,
-                            message = "didFailToConnectPeripheral fired with null peripheral",
-                            cause = null,
-                        ),
-                    )
+    // Lazily initialized when manager is first accessed.
+    // The delegate type depends on whether state restoration is enabled.
+    private var _delegate: CentralDelegate? = null
+    private var _objCDelegate: CBCentralManagerDelegateProtocol? = null
+    private var _delegateProxy: KmpBleDelegateProxy? = null
+
+    private val delegate: CentralDelegate
+        get() {
+            if (_delegate == null) {
+                createDelegateAndProxy()
+            }
+            return _delegate!!
+        }
+
+    private val objCDelegate: CBCentralManagerDelegateProtocol
+        get() {
+            if (_objCDelegate == null) {
+                createDelegateAndProxy()
+            }
+            return _objCDelegate!!
+        }
+
+    private val delegateProxy: KmpBleDelegateProxy
+        get() {
+            if (_delegateProxy == null) {
+                createDelegateAndProxy()
+            }
+            return _delegateProxy!!
+        }
+
+    private fun createDelegateAndProxy() {
+        val impl =
+            if (restoreIdentifier != null) {
+                CentralDelegateImpl(isRestorationEnabled = true)
+            } else {
+                CentralDelegateImpl()
+            }
+        _delegate = impl
+        _objCDelegate =
+            if (restoreIdentifier != null) {
+                KmpBleCentralDelegateWithRestorationObjC(impl)
+            } else {
+                KmpBleCentralDelegateObjC(impl)
+            }
+        _delegateProxy =
+            KmpBleDelegateProxy(target = objCDelegate).apply {
+                onConnectionFailure = { peripheral, error ->
+                    val id = peripheral?.identifier?.UUIDString
+                    if (id != null) {
+                        impl.handleConnectionFailure(id, error)
+                    } else {
+                        logEvent(
+                            BleLogEvent.Error(
+                                identifier = null,
+                                message = "didFailToConnectPeripheral fired with null peripheral",
+                                cause = null,
+                            ),
+                        )
+                    }
                 }
             }
-        }
+    }
 
     /**
      * State restoration identifier. Set via [enableStateRestoration] before
@@ -50,11 +92,13 @@ internal object CentralManagerProvider {
     internal var managerFactory: (() -> CBCentralManager)? = null
 
     internal val manager: CBCentralManager by lazy {
+        // Access delegateProxy to trigger delegate creation with correct type
+        val dp = delegateProxy
         managerFactory?.invoke() ?: run {
             val restoreId = restoreIdentifier
             if (restoreId != null) {
                 CBCentralManager(
-                    delegate = delegateProxy,
+                    delegate = dp,
                     queue = queue,
                     options =
                         mapOf<Any?, Any?>(
@@ -63,7 +107,7 @@ internal object CentralManagerProvider {
                 )
             } else {
                 CBCentralManager(
-                    delegate = delegateProxy,
+                    delegate = dp,
                     queue = queue,
                 )
             }
@@ -73,7 +117,7 @@ internal object CentralManagerProvider {
     internal val adapterStateFlow: StateFlow<BluetoothAdapterState>
         get() = delegate.adapterStateFlow
 
-    internal val scanDelegate: KmpBleCentralDelegate
+    internal val scanDelegate: CentralDelegate
         get() = delegate
 
     /** Whether state restoration is enabled. */

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/KmpBleCentralDelegateObjC.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/KmpBleCentralDelegateObjC.kt
@@ -1,0 +1,94 @@
+package com.atruedev.kmpble.internal
+
+import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
+import platform.CoreBluetooth.CBCentralManagerRestoredStatePeripheralsKey
+import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSError
+import platform.Foundation.NSNumber
+import platform.darwin.NSObject
+
+/**
+ * NSObject delegate WITHOUT state restoration support.
+ * Forwards all delegate callbacks to a Kotlin CentralDelegate implementation.
+ */
+internal class KmpBleCentralDelegateObjC(
+    private val delegate: CentralDelegate,
+) : NSObject(),
+    CBCentralManagerDelegateProtocol {
+    override fun centralManagerDidUpdateState(central: CBCentralManager) {
+        (delegate as? CentralDelegateImpl)?.handleAdapterStateUpdate(central)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didDiscoverPeripheral: CBPeripheral,
+        advertisementData: Map<Any?, *>,
+        RSSI: NSNumber,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleScanResult(didDiscoverPeripheral, advertisementData, RSSI)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didConnectPeripheral: CBPeripheral,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleConnect(didConnectPeripheral)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didDisconnectPeripheral: CBPeripheral,
+        error: NSError?,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleDisconnect(didDisconnectPeripheral, error)
+    }
+}
+
+/**
+ * NSObject delegate WITH state restoration support.
+ * Forwards all delegate callbacks to a Kotlin CentralDelegate implementation.
+ */
+internal class KmpBleCentralDelegateWithRestorationObjC(
+    private val delegate: CentralDelegate,
+) : NSObject(),
+    CBCentralManagerDelegateProtocol {
+    override fun centralManagerDidUpdateState(central: CBCentralManager) {
+        (delegate as? CentralDelegateImpl)?.handleAdapterStateUpdate(central)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didDiscoverPeripheral: CBPeripheral,
+        advertisementData: Map<Any?, *>,
+        RSSI: NSNumber,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleScanResult(didDiscoverPeripheral, advertisementData, RSSI)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didConnectPeripheral: CBPeripheral,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleConnect(didConnectPeripheral)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        didDisconnectPeripheral: CBPeripheral,
+        error: NSError?,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleDisconnect(didDisconnectPeripheral, error)
+    }
+
+    override fun centralManager(
+        central: CBCentralManager,
+        willRestoreState: Map<Any?, *>,
+    ) {
+        (delegate as? CentralDelegateImpl)?.handleRestoredPeripherals(
+            (willRestoreState[CBCentralManagerRestoredStatePeripheralsKey] as? List<*>)
+                ?.filterIsInstance<CBPeripheral>()
+                .orEmpty(),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

On iOS, every session logged a CoreBluetooth API-misuse warning:
```
[CoreBluetooth] API MISUSE: <CBCentralManager: 0x...> has no restore identifier
but the delegate implements the centralManager:willRestoreState: method.
Restoring will not be supported
```

The single `KmpBleCentralDelegate` always implemented `centralManager:willRestoreState:` regardless of whether state restoration was enabled via `enableStateRestoration()`. When the manager was created without `CBCentralManagerOptionRestoreIdentifierKey`, CoreBluetooth emitted this warning.

## Approach

Split the delegate into two ObjC classes:
- `KmpBleCentralDelegateObjC` - no `willRestoreState` (default, restoration disabled)
- `KmpBleCentralDelegateWithRestorationObjC` - implements `willRestoreState` (when enabled via `enableStateRestoration()`)

`CentralManagerProvider` now lazily creates the correct delegate type based on the `restoreIdentifier` value. The common state and logic are extracted into `CentralDelegateState` and `CentralDelegateImpl`, with a `CentralDelegate` interface for clean abstraction.

## Testing

- iOS simulator compilation: ✅
- JVM compilation: ✅
- ktlintCheck: ✅

Closes #219