### PR TITLE
fix(kmp-314): replace qualified kotlinx.coroutines names with imports

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -229,7 +229,7 @@ internal class AndroidGattServer(
                             // Cancel any pending notification/indication for this device
                             pendingNotifySent
                                 .remove(device.address)
-                                ?.cancel(kotlinx.coroutines.CancellationException("Device disconnected"))
+                                ?.cancel(CancellationException("Device disconnected"))
                             logEvent(BleLogEvent.ServerClientEvent(deviceId, "disconnected"))
                             if (!_connectionEvents.tryEmit(ServerConnectionEvent.Disconnected(deviceId))) {
                                 logEvent(
@@ -730,7 +730,7 @@ internal class AndroidGattServer(
 
         return try {
             withTimeout(NOTIFY_TIMEOUT_MS) { deferred.await() }
-        } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+        } catch (_: TimeoutCancellationException) {
             pendingNotifySent.remove(device.address)
             throw ServerException.NotifyFailed(
                 if (confirm) "Indication timed out" else "Notification timed out",
@@ -763,7 +763,7 @@ internal class AndroidGattServer(
 
         // Cancel all pending notifications/indications
         for ((_, deferred) in pendingNotifySent) {
-            deferred.cancel(kotlinx.coroutines.CancellationException("Server closed"))
+            deferred.cancel(CancellationException("Server closed"))
         }
         pendingNotifySent.clear()
 
@@ -936,7 +936,7 @@ internal class AndroidGattServer(
                     return BluetoothGatt.GATT_FAILURE
                 }
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 logEvent(
                     BleLogEvent.ServerRequest(
                         deviceId,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -21,6 +21,7 @@ import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +37,7 @@ public class FakePeripheral internal constructor(
     private val onConnectHandler: suspend () -> Result<Unit>,
     private val onDisconnectHandler: suspend () -> Result<Unit>,
     private val onL2capHandler: L2capHandler?,
-    private val observationDispatcher: kotlinx.coroutines.CoroutineDispatcher =
+    private val observationDispatcher: CoroutineDispatcher =
         Dispatchers.Default.limitedParallelism(
             1,
         ),

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosGattServer.kt
@@ -10,12 +10,14 @@ import com.atruedev.kmpble.internal.PeripheralManagerProvider
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -192,7 +194,7 @@ internal class IosGattServer(
             withTimeout(POWER_ON_TIMEOUT_MS) {
                 delegate.managerState.first { it == CBPeripheralManagerStatePoweredOn }
             }
-        } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+        } catch (_: TimeoutCancellationException) {
             setDelegateCallbacks(active = false)
             throw ServerException.OpenFailed(
                 "Timeout waiting for Bluetooth to power on (state: ${delegate.managerState.value})",
@@ -220,7 +222,7 @@ internal class IosGattServer(
                         "addService failed for ${serviceDef.uuid}: ${error.localizedDescription}",
                     )
                 }
-            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (e: TimeoutCancellationException) {
                 pendingServiceAdd = null
                 throw ServerException.OpenFailed(
                     "Timeout adding service ${serviceDef.uuid}",
@@ -311,7 +313,7 @@ internal class IosGattServer(
 
         manager.removeAllServices()
 
-        readyToUpdate.cancel(kotlinx.coroutines.CancellationException("Server closed"))
+        readyToUpdate.cancel(CancellationException("Server closed"))
 
         // Don't clear collections here - races with in-flight coroutines before cancellation.
         scope.cancel()
@@ -370,7 +372,7 @@ internal class IosGattServer(
                     ),
                 )
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 logEvent(
                     BleLogEvent.ServerRequest(
                         request.centralId,
@@ -450,7 +452,7 @@ internal class IosGattServer(
                 }
                 logEvent(BleLogEvent.ServerRequest(centralId, "write (${data.size}B)", charUuid, status))
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 logEvent(
                     BleLogEvent.ServerRequest(centralId, "write-failed (handler threw)", charUuid, GattStatus.Failure),
                 )
@@ -548,7 +550,7 @@ internal class IosGattServer(
             try {
                 evictIdleCentrals()
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 logEvent(BleLogEvent.Error(null, "central sweep failed", e))
             }
         }
@@ -589,7 +591,7 @@ internal class IosGattServer(
                 withTimeout(NOTIFY_TIMEOUT) {
                     readyToUpdate.await()
                 }
-            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 throw ServerException.NotifyFailed(
                     "Transmit queue full - timeout waiting for ready (attempt ${attempt + 1}/$MAX_NOTIFY_RETRIES)",
                 )


### PR DESCRIPTION
## Problem

Watchdog scan detected qualified  names in code body (KMP-314) violating Kotlin conventions:
- : 4 occurrences of  and 
- : 6 occurrences of  and 
- : 1 occurrence of  in constructor parameter

## Approach

Added explicit imports for the required types and replaced qualified names with simple names in code body:
- : Added  (already had ), replaced 4 qualified references
- : Added imports for  and , replaced 6 qualified references
- : Added , replaced 1 qualified reference in constructor parameter

All builds, ktlintCheck, and JVM tests pass.

Closes #KMP-314