### PR TITLE
fix(server): add WHY comments for runBlocking in close() methods

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidAdvertiser.kt
@@ -136,6 +136,7 @@ internal class AndroidAdvertiser(
         }
 
     override fun close() {
+        // runBlocking safe — uses limitedParallelism(1) dispatcher, no circular wait
         runBlocking(serialDispatcher) {
             stopInternal()
             advertiser = null

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -117,6 +117,7 @@ internal class AndroidExtendedAdvertiser(
         }
 
     override fun close() {
+        // runBlocking safe — uses limitedParallelism(1) dispatcher, no circular wait
         runBlocking(serialDispatcher) {
             val advertiser =
                 try {


### PR DESCRIPTION
## Problem
The `runBlocking` calls in `AndroidAdvertiser.close()` and `AndroidExtendedAdvertiser.close()` are safe (they use `limitedParallelism(1)` dispatcher with no circular wait), but the WHY comment explaining this safety was missing per the project's code documentation convention.

## Approach
Add a `// runBlocking safe — uses limitedParallelism(1) dispatcher, no circular wait` comment above each `runBlocking` call in both `close()` methods.

- `AndroidAdvertiser.kt:139` — added comment
- `AndroidExtendedAdvertiser.kt:120` — added comment