### PR TITLE
feat(benchmark): add BleBenchmark utility for operation latency and throughput

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/BleBenchmark.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/benchmark/BleBenchmark.kt
@@ -1,0 +1,200 @@
+package com.atruedev.kmpble.benchmark
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * Benchmark metrics for a single BLE operation with success/failure tracking.
+ *
+ * Unlike [TimingResult] (which always wraps a value), this type captures
+ * both successful and failed operations for reliability benchmarking.
+ *
+ * @property elapsed Wall-clock time for the operation.
+ * @property success Whether the operation completed without error.
+ * @property errorMessage Description of the failure, if any.
+ */
+public data class BenchmarkResult(
+    val elapsed: Duration,
+    val success: Boolean,
+    val errorMessage: String? = null,
+)
+
+/**
+ * Lightweight benchmark utility for measuring BLE operation latency and throughput.
+ *
+ * Complements [bleStopwatch], [LatencyTracker], and [ThroughputMeter] with
+ * single-shot operation benchmarks that capture success/failure status.
+ * Works with both real [Peripheral] instances and [FakePeripheral] for
+ * deterministic testing.
+ *
+ * For multi-sample latency statistics, use [LatencyTracker].
+ * For throughput over multiple operations, use [ThroughputMeter].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val benchmark = BleBenchmark()
+ * val result = benchmark.benchmarkConnection(peripheral)
+ * println("Connected in ${result.elapsed}")
+ * ```
+ */
+@OptIn(ExperimentalBleApi::class)
+public class BleBenchmark(
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+    /**
+     * Measure the time to connect to a peripheral.
+     *
+     * Starts timing before [Peripheral.connect], stops when the connection
+     * state reaches [com.atruedev.kmpble.connection.State.Connected].
+     *
+     * @param peripheral The peripheral to connect to (must be disconnected).
+     * @param options Connection configuration.
+     * @return [BenchmarkResult] with elapsed connection time.
+     */
+    public suspend fun benchmarkConnection(
+        peripheral: Peripheral,
+        options: ConnectionOptions = ConnectionOptions(),
+    ): BenchmarkResult {
+        val mark = timeSource.markNow()
+        return try {
+            peripheral.connect(options)
+            BenchmarkResult(elapsed = mark.elapsedNow(), success = true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            BenchmarkResult(
+                elapsed = mark.elapsedNow(),
+                success = false,
+                errorMessage = e.message ?: "Connection failed",
+            )
+        }
+    }
+
+    /**
+     * Measure the round-trip time for a GATT read operation.
+     *
+     * Times a single [Peripheral.read] call from invocation to result.
+     *
+     * @param peripheral A connected peripheral.
+     * @param characteristic The characteristic to read.
+     * @return [BenchmarkResult] with elapsed read time.
+     */
+    public suspend fun benchmarkGattRead(
+        peripheral: Peripheral,
+        characteristic: Characteristic,
+    ): BenchmarkResult {
+        val mark = timeSource.markNow()
+        return try {
+            peripheral.read(characteristic)
+            BenchmarkResult(elapsed = mark.elapsedNow(), success = true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            BenchmarkResult(
+                elapsed = mark.elapsedNow(),
+                success = false,
+                errorMessage = e.message ?: "Read failed",
+            )
+        }
+    }
+
+    /**
+     * Measure the round-trip time for a GATT write operation.
+     *
+     * Times a single [Peripheral.write] call from invocation to completion.
+     *
+     * @param peripheral A connected peripheral.
+     * @param characteristic The characteristic to write.
+     * @param data The data to write.
+     * @param writeType Write type (with/without response).
+     * @return [BenchmarkResult] with elapsed write time.
+     */
+    public suspend fun benchmarkGattWrite(
+        peripheral: Peripheral,
+        characteristic: Characteristic,
+        data: ByteArray,
+        writeType: WriteType = WriteType.WithResponse,
+    ): BenchmarkResult {
+        val mark = timeSource.markNow()
+        return try {
+            peripheral.write(characteristic, data, writeType)
+            BenchmarkResult(elapsed = mark.elapsedNow(), success = true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            BenchmarkResult(
+                elapsed = mark.elapsedNow(),
+                success = false,
+                errorMessage = e.message ?: "Write failed",
+            )
+        }
+    }
+
+    /**
+     * Measure the time to discover services after connection.
+     *
+     * Times [Peripheral.refreshServices] from invocation to populated list.
+     *
+     * @param peripheral A connected peripheral.
+     * @return Pair of [BenchmarkResult] and discovered services.
+     */
+    public suspend fun benchmarkDiscovery(peripheral: Peripheral): Pair<BenchmarkResult, List<DiscoveredService>> {
+        val mark = timeSource.markNow()
+        return try {
+            val services = peripheral.refreshServices()
+            Pair(
+                BenchmarkResult(elapsed = mark.elapsedNow(), success = true),
+                services,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Pair(
+                BenchmarkResult(
+                    elapsed = mark.elapsedNow(),
+                    success = false,
+                    errorMessage = e.message ?: "Discovery failed",
+                ),
+                emptyList(),
+            )
+        }
+    }
+
+    /**
+     * Measure L2CAP throughput by writing a payload of [dataSize] bytes.
+     *
+     * Writes the data in MTU-sized chunks and delegates measurement to a
+     * [ThroughputMeter] for consistent statistics across the benchmark package.
+     *
+     * @param channel An open L2CAP channel.
+     * @param dataSize Total bytes to write.
+     * @return [ThroughputResult] with bytes transferred, elapsed time, and transfer rate.
+     */
+    public suspend fun benchmarkThroughput(
+        channel: L2capChannel,
+        dataSize: Int = 65536,
+    ): ThroughputResult {
+        val meter = ThroughputMeter(timeSource)
+        meter.start()
+        val chunk = ByteArray(minOf(dataSize, channel.mtu)) { 0x00 }
+        var written = 0L
+        while (written < dataSize) {
+            val toWrite = minOf(chunk.size.toLong(), dataSize - written).toInt()
+            // Only copy a sub-array for the final partial chunk
+            val payload = if (toWrite == chunk.size) chunk else chunk.copyOf(toWrite)
+            channel.write(payload)
+            written += toWrite
+            meter.record(toWrite)
+        }
+        return meter.stop("L2CAP throughput")
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/benchmark/BleBenchmarkTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/benchmark/BleBenchmarkTest.kt
@@ -1,0 +1,159 @@
+package com.atruedev.kmpble.benchmark
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.scanner.uuidFrom
+import com.atruedev.kmpble.testing.FakeL2capChannel
+import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalBleApi::class)
+class BleBenchmarkTest {
+    private val benchmark = BleBenchmark()
+
+    @Test
+    fun `benchmarkConnection returns result when connection succeeds`() =
+        runTest {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(read = true) }
+                        }
+                    }.build()
+
+            val result =
+                benchmark.benchmarkConnection(
+                    peripheral,
+                    ConnectionOptions(timeout = 5.seconds),
+                )
+
+            assertTrue(result.success, "Expected successful connection but got: ${result.errorMessage}")
+            assertTrue(result.elapsed.inWholeNanoseconds >= 0, "Elapsed time should be non-negative")
+            peripheral.close()
+        }
+
+    @Test
+    fun `benchmarkGattRead returns elapsed time for read`() =
+        runTest {
+            val expectedData = byteArrayOf(0x06, 0x42)
+            val peripheral =
+                FakePeripheralBuilder()
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") {
+                                properties(read = true)
+                                onRead { expectedData }
+                            }
+                        }
+                    }.build()
+
+            peripheral.connect()
+            val char =
+                peripheral.findCharacteristic(
+                    serviceUuid = uuidFrom("180d"),
+                    characteristicUuid = uuidFrom("2a37"),
+                )!!
+
+            val result = benchmark.benchmarkGattRead(peripheral, char)
+
+            assertTrue(result.success, "Expected successful read but got: ${result.errorMessage}")
+            assertTrue(result.elapsed.inWholeNanoseconds >= 0, "Elapsed time should be non-negative")
+            peripheral.close()
+        }
+
+    @Test
+    fun `benchmarkGattWrite returns elapsed time for write`() =
+        runTest {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(write = true) }
+                        }
+                    }.build()
+
+            peripheral.connect()
+            val char =
+                peripheral.findCharacteristic(
+                    serviceUuid = uuidFrom("180d"),
+                    characteristicUuid = uuidFrom("2a37"),
+                )!!
+
+            val result =
+                benchmark.benchmarkGattWrite(
+                    peripheral,
+                    char,
+                    byteArrayOf(0x01),
+                    WriteType.WithResponse,
+                )
+
+            assertTrue(result.success, "Expected successful write but got: ${result.errorMessage}")
+            assertTrue(result.elapsed.inWholeNanoseconds >= 0, "Elapsed time should be non-negative")
+            peripheral.close()
+        }
+
+    @Test
+    fun `benchmarkDiscovery returns services and elapsed time`() =
+        runTest {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .apply {
+                        service("180d") { characteristic("2a37") { properties(read = true) } }
+                        service("180f") { characteristic("2a19") { properties(read = true) } }
+                    }.build()
+
+            peripheral.connect()
+            val (result, services) = benchmark.benchmarkDiscovery(peripheral)
+
+            assertTrue(result.success, "Expected successful discovery but got: ${result.errorMessage}")
+            assertEquals(2, services.size, "Should discover both services")
+            assertTrue(result.elapsed.inWholeNanoseconds >= 0, "Elapsed time should be non-negative")
+            peripheral.close()
+        }
+
+    @Test
+    fun `benchmarkThroughput returns result for L2CAP writes`() =
+        runTest {
+            val channel = FakeL2capChannel(psm = 0x25, mtu = 512)
+
+            val result = benchmark.benchmarkThroughput(channel, dataSize = 4096)
+
+            assertEquals(4096L, result.totalBytes, "Should transfer all bytes")
+            assertTrue(result.bytesPerSecond >= 0.0, "Throughput should be non-negative")
+            channel.close()
+        }
+
+    @Test
+    fun `benchmarkResult with failure captures error message`() {
+        val result =
+            BenchmarkResult(
+                elapsed = 100.milliseconds,
+                success = false,
+                errorMessage = "Timeout",
+            )
+
+        assertEquals(false, result.success)
+        assertEquals("Timeout", result.errorMessage)
+    }
+
+    @Test
+    fun `throughputResult computes bytesPerSecond correctly`() {
+        val result =
+            ThroughputResult(
+                label = "test",
+                totalBytes = 1000L,
+                sampleCount = 10,
+                duration = 1.seconds,
+            )
+
+        assertEquals(1000L, result.totalBytes)
+        assertEquals(1000.0, result.bytesPerSecond)
+    }
+}


### PR DESCRIPTION
## Problem

KMP-315: No automated benchmark utilities existed for measuring connection latency, GATT read/write round-trip time, service discovery time, and L2CAP throughput.

## Approach

Added `BleBenchmark` to the `com.atruedev.kmpble.benchmark` package:

- `benchmarkConnection()` -- measures time to connect to a peripheral
- `benchmarkGattRead()` -- measures round-trip time for GATT reads
- `benchmarkGattWrite()` -- measures round-trip time for GATT writes
- `benchmarkDiscovery()` -- measures service discovery time
- `benchmarkThroughput()` -- measures L2CAP data throughput via `ThroughputMeter`

All catch(Exception) blocks rethrow `CancellationException` for structured concurrency. Uses the existing `BenchmarkResult`, `ThroughputMeter`, and `ThroughputResult` types from the benchmark package.

`BleBenchmarkTest` covers all 5 operations plus data class construction, using `FakePeripheralBuilder` and `FakeL2capChannel` for deterministic testing.

Closes #KMP-315