### PR TITLE
chore(release): prep v0.8.5 -- version bump, Package.swift, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.5] - 2026-06-18
+
+### Added
+- feat(sample): add BleQuickstart end-to-end code examples and update README (#227)
+- test(benchmark): add cross-platform benchmark comparison tests (#228)
+
+### Fixed
+- fix: replace em-dashes with hyphens in comments and README
+
+---
+
 ## [Unreleased]
 
 _Changes on `main` that have not yet been tagged for release._
@@ -619,7 +630,8 @@ _No notable changes._
 
 ---
 
-[Unreleased]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.4...HEAD
+[Unreleased]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.5...HEAD
+[0.8.5]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.4...v0.8.5
 [0.8.4]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/gary-quinn/kmp-ble/compare/v0.8.1...v0.8.2

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "KmpBle",
-            url: "https://github.com/gary-quinn/kmp-ble/releases/download/v0.8.4/KmpBle.xcframework.zip",
-            checksum: "a6200654ee35329924fbf490858d3e0da16a92b5a1f46853313b688ad9e430e7"
+            url: "https://github.com/gary-quinn/kmp-ble/releases/download/v0.8.5/KmpBle.xcframework.zip",
+            checksum: "tbd-update-at-release"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Kotlin Multiplatform BLE library for Android and iOS.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("com.atruedev:kmp-ble:0.8.4")
+            implementation("com.atruedev:kmp-ble:0.8.5")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.4")
-            implementation("com.atruedev:kmp-ble-dfu:0.8.4")
-            implementation("com.atruedev:kmp-ble-codec:0.8.4")
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.4")
+            implementation("com.atruedev:kmp-ble-profiles:0.8.5")
+            implementation("com.atruedev:kmp-ble-dfu:0.8.5")
+            implementation("com.atruedev:kmp-ble-codec:0.8.5")
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")
         }
     }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -18,14 +18,14 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Core - scan, connect, GATT client/server, advertise, L2CAP
-            implementation("com.atruedev:kmp-ble:0.8.4")
+            implementation("com.atruedev:kmp-ble:0.8.5")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.4")  // type-safe GATT profiles
-            implementation("com.atruedev:kmp-ble-dfu:0.8.4")       // Nordic DFU firmware updates
-            implementation("com.atruedev:kmp-ble-codec:0.8.4")     // typed read/write codec
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.4")  // CBOR via kotlinx-serialization
-            implementation("com.atruedev:kmp-ble-quirks:0.8.4")    // OEM device workarounds
+            implementation("com.atruedev:kmp-ble-profiles:0.8.5")  // type-safe GATT profiles
+            implementation("com.atruedev:kmp-ble-dfu:0.8.5")       // Nordic DFU firmware updates
+            implementation("com.atruedev:kmp-ble-codec:0.8.5")     // typed read/write codec
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")  // CBOR via kotlinx-serialization
+            implementation("com.atruedev:kmp-ble-quirks:0.8.5")    // OEM device workarounds
         }
     }
 }


### PR DESCRIPTION
## Problem
KMP-319: Release prep for v0.8.5. Version references throughout the project still pointed to 0.8.4, and the CHANGELOG had no 0.8.5 section.

## Approach
Updated all version references and release artifacts:

- **README.md**: Bumped dependency versions from 0.8.4 to 0.8.5 (kmp-ble and all submodules)
- **llms.txt**: Bumped dependency versions from 0.8.4 to 0.8.5
- **Package.swift**: Updated download URL to v0.8.5 (checksum placeholder — updated at actual release time)
- **CHANGELOG.md**: Added 0.8.5 section documenting changes since 0.8.4:
  - feat(sample): BleQuickstart end-to-end code examples (#227)
  - test(benchmark): cross-platform benchmark comparison tests (#228)
  - fix: em-dash typography fix
- Updated compare links for 0.8.5 release

Closes KMP-319