### PR TITLE
fix(ci): use last docs-update merge commit as changelog baseline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,12 +143,18 @@ jobs:
           echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
           PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${{ needs.publish.outputs.tag }}$" | head -1)
           echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          # Use the last docs-update merge commit as the changelog baseline.
+          # This avoids re-including PRs already listed in the previous version's
+          # CHANGELOG section (those PRs were merged after the previous tag but
+          # documented in that version's auto-update-docs commit).
+          DOCS_BASELINE=$(git log --oneline --grep="^docs: update docs for v" --merges --format="%H" | head -1)
+          echo "docs_baseline=${DOCS_BASELINE:-$PREV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Generate changelog entries from merged PRs
         id: changelog
         uses: gary-quinn/shared-actions/changelog@4975dde119744969d162d01444f13e2515c639c2 # v1
         with:
-          prev_tag: ${{ steps.meta.outputs.prev_tag }}
+          prev_tag: ${{ steps.meta.outputs.docs_baseline }}
           current_tag: ${{ needs.publish.outputs.tag }}
 
       - name: Update README.md


### PR DESCRIPTION
## Problem

CI auto-update-docs generated duplicate CHANGELOG entries (PR #231). The changelog shared-action used the previous git tag as baseline for `git log`, but CHANGELOG sections are populated **after** the tag by the `docs: update docs for v*` merge commit. PRs merged between tag and docs-update were re-included in the next release's changelog (e.g. PRs #222–#226 appeared in both v0.8.4 and v0.8.5 sections).

## Fix

Use the last `docs: update docs for v*` merge commit as the changelog baseline instead of the previous tag:

```bash
DOCS_BASELINE=$(git log --oneline --grep="^docs: update docs for v" --merges --format="%H" | head -1)
```

This commit represents the point where the CHANGELOG was finalized for the previous release. Only PRs merged after it belong in the new section.

Fallback: `${DOCS_BASELINE:-$PREV_TAG}` — uses tag if no docs-update commit exists (first release).

## Before/After

| | Before | After |
|---|---|---|
| Baseline | v0.8.4 tag (June 16) | docs-update merge (June 18) |
| PRs included | #222–#229 (8 PRs, 4 already in v0.8.4) | #227–#229 (3 PRs) |
| Duplicates | ✅ Yes | ❌ No |

## Changes

- `.github/workflows/publish.yml`: `Get release metadata` step — add `DOCS_BASELINE` detection
- `Generate changelog entries` — use `docs_baseline` instead of `prev_tag`
- `PREV_TAG` preserved for compare links (`[...]/compare/v0.8.4...v0.8.5`)