### PR TITLE
feat(monitoring): add ConnectionQualityMonitor with RSSI and connection lifecycle tracking

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/ConnectionQuality.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/ConnectionQuality.kt
@@ -1,0 +1,24 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.peripheral.Peripheral
+
+/**
+ * Aggregated connection health statistics for a [Peripheral].
+ *
+ * Tracks connection lifecycle events and RSSI snapshots to provide
+ * an at-a-glance quality signal. Useful for app-level telemetry,
+ * debugging intermittent disconnects, and user-facing status displays.
+ */
+public data class ConnectionQuality(
+    /** Total successful connections established. */
+    val totalConnections: Int = 0,
+    /** Total disconnections (all causes). */
+    val totalDisconnections: Int = 0,
+    /** Most recent RSSI reading, or null if never read. */
+    val lastRssi: Int? = null,
+    /** Whether the peripheral is currently in a Connected state. */
+    val isConnected: Boolean = false,
+) {
+    /** Number of reconnections (disconnections that were followed by a new connection). */
+    val reconnectionCount: Int get() = maxOf(0, totalConnections - 1)
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/ConnectionQualityMonitor.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/ConnectionQualityMonitor.kt
@@ -1,0 +1,103 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Monitors a [Peripheral]'s connection lifecycle and exposes aggregated
+ * [ConnectionQuality] metrics via a [StateFlow].
+ *
+ * Launch monitoring with [start] and stop with [stop]. The monitor auto-tracks
+ * connection/disconnection events through the peripheral's [Peripheral.state].
+ *
+ * ## Usage
+ * ```
+ * val monitor = ConnectionQualityMonitor(peripheral, scope)
+ * monitor.start()
+ * monitor.connectionQuality.collect { quality ->
+ *     updateUi(quality)
+ * }
+ * ```
+ */
+public class ConnectionQualityMonitor(
+    private val peripheral: Peripheral,
+    private val scope: CoroutineScope,
+) {
+    private val _connectionQuality = MutableStateFlow(ConnectionQuality())
+    public val connectionQuality: StateFlow<ConnectionQuality> = _connectionQuality.asStateFlow()
+
+    private var started = false
+    private var collectionJob: Job? = null
+
+    /**
+     * Begin monitoring the peripheral's connection lifecycle.
+     *
+     * Safe to call multiple times - subsequent calls are no-ops.
+     * Does not block; launches a coroutine in [scope] to observe state changes.
+     */
+    public fun start() {
+        if (started) return
+        started = true
+        collectionJob =
+            scope.launch {
+                try {
+                    peripheral.state.collect { state ->
+                        updateFromState(state)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    // State collection failed; leave last known quality snapshot intact
+                }
+            }
+    }
+
+    /**
+     * Stop monitoring. The [connectionQuality] flow retains its last value.
+     *
+     * Cancels the active collection coroutine (does not cancel the scope).
+     * Call [start] to resume monitoring.
+     */
+    public fun stop() {
+        started = false
+        collectionJob?.cancel()
+        collectionJob = null
+    }
+
+    /**
+     * Record an RSSI reading. Call after [Peripheral.readRssi] to feed
+     * the result into the quality snapshot.
+     */
+    public fun recordRssi(rssi: Int) {
+        _connectionQuality.update { it.copy(lastRssi = rssi) }
+    }
+
+    private fun updateFromState(state: State) {
+        _connectionQuality.update { current ->
+            val wasConnected = current.isConnected
+            val isNowConnected = state is State.Connected
+
+            when {
+                isNowConnected && !wasConnected ->
+                    current.copy(
+                        totalConnections = current.totalConnections + 1,
+                        isConnected = true,
+                    )
+                !isNowConnected && wasConnected ->
+                    current.copy(
+                        totalDisconnections = current.totalDisconnections + 1,
+                        isConnected = false,
+                    )
+                else -> current.copy(isConnected = isNowConnected)
+            }
+        }
+    }
+}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/ConnectionQualityMonitorTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/ConnectionQualityMonitorTest.kt
@@ -1,0 +1,229 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionQualityMonitorTest {
+    @Test
+    fun initialQualityIsDefault() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = ConnectionQualityMonitor(peripheral, CoroutineScope(dispatcher))
+        val quality = monitor.connectionQuality.value
+        assertEquals(0, quality.totalConnections)
+        assertEquals(0, quality.totalDisconnections)
+        assertEquals(0, quality.reconnectionCount)
+        assertNull(quality.lastRssi)
+        assertFalse(quality.isConnected)
+    }
+
+    @Test
+    fun connectingIncrementsConnectionCount() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            // connect() completes synchronously on real dispatchers;
+            // process any pending test-dispatcher tasks to let the collector run
+            scheduler.runCurrent()
+
+            val quality = monitor.connectionQuality.value
+            assertEquals(1, quality.totalConnections)
+            assertTrue(quality.isConnected)
+        }
+    }
+
+    @Test
+    fun disconnectIncrementsDisconnectionCount() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            val quality = monitor.connectionQuality.value
+            assertEquals(1, quality.totalConnections)
+            assertEquals(1, quality.totalDisconnections)
+            assertFalse(quality.isConnected)
+        }
+    }
+
+    @Test
+    fun reconnectAfterDisconnectTracksBothEvents() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val quality = monitor.connectionQuality.value
+            assertEquals(2, quality.totalConnections)
+            assertEquals(1, quality.totalDisconnections)
+            assertEquals(1, quality.reconnectionCount)
+            assertTrue(quality.isConnected)
+        }
+    }
+
+    @Test
+    fun recordRssiUpdatesLastRssi() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = ConnectionQualityMonitor(peripheral, CoroutineScope(dispatcher))
+
+        monitor.recordRssi(-55)
+        assertEquals(-55, monitor.connectionQuality.value.lastRssi)
+
+        monitor.recordRssi(-72)
+        assertEquals(-72, monitor.connectionQuality.value.lastRssi)
+    }
+
+    @Test
+    fun startIsIdempotent() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+
+            monitor.start()
+            monitor.start()
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            assertEquals(1, monitor.connectionQuality.value.totalConnections)
+        }
+    }
+
+    @Test
+    fun multipleConnectDisconnectCyclesAreTracked() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val quality = monitor.connectionQuality.value
+            assertEquals(3, quality.totalConnections)
+            assertEquals(2, quality.totalDisconnections)
+            assertEquals(2, quality.reconnectionCount)
+            assertTrue(quality.isConnected)
+        }
+    }
+
+    @Test
+    fun rssiAndConnectionAreIndependent() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            monitor.recordRssi(-80)
+            assertEquals(-80, monitor.connectionQuality.value.lastRssi)
+            assertFalse(monitor.connectionQuality.value.isConnected)
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            assertEquals(-80, monitor.connectionQuality.value.lastRssi)
+            assertTrue(monitor.connectionQuality.value.isConnected)
+        }
+    }
+
+    @Test
+    fun stopPreventsFurtherUpdates() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = ConnectionQualityMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            assertEquals(1, monitor.connectionQuality.value.totalConnections)
+
+            monitor.stop()
+
+            peripheral.disconnect()
+            scheduler.runCurrent()
+            assertEquals(1, monitor.connectionQuality.value.totalConnections)
+            assertEquals(0, monitor.connectionQuality.value.totalDisconnections)
+        }
+    }
+}


### PR DESCRIPTION
## Problem
No built-in way to monitor connection quality for BLE peripherals — consumers must manually track RSSI, connection counts, and disconnection events by collecting peripheral state directly, leading to duplicated boilerplate across apps.

## Approach
Introduces a **stand-alone ConnectionQualityMonitor** that wraps a Peripheral (no interface changes needed) and exposes aggregated connection health metrics as a StateFlow:

- **ConnectionQuality** data class: totalConnections, totalDisconnections, lastRssi, isConnected, reconnectionCount
- **ConnectionQualityMonitor**: start/stop lifecycle, infinite StateFlow collection on provided scope, CancellationException-safe
- Uses the existing Peripheral.state flow — no platform-specific changes required
- 9 jvmTest cases covering: connect, disconnect, reconnect, RSSI, idempotent start, stop semantics (cancels collection coroutine), multi-cycle tracking

Closes #KMP-321