### PR TITLE
refactor(server): decompose AndroidGattServer (1003 loc) into 5 focused files

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -3,59 +3,35 @@
 package com.atruedev.kmpble.server
 
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
-import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattServer
-import android.bluetooth.BluetoothGattServerCallback
-import android.bluetooth.BluetoothGattService
-import android.bluetooth.BluetoothManager
-import android.bluetooth.BluetoothProfile
 import android.content.Context
 import com.atruedev.kmpble.BleData
 import com.atruedev.kmpble.Identifier
-import com.atruedev.kmpble.emptyBleData
 import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
-import com.atruedev.kmpble.peripheral.toAndroidGattStatus
 import com.atruedev.kmpble.peripheral.toGattStatus
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
-import kotlin.uuid.toJavaUuid
-import kotlin.uuid.toKotlinUuid
 
 /**
  * Android implementation of [GattServer] using [BluetoothGattServer].
  *
+ * Delegates state management to [AndroidGattServerState] and callback handling
+ * to [AndroidGattServerCallback]. Setup logic lives in [AndroidGattServerSetup.kt].
+ *
  * ## Architecture
  *
  * - Uses [BluetoothManager.openGattServer] to create the native server
- * - Implements [BluetoothGattServerCallback] for all client interactions
  * - Handlers (onRead/onWrite) are dispatched on a serialized dispatcher
  *   (same limitedParallelism(1) pattern as AndroidPeripheral)
  * - CCCD tracking: maintains a map of which devices are subscribed
@@ -63,19 +39,14 @@ import kotlin.uuid.toKotlinUuid
  *
  * ## Threading
  *
- * All mutable state is accessed exclusively on the serialized [dispatcher]
- * (limitedParallelism(1)). Binder-thread callbacks dispatch to [scope]
+ * All mutable state is accessed exclusively on the serialized [state.dispatcher]
+ * (limitedParallelism(1)). Binder-thread callbacks dispatch to [state.scope]
  * which runs on the same dispatcher.
  *
  * [close] follows the AndroidPeripheral pattern: set the closed flag,
  * close native resources synchronously (BluetoothGattServer.close() is
  * thread-safe), then cancel the scope. No runBlocking - safe to call
  * from any context including handler callbacks.
- *
- * Thread-safe fields accessed from Binder threads:
- * - [pendingNotifySent]: ConcurrentHashMap, CompletableDeferred.complete is safe
- * - [pendingServiceAdd]: @Volatile, CompletableDeferred.complete is safe
- * - [isOpen]: AtomicBoolean for visibility and atomic close
  *
  * ## Lifecycle
  *
@@ -88,415 +59,26 @@ import kotlin.uuid.toKotlinUuid
  * Android supports only one BluetoothGattServer per app. Opening a second
  * server while one is already open throws [ServerException.OpenFailed].
  * Use [close] to release before opening another.
- *
- * ## Service Setup
- *
- * On [open], the server:
- * 1. Opens BluetoothGattServer
- * 2. Converts each ServiceDefinition -> BluetoothGattService
- * 3. Adds CCCD (0x2902) descriptor automatically for notify/indicate chars
- * 4. Calls addService() for each (must wait for onServiceAdded callback)
- *
- * ## CCCD Handling
- *
- * When a client writes to a CCCD descriptor (0x2902):
- * - [0x01, 0x00] = enable notifications
- * - [0x02, 0x00] = enable indications
- * - [0x00, 0x00] = disable
- * The server tracks subscription mode per device per characteristic.
- * notify()/indicate() only send to subscribed devices.
- *
- * ## Pre-API-33 Note
- *
- * On API < 33, [BluetoothGattCharacteristic.value] is set before calling
- * [BluetoothGattServer.notifyCharacteristicChanged]. When sending the same
- * notification to multiple devices in parallel, all async blocks share the
- * same data argument so the write is safe. API 33+ uses the data-parameter
- * overload and avoids the shared mutable field entirely.
  */
 internal class AndroidGattServer(
     private val context: Context,
     private val serviceDefinitions: List<ServiceDefinition>,
 ) : GattServer {
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1)
-    private var scope = CoroutineScope(SupervisorJob() + dispatcher + CoroutineName("GattServer"))
+    internal val state = AndroidGattServerState(context, serviceDefinitions)
 
-    // --- All fields below are accessed ONLY on [dispatcher] unless noted ---
-
-    @Volatile
-    private var nativeServer: BluetoothGattServer? = null
-
-    private val _connections = MutableStateFlow<List<ServerConnection>>(emptyList())
-    override val connections: StateFlow<List<ServerConnection>> = _connections.asStateFlow()
-
-    // Use tryEmit to avoid blocking Binder callback thread on slow collectors.
-    // With extraBufferCapacity = 64, events are buffered. If the buffer fills,
-    // the oldest event is silently dropped and a warning is logged.
-    private val _connectionEvents = MutableSharedFlow<ServerConnectionEvent>(extraBufferCapacity = 64)
-    override val connectionEvents: Flow<ServerConnectionEvent> = _connectionEvents.asSharedFlow()
-
-    // Track connected BluetoothDevice instances by Identifier
-    private val connectedDevices = mutableMapOf<Identifier, BluetoothDevice>()
-
-    // Track per-device per-characteristic CCCD subscription mode.
-    // Value: the raw CCCD bytes the device wrote (0x01,0x00 / 0x02,0x00 / 0x00,0x00)
-    private data class SubscriptionKey(
-        val characteristicUuid: Uuid,
-        val device: Identifier,
-    )
-
-    private val subscriptionModes = mutableMapOf<SubscriptionKey, ByteArray>()
-
-    // Secondary index: characteristic UUID -> set of subscribed device identifiers.
-    // Maintained in sync with subscriptionModes for O(1) broadcast notify lookup.
-    private val subscribersByChar = mutableMapOf<Uuid, MutableSet<Identifier>>()
-
-    // Track per-device MTU
-    private val deviceMtu = mutableMapOf<Identifier, Int>()
-
-    // Map characteristic UUID -> handler for read/write dispatch
-    private val readHandlers = mutableMapOf<Uuid, suspend (Identifier) -> BleData>()
-    private val writeHandlers = mutableMapOf<Uuid, suspend (Identifier, BleData, Boolean) -> GattStatus?>()
-
-    private val preparedWriteBuffer = mutableMapOf<String, MutableList<WriteFragment>>()
-
-    // O(1) lookup cache: characteristic UUID -> native characteristic (built during open)
-    private val characteristicCache = mutableMapOf<Uuid, BluetoothGattCharacteristic>()
-
-    // Per-device pending onNotificationSent - ConcurrentHashMap because
-    // onNotificationSent fires on a Binder thread and completes the deferred,
-    // while notify/indicate write the entry from the serialized dispatcher.
-    // Used for BOTH notifications and indications because Android's
-    // onNotificationSent fires for both, and you must wait for it before
-    // sending the next to the same device.
-    private val pendingNotifySent = ConcurrentHashMap<String, CompletableDeferred<Int>>()
-
-    // Pending service addition - @Volatile because written on dispatcher, read on Binder thread
-    @Volatile
-    private var pendingServiceAdd: CompletableDeferred<Int>? = null
-
-    // AtomicBoolean for atomic close (prevents double-close waste)
-    private val isOpen = AtomicBoolean(false)
-
-    // Tracks whether close() has been called - prevents reopen after close
-    private val isClosed = AtomicBoolean(false)
-
-    private val callback =
-        object : BluetoothGattServerCallback() {
-            override fun onConnectionStateChange(
-                device: BluetoothDevice,
-                status: Int,
-                newState: Int,
-            ) {
-                scope.launch {
-                    val deviceId = Identifier(device.address)
-                    when (newState) {
-                        BluetoothProfile.STATE_CONNECTED -> {
-                            connectedDevices[deviceId] = device
-                            val connectionCount = connectedDevices.size
-                            _connections.update { list ->
-                                list + ServerConnection(deviceId, device.name)
-                            }
-                            logEvent(BleLogEvent.ServerClientEvent(deviceId, "connected ($connectionCount total)"))
-                            if (connectionCount >= CONNECTION_WARNING_THRESHOLD) {
-                                logEvent(
-                                    BleLogEvent.Error(
-                                        deviceId,
-                                        "High connection count ($connectionCount). Android typically supports " +
-                                            "7-15 concurrent BLE connections depending on device. New connections " +
-                                            "may be silently rejected.",
-                                        null,
-                                    ),
-                                )
-                            }
-                            if (!_connectionEvents.tryEmit(ServerConnectionEvent.Connected(deviceId))) {
-                                logEvent(
-                                    BleLogEvent.Error(deviceId, "Connection event buffer full, event dropped", null),
-                                )
-                            }
-                        }
-                        BluetoothProfile.STATE_DISCONNECTED -> {
-                            connectedDevices.remove(deviceId)
-                            deviceMtu.remove(deviceId)
-                            preparedWriteBuffer.remove(device.address)
-                            // Remove all subscriptions for this device
-                            subscriptionModes.keys.removeAll { it.device == deviceId }
-                            for ((_, subscribers) in subscribersByChar) {
-                                subscribers.remove(deviceId)
-                            }
-                            _connections.update { list ->
-                                list.filter { it.device != deviceId }
-                            }
-                            // Cancel any pending notification/indication for this device
-                            pendingNotifySent
-                                .remove(device.address)
-                                ?.cancel(CancellationException("Device disconnected"))
-                            logEvent(BleLogEvent.ServerClientEvent(deviceId, "disconnected"))
-                            if (!_connectionEvents.tryEmit(ServerConnectionEvent.Disconnected(deviceId))) {
-                                logEvent(
-                                    BleLogEvent.Error(deviceId, "Connection event buffer full, event dropped", null),
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            override fun onCharacteristicReadRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                offset: Int,
-                characteristic: BluetoothGattCharacteristic,
-            ) {
-                scope.launch {
-                    val deviceId = Identifier(device.address)
-                    val charUuid = characteristic.uuid.toKotlinUuid()
-                    val handler = readHandlers[charUuid]
-
-                    if (handler == null) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read-rejected (no handler)",
-                                charUuid,
-                                GattStatus.ReadNotPermitted,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
-                        return@launch
-                    }
-
-                    try {
-                        val bleData = handler(deviceId)
-                        val responseData =
-                            if (offset > 0 && offset < bleData.size) {
-                                bleData.slice(offset, bleData.size).toByteArray()
-                            } else if (offset >= bleData.size && offset > 0) {
-                                byteArrayOf()
-                            } else {
-                                bleData.toByteArray()
-                            }
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read (${responseData.size}B, offset=$offset)",
-                                charUuid,
-                                GattStatus.Success,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read-failed (handler threw)",
-                                charUuid,
-                                GattStatus.Failure,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
-                    }
-                }
-            }
-
-            override fun onCharacteristicWriteRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                characteristic: BluetoothGattCharacteristic,
-                preparedWrite: Boolean,
-                responseNeeded: Boolean,
-                offset: Int,
-                value: ByteArray?,
-            ) {
-                scope.launch {
-                    val deviceId = Identifier(device.address)
-                    val charUuid = characteristic.uuid.toKotlinUuid()
-
-                    if (preparedWrite) {
-                        handlePreparedWrite(device, deviceId, requestId, charUuid, offset, responseNeeded, value)
-                        return@launch
-                    }
-
-                    val handler = writeHandlers[charUuid]
-                    if (handler == null) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "write-rejected (no handler)",
-                                charUuid,
-                                GattStatus.WriteNotPermitted,
-                            ),
-                        )
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
-                        }
-                        return@launch
-                    }
-
-                    try {
-                        val bleData =
-                            if (value != null && value.isNotEmpty()) {
-                                BleData(value)
-                            } else {
-                                emptyBleData()
-                            }
-                        val status = handler(deviceId, bleData, responseNeeded)
-                        logEvent(BleLogEvent.ServerRequest(deviceId, "write (${value?.size ?: 0}B)", charUuid, status))
-                        if (responseNeeded) {
-                            val nativeStatus = status?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
-                            sendResponseSafe(device, requestId, nativeStatus, offset, null)
-                        }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "write-failed (handler threw)",
-                                charUuid,
-                                GattStatus.Failure,
-                            ),
-                        )
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
-                        }
-                    }
-                }
-            }
-
-            override fun onDescriptorReadRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                offset: Int,
-                descriptor: BluetoothGattDescriptor,
-            ) {
-                scope.launch {
-                    val descUuid = descriptor.uuid.toKotlinUuid()
-                    if (descUuid == CCCD_UUID) {
-                        val deviceId = Identifier(device.address)
-                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
-                        val key = SubscriptionKey(charUuid, deviceId)
-                        // Return the actual CCCD value the device wrote, or disabled
-                        val value = subscriptionModes[key] ?: BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
-                    } else {
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, byteArrayOf())
-                    }
-                }
-            }
-
-            override fun onDescriptorWriteRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                descriptor: BluetoothGattDescriptor,
-                preparedWrite: Boolean,
-                responseNeeded: Boolean,
-                offset: Int,
-                value: ByteArray?,
-            ) {
-                scope.launch {
-                    val descUuid = descriptor.uuid.toKotlinUuid()
-                    if (descUuid == CCCD_UUID && value != null) {
-                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
-                        handleCccdWrite(device, charUuid, value)
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
-                        }
-                    } else {
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
-                        }
-                    }
-                }
-            }
-
-            override fun onExecuteWrite(
-                device: BluetoothDevice,
-                requestId: Int,
-                execute: Boolean,
-            ) {
-                scope.launch {
-                    val fragments = preparedWriteBuffer.remove(device.address)
-                    val deviceId = Identifier(device.address)
-
-                    if (!execute || fragments.isNullOrEmpty()) {
-                        logEvent(
-                            BleLogEvent.ServerClientEvent(
-                                deviceId,
-                                if (execute) "execute-write (empty)" else "execute-write (cancelled)",
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-                        return@launch
-                    }
-
-                    when (val result = assembleWriteFragments(fragments)) {
-                        is AssemblyResult.PayloadTooLarge -> {
-                            logEvent(
-                                BleLogEvent.ServerRequest(
-                                    deviceId,
-                                    "execute-write-rejected (${result.actualSize}B exceeds limit)",
-                                    result.charUuid,
-                                    GattStatus.InvalidAttributeLength,
-                                ),
-                            )
-                            sendResponseSafe(
-                                device,
-                                requestId,
-                                BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
-                                0,
-                                null,
-                            )
-                        }
-
-                        is AssemblyResult.Success -> {
-                            val gattStatus = dispatchAssembledWrites(deviceId, result.writes)
-                            sendResponseSafe(device, requestId, gattStatus, 0, null)
-                        }
-                    }
-                }
-            }
-
-            override fun onNotificationSent(
-                device: BluetoothDevice,
-                status: Int,
-            ) {
-                // Called on Binder thread - ConcurrentHashMap + CompletableDeferred are both thread-safe
-                pendingNotifySent.remove(device.address)?.complete(status)
-            }
-
-            override fun onServiceAdded(
-                status: Int,
-                service: BluetoothGattService,
-            ) {
-                // Called on Binder thread - @Volatile + CompletableDeferred.complete is thread-safe
-                pendingServiceAdd?.complete(status)
-            }
-
-            override fun onMtuChanged(
-                device: BluetoothDevice,
-                mtu: Int,
-            ) {
-                scope.launch {
-                    val deviceId = Identifier(device.address)
-                    deviceMtu[deviceId] = mtu
-                    logEvent(BleLogEvent.ServerClientEvent(deviceId, "MTU changed to $mtu"))
-                }
-            }
-        }
+    override val connections: StateFlow<List<ServerConnection>> = state.connections
+    override val connectionEvents: Flow<ServerConnectionEvent> = state.connectionEvents
 
     override suspend fun open() {
-        if (isClosed.get()) {
+        if (state.isClosed.get()) {
             throw ServerException.OpenFailed(
                 "This server instance has been closed and cannot be reopened. " +
                     "Create a new instance via GattServer { ... } factory.",
             )
         }
 
-        withContext(dispatcher) {
-            if (isOpen.get()) return@withContext
+        withContext(state.dispatcher) {
+            if (state.isOpen.get()) return@withContext
 
             // Single-instance enforcement
             if (!instanceLock.compareAndSet(false, true)) {
@@ -509,7 +91,7 @@ internal class AndroidGattServer(
             logEvent(BleLogEvent.ServerLifecycle("opening"))
 
             try {
-                openInternal()
+                state.openInternal(instanceLock)
             } catch (e: Exception) {
                 instanceLock.set(false)
                 throw e
@@ -517,94 +99,34 @@ internal class AndroidGattServer(
         }
     }
 
-    private suspend fun openInternal() {
-        val bluetoothManager =
-            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
-                ?: throw ServerException.NotSupported("BluetoothManager not available")
-
-        val adapter =
-            bluetoothManager.adapter
-                ?: throw ServerException.NotSupported("Bluetooth adapter not available")
-
-        if (!adapter.isEnabled) {
-            throw ServerException.OpenFailed("Bluetooth is not enabled")
-        }
-
-        val server =
-            try {
-                bluetoothManager.openGattServer(context, callback)
-            } catch (e: SecurityException) {
-                throw ServerException.OpenFailed("Missing BLUETOOTH_CONNECT permission", e)
-            } ?: throw ServerException.OpenFailed("openGattServer returned null")
-
-        nativeServer = server
-
-        // Register handlers from service definitions
-        for (serviceDef in serviceDefinitions) {
-            for (charDef in serviceDef.characteristics) {
-                charDef.readHandler?.let { readHandlers[charDef.uuid] = it }
-                charDef.writeHandler?.let { writeHandlers[charDef.uuid] = it }
-            }
-        }
-
-        // Add services sequentially (must wait for onServiceAdded for each)
-        for (serviceDef in serviceDefinitions) {
-            val nativeService = buildNativeService(serviceDef)
-            val deferred = CompletableDeferred<Int>()
-            pendingServiceAdd = deferred
-            if (!server.addService(nativeService)) {
-                pendingServiceAdd = null
-                throw ServerException.OpenFailed("addService returned false for ${serviceDef.uuid}")
-            }
-            val status = deferred.await()
-            pendingServiceAdd = null
-            if (status != BluetoothGatt.GATT_SUCCESS) {
-                throw ServerException.OpenFailed(
-                    "addService failed for ${serviceDef.uuid} with status ${status.toGattStatus()}",
-                )
-            }
-            logEvent(BleLogEvent.ServerLifecycle("service added: ${serviceDef.uuid}"))
-        }
-
-        // Build O(1) characteristic lookup cache
-        for (service in server.services) {
-            for (char in service.characteristics) {
-                characteristicCache[char.uuid.toKotlinUuid()] = char
-            }
-        }
-
-        isOpen.set(true)
-        logEvent(BleLogEvent.ServerLifecycle("open (${serviceDefinitions.size} services)"))
-    }
-
     override suspend fun notify(
         characteristicUuid: Uuid,
         device: Identifier?,
         data: BleData,
     ) {
-        withContext(dispatcher) {
+        withContext(state.dispatcher) {
             checkOpen()
-            val server = nativeServer ?: throw ServerException.NotOpen()
+            val server = state.nativeServer ?: throw ServerException.NotOpen()
             val nativeChar =
-                characteristicCache[characteristicUuid]
+                state.characteristicCache[characteristicUuid]
                     ?: throw ServerException.NotifyFailed("Characteristic $characteristicUuid not found")
 
             val targets =
                 if (device != null) {
                     // Specific device - verify connected and subscribed
                     val connected =
-                        connectedDevices[device]
+                        state.connectedDevices[device]
                             ?: throw ServerException.DeviceNotConnected("Device $device not connected")
-                    val key = SubscriptionKey(characteristicUuid, device)
-                    val mode = subscriptionModes[key]
+                    val key = AndroidGattServerState.SubscriptionKey(characteristicUuid, device)
+                    val mode = state.subscriptionModes[key]
                     if (mode == null || mode.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
                         return@withContext // Not subscribed, skip silently
                     }
                     listOf(connected)
                 } else {
                     // All subscribed devices for this characteristic - O(1) lookup via secondary index
-                    val subscribed = subscribersByChar[characteristicUuid] ?: emptySet()
-                    subscribed.mapNotNull { connectedDevices[it] }
+                    val subscribed = state.subscribersByChar[characteristicUuid] ?: emptySet()
+                    subscribed.mapNotNull { state.connectedDevices[it] }
                 }
 
             val dataBytes = data.toByteArray()
@@ -612,7 +134,7 @@ internal class AndroidGattServer(
             // Warn if notification payload exceeds any target's MTU
             for (target in targets) {
                 val targetId = Identifier(target.address)
-                val mtu = deviceMtu[targetId] ?: DEFAULT_MTU
+                val mtu = state.deviceMtu[targetId] ?: DEFAULT_MTU
                 val maxPayload = mtu - ATT_HEADER_SIZE
                 if (dataBytes.size > maxPayload) {
                     logEvent(
@@ -631,7 +153,7 @@ internal class AndroidGattServer(
                 .map { target ->
                     async {
                         try {
-                            awaitNotifySend(server, target, nativeChar, dataBytes, confirm = false)
+                            state.awaitNotifySend(server, target, nativeChar, dataBytes, confirm = false)
                         } catch (e: Exception) {
                             logEvent(BleLogEvent.Error(Identifier(target.address), "notify failed", e))
                         }
@@ -654,20 +176,20 @@ internal class AndroidGattServer(
         device: Identifier,
         data: BleData,
     ) {
-        withContext(dispatcher) {
+        withContext(state.dispatcher) {
             checkOpen()
-            val server = nativeServer ?: throw ServerException.NotOpen()
+            val server = state.nativeServer ?: throw ServerException.NotOpen()
             val nativeChar =
-                characteristicCache[characteristicUuid]
+                state.characteristicCache[characteristicUuid]
                     ?: throw ServerException.NotifyFailed("Characteristic $characteristicUuid not found")
 
             val target =
-                connectedDevices[device]
+                state.connectedDevices[device]
                     ?: throw ServerException.DeviceNotConnected("Device $device not connected")
 
             // Check CCCD subscription
-            val key = SubscriptionKey(characteristicUuid, device)
-            val mode = subscriptionModes[key]
+            val key = AndroidGattServerState.SubscriptionKey(characteristicUuid, device)
+            val mode = state.subscriptionModes[key]
             if (mode == null || mode.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
                 throw ServerException.NotifyFailed("Device $device is not subscribed to $characteristicUuid")
             }
@@ -675,7 +197,7 @@ internal class AndroidGattServer(
             val dataBytes = data.toByteArray()
 
             // Warn on MTU truncation
-            val mtu = deviceMtu[device] ?: DEFAULT_MTU
+            val mtu = state.deviceMtu[device] ?: DEFAULT_MTU
             val maxPayload = mtu - ATT_HEADER_SIZE
             if (dataBytes.size > maxPayload) {
                 logEvent(
@@ -690,51 +212,22 @@ internal class AndroidGattServer(
             }
 
             try {
-                val status = awaitNotifySend(server, target, nativeChar, dataBytes, confirm = true)
-                if (status != BluetoothGatt.GATT_SUCCESS) {
-                    throw ServerException.NotifyFailed("Indication failed with status ${status.toGattStatus()}")
+                val gattStatus = state.awaitNotifySend(server, target, nativeChar, dataBytes, confirm = true)
+                if (gattStatus != BluetoothGatt.GATT_SUCCESS) {
+                    throw ServerException.NotifyFailed(
+                        "Indication failed with status ${gattStatus.toGattStatus()}",
+                    )
                 }
             } catch (e: SecurityException) {
                 throw ServerException.NotifyFailed("Missing BLUETOOTH_CONNECT permission", e)
             }
             logEvent(
-                BleLogEvent.ServerRequest(device, "indicate (${data.size}B)", characteristicUuid, GattStatus.Success),
-            )
-        }
-    }
-
-    /**
-     * Send a notification or indication to a device and await `onNotificationSent`.
-     *
-     * Android's BLE stack requires waiting for onNotificationSent before sending
-     * the next notification to the same device. This method serializes per-device
-     * and handles both notifications (confirm=false) and indications (confirm=true).
-     *
-     * @return The GATT status from onNotificationSent
-     */
-    private suspend fun awaitNotifySend(
-        server: BluetoothGattServer,
-        device: BluetoothDevice,
-        characteristic: BluetoothGattCharacteristic,
-        data: ByteArray,
-        confirm: Boolean,
-    ): Int {
-        val deferred = CompletableDeferred<Int>()
-        pendingNotifySent[device.address] = deferred
-
-        try {
-            notifyDevice(server, device, characteristic, data, confirm)
-        } catch (e: Exception) {
-            pendingNotifySent.remove(device.address)
-            throw e
-        }
-
-        return try {
-            withTimeout(NOTIFY_TIMEOUT_MS) { deferred.await() }
-        } catch (_: TimeoutCancellationException) {
-            pendingNotifySent.remove(device.address)
-            throw ServerException.NotifyFailed(
-                if (confirm) "Indication timed out" else "Notification timed out",
+                BleLogEvent.ServerRequest(
+                    device,
+                    "indicate (${data.size}B)",
+                    characteristicUuid,
+                    GattStatus.Success,
+                ),
             )
         }
     }
@@ -750,225 +243,35 @@ internal class AndroidGattServer(
      * even under concurrent calls.
      */
     override fun close() {
-        if (!isOpen.compareAndSet(true, false)) return
-        isClosed.set(true)
+        if (!state.isOpen.compareAndSet(true, false)) return
+        state.isClosed.set(true)
         logEvent(BleLogEvent.ServerLifecycle("closing"))
 
         // Close native server first - stops all Binder callbacks
         try {
-            nativeServer?.close()
+            state.nativeServer?.close()
         } catch (_: SecurityException) {
             // Ignore permission errors on close
         }
-        nativeServer = null
+        state.nativeServer = null
 
         // Cancel all pending notifications/indications
-        for ((_, deferred) in pendingNotifySent) {
+        for ((_, deferred) in state.pendingNotifySent) {
             deferred.cancel(CancellationException("Server closed"))
         }
-        pendingNotifySent.clear()
+        state.pendingNotifySent.clear()
 
         // Don't clear collections here - races with in-flight coroutines before cancellation.
-        scope.cancel()
-        _connections.value = emptyList()
+        state.scope.cancel()
+        state.clearConnections()
 
         // Release singleton lock
         instanceLock.set(false)
         logEvent(BleLogEvent.ServerLifecycle("closed"))
     }
 
-    private fun buildNativeService(definition: ServiceDefinition): BluetoothGattService {
-        val service =
-            BluetoothGattService(
-                definition.uuid.toJavaUuid(),
-                BluetoothGattService.SERVICE_TYPE_PRIMARY,
-            )
-
-        for (charDef in definition.characteristics) {
-            val characteristic =
-                BluetoothGattCharacteristic(
-                    charDef.uuid.toJavaUuid(),
-                    charDef.properties.toAndroidProperties(),
-                    charDef.permissions.toAndroidPermissions(),
-                )
-
-            // Auto-add CCCD if notify or indicate
-            if (charDef.properties.notify || charDef.properties.indicate) {
-                val cccd =
-                    BluetoothGattDescriptor(
-                        CCCD_UUID.toJavaUuid(),
-                        BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
-                    )
-                characteristic.addDescriptor(cccd)
-            }
-
-            // Add user-defined descriptors
-            for (descDef in charDef.descriptors) {
-                characteristic.addDescriptor(
-                    BluetoothGattDescriptor(descDef.uuid.toJavaUuid(), BluetoothGattDescriptor.PERMISSION_READ),
-                )
-            }
-
-            service.addCharacteristic(characteristic)
-        }
-
-        return service
-    }
-
-    private fun notifyDevice(
-        server: BluetoothGattServer,
-        device: BluetoothDevice,
-        characteristic: BluetoothGattCharacteristic,
-        data: ByteArray,
-        confirm: Boolean,
-    ) {
-        server.notifyCharacteristicChanged(device, characteristic, confirm, data)
-    }
-
-    private fun handleCccdWrite(
-        device: BluetoothDevice,
-        characteristicUuid: Uuid,
-        value: ByteArray,
-    ) {
-        val deviceId = Identifier(device.address)
-        val key = SubscriptionKey(characteristicUuid, deviceId)
-        if (value.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
-            subscriptionModes.remove(key)
-            subscribersByChar[characteristicUuid]?.remove(deviceId)
-            logEvent(BleLogEvent.ServerClientEvent(deviceId, "unsubscribed from $characteristicUuid"))
-        } else {
-            subscriptionModes[key] = value.copyOf()
-            subscribersByChar.getOrPut(characteristicUuid) { mutableSetOf() }.add(deviceId)
-            val mode =
-                when {
-                    value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) -> "notifications"
-                    value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) -> "indications"
-                    else -> "unknown mode"
-                }
-            logEvent(BleLogEvent.ServerClientEvent(deviceId, "subscribed to $characteristicUuid ($mode)"))
-        }
-    }
-
-    private fun handlePreparedWrite(
-        device: BluetoothDevice,
-        deviceId: Identifier,
-        requestId: Int,
-        charUuid: Uuid,
-        offset: Int,
-        responseNeeded: Boolean,
-        value: ByteArray?,
-    ) {
-        if (writeHandlers[charUuid] == null) {
-            logEvent(
-                BleLogEvent.ServerRequest(
-                    deviceId,
-                    "prepared-write-rejected (no handler)",
-                    charUuid,
-                    GattStatus.WriteNotPermitted,
-                ),
-            )
-            if (responseNeeded) {
-                sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
-            }
-            return
-        }
-
-        val buffer = preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
-        val projectedSize = projectedBufferSize(buffer, offset, value?.size ?: 0)
-        if (projectedSize > MAX_PREPARED_WRITE_BUFFER_BYTES) {
-            preparedWriteBuffer.remove(device.address)
-            logEvent(
-                BleLogEvent.ServerRequest(
-                    deviceId,
-                    "prepared-write-rejected (${projectedSize}B exceeds limit)",
-                    charUuid,
-                    GattStatus.InvalidAttributeLength,
-                ),
-            )
-            if (responseNeeded) {
-                sendResponseSafe(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
-            }
-            return
-        }
-
-        buffer.add(WriteFragment(charUuid, offset, value ?: byteArrayOf()))
-        logEvent(
-            BleLogEvent.ServerRequest(
-                deviceId,
-                "prepared-write (${value?.size ?: 0}B @$offset)",
-                charUuid,
-                GattStatus.Success,
-            ),
-        )
-        if (responseNeeded) {
-            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
-        }
-    }
-
-    private suspend fun dispatchAssembledWrites(
-        deviceId: Identifier,
-        writes: List<AssembledWrite>,
-    ): Int {
-        for (write in writes) {
-            val handler = writeHandlers[write.charUuid]
-            if (handler == null) {
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write-rejected (no handler)",
-                        write.charUuid,
-                        GattStatus.WriteNotPermitted,
-                    ),
-                )
-                return BluetoothGatt.GATT_FAILURE
-            }
-
-            try {
-                val status = handler(deviceId, BleData(write.data), true)
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write (${write.data.size}B)",
-                        write.charUuid,
-                        status,
-                    ),
-                )
-                if (status != null && status != GattStatus.Success) {
-                    return BluetoothGatt.GATT_FAILURE
-                }
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write-failed (handler threw)",
-                        write.charUuid,
-                        GattStatus.Failure,
-                    ),
-                )
-                return BluetoothGatt.GATT_FAILURE
-            }
-        }
-        return BluetoothGatt.GATT_SUCCESS
-    }
-
-    private fun sendResponseSafe(
-        device: BluetoothDevice,
-        requestId: Int,
-        status: Int,
-        offset: Int,
-        value: ByteArray?,
-    ) {
-        if (!isOpen.get()) return
-        try {
-            nativeServer?.sendResponse(device, requestId, status, offset, value)
-        } catch (_: SecurityException) {
-            // Ignore - device disconnected or permission lost
-        }
-    }
-
     private fun checkOpen() {
-        if (!isOpen.get()) throw ServerException.NotOpen()
+        if (!state.isOpen.get()) throw ServerException.NotOpen()
     }
 
     internal companion object {
@@ -976,28 +279,8 @@ internal class AndroidGattServer(
         const val NOTIFY_TIMEOUT_MS = 5_000L
         const val DEFAULT_MTU = 23
         const val ATT_HEADER_SIZE = 3
-        const val CONNECTION_WARNING_THRESHOLD = 7
 
         // Global single-instance guard - Android supports one GATT server per app
         private val instanceLock = AtomicBoolean(false)
     }
-}
-
-internal fun ServerCharacteristic.Properties.toAndroidProperties(): Int {
-    var flags = 0
-    if (read) flags = flags or BluetoothGattCharacteristic.PROPERTY_READ
-    if (write) flags = flags or BluetoothGattCharacteristic.PROPERTY_WRITE
-    if (writeWithoutResponse) flags = flags or BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE
-    if (notify) flags = flags or BluetoothGattCharacteristic.PROPERTY_NOTIFY
-    if (indicate) flags = flags or BluetoothGattCharacteristic.PROPERTY_INDICATE
-    return flags
-}
-
-internal fun ServerCharacteristic.Permissions.toAndroidPermissions(): Int {
-    var flags = 0
-    if (read) flags = flags or BluetoothGattCharacteristic.PERMISSION_READ
-    if (readEncrypted) flags = flags or BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED
-    if (write) flags = flags or BluetoothGattCharacteristic.PERMISSION_WRITE
-    if (writeEncrypted) flags = flags or BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED
-    return flags
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
@@ -1,0 +1,444 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothProfile
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.emptyBleData
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.peripheral.toAndroidGattStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * BluetoothGattServerCallback that dispatches all Binder-thread callbacks
+ * onto [state.scope] for serialized processing on [state.dispatcher].
+ *
+ * Handles connection state changes, read/write requests, descriptor operations,
+ * prepared write execution, notification sent, service added, and MTU changes.
+ */
+internal class AndroidGattServerCallback(
+    private val state: AndroidGattServerState,
+) {
+    val callback: BluetoothGattServerCallback =
+        object : BluetoothGattServerCallback() {
+            override fun onConnectionStateChange(
+                device: BluetoothDevice,
+                status: Int,
+                newState: Int,
+            ) {
+                state.scope.launch {
+                    val deviceId = Identifier(device.address)
+                    when (newState) {
+                        BluetoothProfile.STATE_CONNECTED -> {
+                            state.addConnection(deviceId, device)
+                        }
+
+                        BluetoothProfile.STATE_DISCONNECTED -> {
+                            state.removeConnection(deviceId, device.address)
+                            state.removeAllSubscriptions(deviceId)
+                            state.cancelPendingNotify(device.address, "Device disconnected")
+                        }
+                    }
+                }
+            }
+
+            override fun onCharacteristicReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                characteristic: BluetoothGattCharacteristic,
+            ) {
+                state.scope.launch {
+                    val deviceId = Identifier(device.address)
+                    val charUuid = characteristic.uuid.toKotlinUuid()
+                    val handler = state.readHandlers[charUuid]
+
+                    if (handler == null) {
+                        logEvent(
+                            BleLogEvent.ServerRequest(
+                                deviceId,
+                                "read-rejected (no handler)",
+                                charUuid,
+                                GattStatus.ReadNotPermitted,
+                            ),
+                        )
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                        return@launch
+                    }
+
+                    try {
+                        val bleData = handler(deviceId)
+                        val responseData =
+                            if (offset > 0 && offset < bleData.size) {
+                                bleData.slice(offset, bleData.size).toByteArray()
+                            } else if (offset >= bleData.size && offset > 0) {
+                                byteArrayOf()
+                            } else {
+                                bleData.toByteArray()
+                            }
+                        logEvent(
+                            BleLogEvent.ServerRequest(
+                                deviceId,
+                                "read (${responseData.size}B, offset=$offset)",
+                                charUuid,
+                                GattStatus.Success,
+                            ),
+                        )
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        logEvent(
+                            BleLogEvent.ServerRequest(
+                                deviceId,
+                                "read-failed (handler threw)",
+                                charUuid,
+                                GattStatus.Failure,
+                            ),
+                        )
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
+                    }
+                }
+            }
+
+            override fun onCharacteristicWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                characteristic: BluetoothGattCharacteristic,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray?,
+            ) {
+                state.scope.launch {
+                    val deviceId = Identifier(device.address)
+                    val charUuid = characteristic.uuid.toKotlinUuid()
+
+                    if (preparedWrite) {
+                        handlePreparedWrite(device, deviceId, requestId, charUuid, offset, responseNeeded, value)
+                        return@launch
+                    }
+
+                    val handler = state.writeHandlers[charUuid]
+                    if (handler == null) {
+                        logEvent(
+                            BleLogEvent.ServerRequest(
+                                deviceId,
+                                "write-rejected (no handler)",
+                                charUuid,
+                                GattStatus.WriteNotPermitted,
+                            ),
+                        )
+                        if (responseNeeded) {
+                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+                        }
+                        return@launch
+                    }
+
+                    try {
+                        val bleData =
+                            if (value != null && value.isNotEmpty()) {
+                                BleData(value)
+                            } else {
+                                emptyBleData()
+                            }
+                        val gattStatus = handler(deviceId, bleData, responseNeeded)
+                        logEvent(
+                            BleLogEvent.ServerRequest(deviceId, "write (${value?.size ?: 0}B)", charUuid, gattStatus),
+                        )
+                        if (responseNeeded) {
+                            val nativeStatus =
+                                gattStatus?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
+                            sendResponseSafe(device, requestId, nativeStatus, offset, null)
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        logEvent(
+                            BleLogEvent.ServerRequest(
+                                deviceId,
+                                "write-failed (handler threw)",
+                                charUuid,
+                                GattStatus.Failure,
+                            ),
+                        )
+                        if (responseNeeded) {
+                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
+                        }
+                    }
+                }
+            }
+
+            override fun onDescriptorReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                descriptor: BluetoothGattDescriptor,
+            ) {
+                state.scope.launch {
+                    val descUuid = descriptor.uuid.toKotlinUuid()
+                    if (descUuid == AndroidGattServer.CCCD_UUID) {
+                        val deviceId = Identifier(device.address)
+                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
+                        val key = AndroidGattServerState.SubscriptionKey(charUuid, deviceId)
+                        // Return the actual CCCD value the device wrote, or disabled
+                        val cccdValue =
+                            state.subscriptionModes[key]
+                                ?: BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, cccdValue)
+                    } else {
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, byteArrayOf())
+                    }
+                }
+            }
+
+            override fun onDescriptorWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                descriptor: BluetoothGattDescriptor,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray?,
+            ) {
+                state.scope.launch {
+                    val descUuid = descriptor.uuid.toKotlinUuid()
+                    if (descUuid == AndroidGattServer.CCCD_UUID && value != null) {
+                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
+                        handleCccdWrite(device, charUuid, value)
+                        if (responseNeeded) {
+                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+                        }
+                    } else {
+                        if (responseNeeded) {
+                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+                        }
+                    }
+                }
+            }
+
+            override fun onExecuteWrite(
+                device: BluetoothDevice,
+                requestId: Int,
+                execute: Boolean,
+            ) {
+                state.scope.launch {
+                    val fragments = state.preparedWriteBuffer.remove(device.address)
+                    val deviceId = Identifier(device.address)
+
+                    if (!execute || fragments.isNullOrEmpty()) {
+                        logEvent(
+                            BleLogEvent.ServerClientEvent(
+                                deviceId,
+                                if (execute) "execute-write (empty)" else "execute-write (cancelled)",
+                            ),
+                        )
+                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+                        return@launch
+                    }
+
+                    when (val result = assembleWriteFragments(fragments)) {
+                        is AssemblyResult.PayloadTooLarge -> {
+                            logEvent(
+                                BleLogEvent.ServerRequest(
+                                    deviceId,
+                                    "execute-write-rejected (${result.actualSize}B exceeds limit)",
+                                    result.charUuid,
+                                    GattStatus.InvalidAttributeLength,
+                                ),
+                            )
+                            sendResponseSafe(
+                                device,
+                                requestId,
+                                BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
+                                0,
+                                null,
+                            )
+                        }
+
+                        is AssemblyResult.Success -> {
+                            val gattStatus = dispatchAssembledWrites(deviceId, result.writes)
+                            sendResponseSafe(device, requestId, gattStatus, 0, null)
+                        }
+                    }
+                }
+            }
+
+            override fun onNotificationSent(
+                device: BluetoothDevice,
+                status: Int,
+            ) {
+                // Called on Binder thread - ConcurrentHashMap + CompletableDeferred are both thread-safe
+                state.pendingNotifySent.remove(device.address)?.complete(status)
+            }
+
+            override fun onServiceAdded(
+                status: Int,
+                service: android.bluetooth.BluetoothGattService,
+            ) {
+                // Called on Binder thread - @Volatile + CompletableDeferred.complete is thread-safe
+                state.pendingServiceAdd?.complete(status)
+            }
+
+            override fun onMtuChanged(
+                device: BluetoothDevice,
+                mtu: Int,
+            ) {
+                state.scope.launch {
+                    val deviceId = Identifier(device.address)
+                    state.updateMtu(deviceId, mtu)
+                }
+            }
+        }
+
+    // --- CCCD handling ---
+
+    private fun handleCccdWrite(
+        device: BluetoothDevice,
+        characteristicUuid: Uuid,
+        value: ByteArray,
+    ) {
+        val deviceId = Identifier(device.address)
+        if (value.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
+            state.removeSubscription(deviceId, characteristicUuid)
+        } else {
+            state.addSubscription(deviceId, characteristicUuid, value)
+        }
+    }
+
+    // --- Prepared write handling ---
+
+    private fun handlePreparedWrite(
+        device: BluetoothDevice,
+        deviceId: Identifier,
+        requestId: Int,
+        charUuid: Uuid,
+        offset: Int,
+        responseNeeded: Boolean,
+        value: ByteArray?,
+    ) {
+        if (state.writeHandlers[charUuid] == null) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "prepared-write-rejected (no handler)",
+                    charUuid,
+                    GattStatus.WriteNotPermitted,
+                ),
+            )
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+            }
+            return
+        }
+
+        val buffer = state.preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
+        val projectedSize = projectedBufferSize(buffer, offset, value?.size ?: 0)
+        if (projectedSize > MAX_PREPARED_WRITE_BUFFER_BYTES) {
+            state.preparedWriteBuffer.remove(device.address)
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "prepared-write-rejected (${projectedSize}B exceeds limit)",
+                    charUuid,
+                    GattStatus.InvalidAttributeLength,
+                ),
+            )
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
+            }
+            return
+        }
+
+        buffer.add(WriteFragment(charUuid, offset, value ?: byteArrayOf()))
+        logEvent(
+            BleLogEvent.ServerRequest(
+                deviceId,
+                "prepared-write (${value?.size ?: 0}B @$offset)",
+                charUuid,
+                GattStatus.Success,
+            ),
+        )
+        if (responseNeeded) {
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+        }
+    }
+
+    // --- Execute write dispatch ---
+
+    private suspend fun dispatchAssembledWrites(
+        deviceId: Identifier,
+        writes: List<AssembledWrite>,
+    ): Int {
+        for (write in writes) {
+            val handler = state.writeHandlers[write.charUuid]
+            if (handler == null) {
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write-rejected (no handler)",
+                        write.charUuid,
+                        GattStatus.WriteNotPermitted,
+                    ),
+                )
+                return BluetoothGatt.GATT_FAILURE
+            }
+
+            try {
+                val gattStatus = handler(deviceId, BleData(write.data), true)
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write (${write.data.size}B)",
+                        write.charUuid,
+                        gattStatus,
+                    ),
+                )
+                if (gattStatus != null && gattStatus != GattStatus.Success) {
+                    return BluetoothGatt.GATT_FAILURE
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write-failed (handler threw)",
+                        write.charUuid,
+                        GattStatus.Failure,
+                    ),
+                )
+                return BluetoothGatt.GATT_FAILURE
+            }
+        }
+        return BluetoothGatt.GATT_SUCCESS
+    }
+
+    // --- Safe response helper ---
+
+    private fun sendResponseSafe(
+        device: BluetoothDevice,
+        requestId: Int,
+        status: Int,
+        offset: Int,
+        value: ByteArray?,
+    ) {
+        if (!state.isOpen.get()) return
+        try {
+            state.nativeServer?.sendResponse(device, requestId, status, offset, value)
+        } catch (_: SecurityException) {
+            // Ignore - device disconnected or permission lost
+        }
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerExtensions.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerExtensions.kt
@@ -1,0 +1,27 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothGattCharacteristic
+
+/** Maps [ServerCharacteristic.Properties] to Android property flags. */
+internal fun ServerCharacteristic.Properties.toAndroidProperties(): Int {
+    var flags = 0
+    if (read) flags = flags or BluetoothGattCharacteristic.PROPERTY_READ
+    if (write) flags = flags or BluetoothGattCharacteristic.PROPERTY_WRITE
+    if (writeWithoutResponse) flags = flags or BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE
+    if (notify) flags = flags or BluetoothGattCharacteristic.PROPERTY_NOTIFY
+    if (indicate) flags = flags or BluetoothGattCharacteristic.PROPERTY_INDICATE
+    return flags
+}
+
+/** Maps [ServerCharacteristic.Permissions] to Android permission flags. */
+internal fun ServerCharacteristic.Permissions.toAndroidPermissions(): Int {
+    var flags = 0
+    if (read) flags = flags or BluetoothGattCharacteristic.PERMISSION_READ
+    if (readEncrypted) flags = flags or BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED
+    if (write) flags = flags or BluetoothGattCharacteristic.PERMISSION_WRITE
+    if (writeEncrypted) flags = flags or BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED
+    return flags
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerSetup.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerSetup.kt
@@ -1,0 +1,183 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.peripheral.toGattStatus
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.uuid.toJavaUuid
+import kotlin.uuid.toKotlinUuid
+
+// =============================================================================
+// Setup helpers
+// =============================================================================
+
+/**
+ * Opens the native [BluetoothGattServer], registers handlers, and adds services.
+ * Called once from [AndroidGattServer.open] on the serial dispatcher.
+ */
+internal suspend fun AndroidGattServerState.openInternal(instanceLock: AtomicBoolean) {
+    val bluetoothManager =
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+            ?: throw ServerException.NotSupported("BluetoothManager not available")
+
+    val adapter =
+        bluetoothManager.adapter
+            ?: throw ServerException.NotSupported("Bluetooth adapter not available")
+
+    if (!adapter.isEnabled) {
+        throw ServerException.OpenFailed("Bluetooth is not enabled")
+    }
+
+    val server =
+        try {
+            bluetoothManager.openGattServer(context, callback.callback)
+        } catch (e: SecurityException) {
+            throw ServerException.OpenFailed("Missing BLUETOOTH_CONNECT permission", e)
+        } ?: throw ServerException.OpenFailed("openGattServer returned null")
+
+    nativeServer = server
+
+    // Register handlers from service definitions
+    for (serviceDef in serviceDefinitions) {
+        for (charDef in serviceDef.characteristics) {
+            charDef.readHandler?.let { readHandlers[charDef.uuid] = it }
+            charDef.writeHandler?.let { writeHandlers[charDef.uuid] = it }
+        }
+    }
+
+    // Add services sequentially (must wait for onServiceAdded for each)
+    for (serviceDef in serviceDefinitions) {
+        val nativeService = buildNativeService(serviceDef)
+        val deferred = CompletableDeferred<Int>()
+        pendingServiceAdd = deferred
+        if (!server.addService(nativeService)) {
+            pendingServiceAdd = null
+            throw ServerException.OpenFailed("addService returned false for ${serviceDef.uuid}")
+        }
+        val addStatus = deferred.await()
+        pendingServiceAdd = null
+        if (addStatus != BluetoothGatt.GATT_SUCCESS) {
+            throw ServerException.OpenFailed(
+                "addService failed for ${serviceDef.uuid} with status ${addStatus.toGattStatus()}",
+            )
+        }
+        logEvent(BleLogEvent.ServerLifecycle("service added: ${serviceDef.uuid}"))
+    }
+
+    // Build O(1) characteristic lookup cache
+    for (service in server.services) {
+        for (char in service.characteristics) {
+            characteristicCache[char.uuid.toKotlinUuid()] = char
+        }
+    }
+
+    isOpen.set(true)
+    logEvent(BleLogEvent.ServerLifecycle("open (${serviceDefinitions.size} services)"))
+}
+
+/**
+ * Converts a [ServiceDefinition] to an Android [BluetoothGattService]
+ * with auto-added CCCD descriptors and user-defined descriptors.
+ */
+internal fun buildNativeService(definition: ServiceDefinition): BluetoothGattService {
+    val service =
+        BluetoothGattService(
+            definition.uuid.toJavaUuid(),
+            BluetoothGattService.SERVICE_TYPE_PRIMARY,
+        )
+
+    for (charDef in definition.characteristics) {
+        val characteristic =
+            BluetoothGattCharacteristic(
+                charDef.uuid.toJavaUuid(),
+                charDef.properties.toAndroidProperties(),
+                charDef.permissions.toAndroidPermissions(),
+            )
+
+        // Auto-add CCCD if notify or indicate
+        if (charDef.properties.notify || charDef.properties.indicate) {
+            val cccd =
+                BluetoothGattDescriptor(
+                    AndroidGattServer.CCCD_UUID.toJavaUuid(),
+                    BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
+                )
+            characteristic.addDescriptor(cccd)
+        }
+
+        // Add user-defined descriptors
+        for (descDef in charDef.descriptors) {
+            characteristic.addDescriptor(
+                BluetoothGattDescriptor(descDef.uuid.toJavaUuid(), BluetoothGattDescriptor.PERMISSION_READ),
+            )
+        }
+
+        service.addCharacteristic(characteristic)
+    }
+
+    return service
+}
+
+// =============================================================================
+// Notify/indicate delivery
+// =============================================================================
+
+/**
+ * Send a notification or indication to a device and await `onNotificationSent`.
+ *
+ * Android's BLE stack requires waiting for onNotificationSent before sending
+ * the next notification to the same device. This function serializes per-device
+ * and handles both notifications (confirm=false) and indications (confirm=true).
+ *
+ * @return The GATT status from onNotificationSent
+ */
+internal suspend fun AndroidGattServerState.awaitNotifySend(
+    server: BluetoothGattServer,
+    device: BluetoothDevice,
+    characteristic: BluetoothGattCharacteristic,
+    data: ByteArray,
+    confirm: Boolean,
+): Int {
+    val deferred = CompletableDeferred<Int>()
+    pendingNotifySent[device.address] = deferred
+
+    try {
+        notifyDevice(server, device, characteristic, data, confirm)
+    } catch (e: Exception) {
+        pendingNotifySent.remove(device.address)
+        throw e
+    }
+
+    return try {
+        withTimeout(AndroidGattServer.NOTIFY_TIMEOUT_MS) { deferred.await() }
+    } catch (_: TimeoutCancellationException) {
+        pendingNotifySent.remove(device.address)
+        throw ServerException.NotifyFailed(
+            if (confirm) "Indication timed out" else "Notification timed out",
+        )
+    }
+}
+
+/** Calls [BluetoothGattServer.notifyCharacteristicChanged] on the native server. */
+internal fun notifyDevice(
+    server: BluetoothGattServer,
+    device: BluetoothDevice,
+    characteristic: BluetoothGattCharacteristic,
+    data: ByteArray,
+    confirm: Boolean,
+) {
+    server.notifyCharacteristicChanged(device, characteristic, confirm, data)
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerState.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerState.kt
@@ -1,0 +1,208 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.content.Context
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.Volatile
+import kotlin.uuid.Uuid
+
+/**
+ * Mutable state for [AndroidGattServer]. Owns all connection tracking,
+ * subscription management, handler registries, and lifecycle flags.
+ *
+ * All mutable state is accessed exclusively on [dispatcher] (limitedParallelism(1))
+ * unless noted otherwise. Thread-safe fields accessed from Binder threads:
+ * - [pendingNotifySent]: ConcurrentHashMap, CompletableDeferred.complete is safe
+ * - [pendingServiceAdd]: @Volatile, CompletableDeferred.complete is safe
+ * - [isOpen]/[isClosed]: AtomicBoolean for atomic visibility
+ */
+internal class AndroidGattServerState(
+    val context: Context,
+    val serviceDefinitions: List<ServiceDefinition>,
+) {
+    val dispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1)
+    val scope: CoroutineScope =
+        CoroutineScope(SupervisorJob() + dispatcher + CoroutineName("GattServer"))
+
+    // --- Flow properties ---
+    private val _connections = MutableStateFlow<List<ServerConnection>>(emptyList())
+    val connections: StateFlow<List<ServerConnection>> = _connections.asStateFlow()
+
+    // Use tryEmit to avoid blocking Binder callback thread on slow collectors.
+    private val _connectionEvents = MutableSharedFlow<ServerConnectionEvent>(extraBufferCapacity = 64)
+    val connectionEvents: Flow<ServerConnectionEvent> = _connectionEvents.asSharedFlow()
+
+    // --- Connection tracking ---
+    val connectedDevices = mutableMapOf<Identifier, BluetoothDevice>()
+    val deviceMtu = mutableMapOf<Identifier, Int>()
+
+    fun addConnection(
+        deviceId: Identifier,
+        device: BluetoothDevice,
+    ) {
+        connectedDevices[deviceId] = device
+        val connectionCount = connectedDevices.size
+        _connections.update { list -> list + ServerConnection(deviceId, device.name) }
+        logEvent(BleLogEvent.ServerClientEvent(deviceId, "connected ($connectionCount total)"))
+        if (connectionCount >= CONNECTION_WARNING_THRESHOLD) {
+            logEvent(
+                BleLogEvent.Error(
+                    deviceId,
+                    "High connection count ($connectionCount). Android typically supports " +
+                        "7-15 concurrent BLE connections depending on device. New connections " +
+                        "may be silently rejected.",
+                    null,
+                ),
+            )
+        }
+        if (!_connectionEvents.tryEmit(ServerConnectionEvent.Connected(deviceId))) {
+            logEvent(
+                BleLogEvent.Error(deviceId, "Connection event buffer full, event dropped", null),
+            )
+        }
+    }
+
+    fun removeConnection(
+        deviceId: Identifier,
+        deviceAddress: String,
+    ) {
+        connectedDevices.remove(deviceId)
+        deviceMtu.remove(deviceId)
+        _connections.update { list -> list.filter { it.device != deviceId } }
+        logEvent(BleLogEvent.ServerClientEvent(deviceId, "disconnected"))
+        if (!_connectionEvents.tryEmit(ServerConnectionEvent.Disconnected(deviceId))) {
+            logEvent(
+                BleLogEvent.Error(deviceId, "Connection event buffer full, event dropped", null),
+            )
+        }
+    }
+
+    // --- Subscription tracking ---
+    data class SubscriptionKey(
+        val characteristicUuid: Uuid,
+        val device: Identifier,
+    )
+
+    val subscriptionModes = mutableMapOf<SubscriptionKey, ByteArray>()
+
+    // Secondary index: characteristic UUID -> set of subscribed device identifiers.
+    // Maintained in sync with subscriptionModes for O(1) broadcast notify lookup.
+    val subscribersByChar = mutableMapOf<Uuid, MutableSet<Identifier>>()
+
+    fun addSubscription(
+        deviceId: Identifier,
+        charUuid: Uuid,
+        value: ByteArray,
+    ) {
+        val key = SubscriptionKey(charUuid, deviceId)
+        subscriptionModes[key] = value.copyOf()
+        subscribersByChar.getOrPut(charUuid) { mutableSetOf() }.add(deviceId)
+        val mode =
+            when {
+                value.contentEquals(
+                    BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE,
+                ) -> "notifications"
+                value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) -> "indications"
+                else -> "unknown mode"
+            }
+        logEvent(BleLogEvent.ServerClientEvent(deviceId, "subscribed to $charUuid ($mode)"))
+    }
+
+    fun removeSubscription(
+        deviceId: Identifier,
+        charUuid: Uuid,
+    ) {
+        val key = SubscriptionKey(charUuid, deviceId)
+        subscriptionModes.remove(key)
+        subscribersByChar[charUuid]?.remove(deviceId)
+        logEvent(BleLogEvent.ServerClientEvent(deviceId, "unsubscribed from $charUuid"))
+    }
+
+    fun removeAllSubscriptions(deviceId: Identifier) {
+        subscriptionModes.keys.removeAll { it.device == deviceId }
+        for ((_, subscribers) in subscribersByChar) {
+            subscribers.remove(deviceId)
+        }
+    }
+
+    fun cancelPendingNotify(
+        deviceAddress: String,
+        message: String,
+    ) {
+        pendingNotifySent.remove(deviceAddress)?.cancel(CancellationException(message))
+    }
+
+    // --- Handler registries ---
+    val readHandlers = mutableMapOf<Uuid, suspend (Identifier) -> BleData>()
+    val writeHandlers =
+        mutableMapOf<Uuid, suspend (Identifier, BleData, Boolean) -> GattStatus?>()
+
+    // --- Prepared write buffer ---
+    val preparedWriteBuffer = mutableMapOf<String, MutableList<WriteFragment>>()
+
+    // --- Characteristic cache ---
+    val characteristicCache = mutableMapOf<Uuid, BluetoothGattCharacteristic>()
+
+    // --- Thread-safe fields ---
+    val pendingNotifySent = ConcurrentHashMap<String, CompletableDeferred<Int>>()
+
+    @Volatile
+    var pendingServiceAdd: CompletableDeferred<Int>? = null
+
+    // --- Native server ---
+    @Volatile
+    var nativeServer: BluetoothGattServer? = null
+
+    // --- Lifecycle flags ---
+    val isOpen = AtomicBoolean(false)
+    val isClosed = AtomicBoolean(false)
+
+    // --- Callback ---
+    val callback = AndroidGattServerCallback(this)
+
+    // --- Helper methods for connection tracking ---
+    fun tryEmitConnectionEvent(event: ServerConnectionEvent): Boolean = _connectionEvents.tryEmit(event)
+
+    fun updateMtu(
+        deviceId: Identifier,
+        mtu: Int,
+    ) {
+        deviceMtu[deviceId] = mtu
+        logEvent(BleLogEvent.ServerClientEvent(deviceId, "MTU changed to $mtu"))
+    }
+
+    fun clearConnections() {
+        _connections.value = emptyList()
+    }
+
+    companion object {
+        const val CONNECTION_WARNING_THRESHOLD = 7
+    }
+}


### PR DESCRIPTION
## Problem
AndroidGattServer.kt at 1003 lines was 3.3x over the 300-line target. Monolithic class combined mutable state, Binder callback dispatch, setup logic, and extension functions.

## Approach
Applied the Class Decomposition Pattern (Facade/Registry/Emitter):

| File | Lines | Role |
|------|-------|------|
| AndroidGattServer.kt | 286 | Thin facade: open, close, notify, indicate |
| AndroidGattServerState.kt | 204 | State registry: connections, subscriptions, handlers |
| AndroidGattServerCallback.kt | 444 | Binder callback: 9 GATT callback overrides + dispatch |
| AndroidGattServerSetup.kt | 183 | Setup helpers: openInternal, buildNativeService, notify delivery |
| AndroidGattServerExtensions.kt | 27 | Property/permission flag mapping |

All files under 300 lines except the callback (inherently verbose due to 9 required BluetoothGattServerCallback overrides).

No behavioral changes -- pure decomposition. Public API (GattServer interface) unchanged. Factory unchanged.