### PR TITLE
fix(server): rethrow CancellationException in notify() async catch block

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -155,6 +155,7 @@ internal class AndroidGattServer(
                         try {
                             state.awaitNotifySend(server, target, nativeChar, dataBytes, confirm = false)
                         } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             logEvent(BleLogEvent.Error(Identifier(target.address), "notify failed", e))
                         }
                     }


### PR DESCRIPTION
## Problem
The `async{}` block inside `targets.map{}.awaitAll()` in `AndroidGattServer.notify()` caught `Exception` generically and swallowed `CancellationException`, preventing clean structured cancellation propagation to the parent coroutine.

## Approach
Add explicit `if (e is CancellationException) throw e` guard before logging the failure, matching the established pattern used in L2CAP open paths (`IosPeripheral.kt`, `AndroidPeripheral.kt`) and `StateRestorationHandler`.

## Files changed
- `src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt` (+1 line)

Closes #241