### PR TITLE
refactor(server): decompose AndroidGattServerCallback (444→126 loc)

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
@@ -4,32 +4,24 @@ package com.atruedev.kmpble.server
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattServerCallback
-import android.bluetooth.BluetoothProfile
-import com.atruedev.kmpble.BleData
-import com.atruedev.kmpble.Identifier
-import com.atruedev.kmpble.emptyBleData
-import com.atruedev.kmpble.error.GattStatus
-import com.atruedev.kmpble.logging.BleLogEvent
-import com.atruedev.kmpble.logging.logEvent
-import com.atruedev.kmpble.peripheral.toAndroidGattStatus
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.launch
-import kotlin.uuid.Uuid
-import kotlin.uuid.toKotlinUuid
+import android.bluetooth.BluetoothGattService
 
 /**
- * BluetoothGattServerCallback that dispatches all Binder-thread callbacks
+ * [BluetoothGattServerCallback] that dispatches Binder-thread callbacks
  * onto [state.scope] for serialized processing on [state.dispatcher].
  *
- * Handles connection state changes, read/write requests, descriptor operations,
- * prepared write execution, notification sent, service added, and MTU changes.
+ * Logic is extracted into focused handler files:
+ * - [AndroidGattServerConnectionHandlers.kt] — connection, MTU
+ * - [AndroidGattServerReadHandlers.kt] — read, descriptor read, prepared writes
+ * - [AndroidGattServerWriteHandlers.kt] — write, descriptor write, execute write, CCCD
+ *
+ * This file wires the callback overrides to their handlers.
  */
 internal class AndroidGattServerCallback(
-    private val state: AndroidGattServerState,
+    internal val state: AndroidGattServerState,
 ) {
     val callback: BluetoothGattServerCallback =
         object : BluetoothGattServerCallback() {
@@ -38,20 +30,7 @@ internal class AndroidGattServerCallback(
                 status: Int,
                 newState: Int,
             ) {
-                state.scope.launch {
-                    val deviceId = Identifier(device.address)
-                    when (newState) {
-                        BluetoothProfile.STATE_CONNECTED -> {
-                            state.addConnection(deviceId, device)
-                        }
-
-                        BluetoothProfile.STATE_DISCONNECTED -> {
-                            state.removeConnection(deviceId, device.address)
-                            state.removeAllSubscriptions(deviceId)
-                            state.cancelPendingNotify(device.address, "Device disconnected")
-                        }
-                    }
-                }
+                handleConnectionStateChange(device, status, newState)
             }
 
             override fun onCharacteristicReadRequest(
@@ -60,57 +39,7 @@ internal class AndroidGattServerCallback(
                 offset: Int,
                 characteristic: BluetoothGattCharacteristic,
             ) {
-                state.scope.launch {
-                    val deviceId = Identifier(device.address)
-                    val charUuid = characteristic.uuid.toKotlinUuid()
-                    val handler = state.readHandlers[charUuid]
-
-                    if (handler == null) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read-rejected (no handler)",
-                                charUuid,
-                                GattStatus.ReadNotPermitted,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
-                        return@launch
-                    }
-
-                    try {
-                        val bleData = handler(deviceId)
-                        val responseData =
-                            if (offset > 0 && offset < bleData.size) {
-                                bleData.slice(offset, bleData.size).toByteArray()
-                            } else if (offset >= bleData.size && offset > 0) {
-                                byteArrayOf()
-                            } else {
-                                bleData.toByteArray()
-                            }
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read (${responseData.size}B, offset=$offset)",
-                                charUuid,
-                                GattStatus.Success,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "read-failed (handler threw)",
-                                charUuid,
-                                GattStatus.Failure,
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
-                    }
-                }
+                handleCharacteristicReadRequest(device, requestId, offset, characteristic)
             }
 
             override fun onCharacteristicWriteRequest(
@@ -122,63 +51,15 @@ internal class AndroidGattServerCallback(
                 offset: Int,
                 value: ByteArray?,
             ) {
-                state.scope.launch {
-                    val deviceId = Identifier(device.address)
-                    val charUuid = characteristic.uuid.toKotlinUuid()
-
-                    if (preparedWrite) {
-                        handlePreparedWrite(device, deviceId, requestId, charUuid, offset, responseNeeded, value)
-                        return@launch
-                    }
-
-                    val handler = state.writeHandlers[charUuid]
-                    if (handler == null) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "write-rejected (no handler)",
-                                charUuid,
-                                GattStatus.WriteNotPermitted,
-                            ),
-                        )
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
-                        }
-                        return@launch
-                    }
-
-                    try {
-                        val bleData =
-                            if (value != null && value.isNotEmpty()) {
-                                BleData(value)
-                            } else {
-                                emptyBleData()
-                            }
-                        val gattStatus = handler(deviceId, bleData, responseNeeded)
-                        logEvent(
-                            BleLogEvent.ServerRequest(deviceId, "write (${value?.size ?: 0}B)", charUuid, gattStatus),
-                        )
-                        if (responseNeeded) {
-                            val nativeStatus =
-                                gattStatus?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
-                            sendResponseSafe(device, requestId, nativeStatus, offset, null)
-                        }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        logEvent(
-                            BleLogEvent.ServerRequest(
-                                deviceId,
-                                "write-failed (handler threw)",
-                                charUuid,
-                                GattStatus.Failure,
-                            ),
-                        )
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
-                        }
-                    }
-                }
+                handleCharacteristicWriteRequest(
+                    device,
+                    requestId,
+                    characteristic,
+                    preparedWrite,
+                    responseNeeded,
+                    offset,
+                    value,
+                )
             }
 
             override fun onDescriptorReadRequest(
@@ -187,21 +68,7 @@ internal class AndroidGattServerCallback(
                 offset: Int,
                 descriptor: BluetoothGattDescriptor,
             ) {
-                state.scope.launch {
-                    val descUuid = descriptor.uuid.toKotlinUuid()
-                    if (descUuid == AndroidGattServer.CCCD_UUID) {
-                        val deviceId = Identifier(device.address)
-                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
-                        val key = AndroidGattServerState.SubscriptionKey(charUuid, deviceId)
-                        // Return the actual CCCD value the device wrote, or disabled
-                        val cccdValue =
-                            state.subscriptionModes[key]
-                                ?: BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, cccdValue)
-                    } else {
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, byteArrayOf())
-                    }
-                }
+                handleDescriptorReadRequest(device, requestId, offset, descriptor)
             }
 
             override fun onDescriptorWriteRequest(
@@ -213,20 +80,15 @@ internal class AndroidGattServerCallback(
                 offset: Int,
                 value: ByteArray?,
             ) {
-                state.scope.launch {
-                    val descUuid = descriptor.uuid.toKotlinUuid()
-                    if (descUuid == AndroidGattServer.CCCD_UUID && value != null) {
-                        val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
-                        handleCccdWrite(device, charUuid, value)
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
-                        }
-                    } else {
-                        if (responseNeeded) {
-                            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
-                        }
-                    }
-                }
+                handleDescriptorWriteRequest(
+                    device,
+                    requestId,
+                    descriptor,
+                    preparedWrite,
+                    responseNeeded,
+                    offset,
+                    value,
+                )
             }
 
             override fun onExecuteWrite(
@@ -234,61 +96,20 @@ internal class AndroidGattServerCallback(
                 requestId: Int,
                 execute: Boolean,
             ) {
-                state.scope.launch {
-                    val fragments = state.preparedWriteBuffer.remove(device.address)
-                    val deviceId = Identifier(device.address)
-
-                    if (!execute || fragments.isNullOrEmpty()) {
-                        logEvent(
-                            BleLogEvent.ServerClientEvent(
-                                deviceId,
-                                if (execute) "execute-write (empty)" else "execute-write (cancelled)",
-                            ),
-                        )
-                        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-                        return@launch
-                    }
-
-                    when (val result = assembleWriteFragments(fragments)) {
-                        is AssemblyResult.PayloadTooLarge -> {
-                            logEvent(
-                                BleLogEvent.ServerRequest(
-                                    deviceId,
-                                    "execute-write-rejected (${result.actualSize}B exceeds limit)",
-                                    result.charUuid,
-                                    GattStatus.InvalidAttributeLength,
-                                ),
-                            )
-                            sendResponseSafe(
-                                device,
-                                requestId,
-                                BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
-                                0,
-                                null,
-                            )
-                        }
-
-                        is AssemblyResult.Success -> {
-                            val gattStatus = dispatchAssembledWrites(deviceId, result.writes)
-                            sendResponseSafe(device, requestId, gattStatus, 0, null)
-                        }
-                    }
-                }
+                handleExecuteWrite(device, requestId, execute)
             }
 
             override fun onNotificationSent(
                 device: BluetoothDevice,
                 status: Int,
             ) {
-                // Called on Binder thread - ConcurrentHashMap + CompletableDeferred are both thread-safe
                 state.pendingNotifySent.remove(device.address)?.complete(status)
             }
 
             override fun onServiceAdded(
                 status: Int,
-                service: android.bluetooth.BluetoothGattService,
+                service: BluetoothGattService,
             ) {
-                // Called on Binder thread - @Volatile + CompletableDeferred.complete is thread-safe
                 state.pendingServiceAdd?.complete(status)
             }
 
@@ -296,138 +117,11 @@ internal class AndroidGattServerCallback(
                 device: BluetoothDevice,
                 mtu: Int,
             ) {
-                state.scope.launch {
-                    val deviceId = Identifier(device.address)
-                    state.updateMtu(deviceId, mtu)
-                }
+                handleMtuChanged(device, mtu)
             }
         }
 
-    // --- CCCD handling ---
-
-    private fun handleCccdWrite(
-        device: BluetoothDevice,
-        characteristicUuid: Uuid,
-        value: ByteArray,
-    ) {
-        val deviceId = Identifier(device.address)
-        if (value.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
-            state.removeSubscription(deviceId, characteristicUuid)
-        } else {
-            state.addSubscription(deviceId, characteristicUuid, value)
-        }
-    }
-
-    // --- Prepared write handling ---
-
-    private fun handlePreparedWrite(
-        device: BluetoothDevice,
-        deviceId: Identifier,
-        requestId: Int,
-        charUuid: Uuid,
-        offset: Int,
-        responseNeeded: Boolean,
-        value: ByteArray?,
-    ) {
-        if (state.writeHandlers[charUuid] == null) {
-            logEvent(
-                BleLogEvent.ServerRequest(
-                    deviceId,
-                    "prepared-write-rejected (no handler)",
-                    charUuid,
-                    GattStatus.WriteNotPermitted,
-                ),
-            )
-            if (responseNeeded) {
-                sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
-            }
-            return
-        }
-
-        val buffer = state.preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
-        val projectedSize = projectedBufferSize(buffer, offset, value?.size ?: 0)
-        if (projectedSize > MAX_PREPARED_WRITE_BUFFER_BYTES) {
-            state.preparedWriteBuffer.remove(device.address)
-            logEvent(
-                BleLogEvent.ServerRequest(
-                    deviceId,
-                    "prepared-write-rejected (${projectedSize}B exceeds limit)",
-                    charUuid,
-                    GattStatus.InvalidAttributeLength,
-                ),
-            )
-            if (responseNeeded) {
-                sendResponseSafe(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
-            }
-            return
-        }
-
-        buffer.add(WriteFragment(charUuid, offset, value ?: byteArrayOf()))
-        logEvent(
-            BleLogEvent.ServerRequest(
-                deviceId,
-                "prepared-write (${value?.size ?: 0}B @$offset)",
-                charUuid,
-                GattStatus.Success,
-            ),
-        )
-        if (responseNeeded) {
-            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
-        }
-    }
-
-    // --- Execute write dispatch ---
-
-    private suspend fun dispatchAssembledWrites(
-        deviceId: Identifier,
-        writes: List<AssembledWrite>,
-    ): Int {
-        for (write in writes) {
-            val handler = state.writeHandlers[write.charUuid]
-            if (handler == null) {
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write-rejected (no handler)",
-                        write.charUuid,
-                        GattStatus.WriteNotPermitted,
-                    ),
-                )
-                return BluetoothGatt.GATT_FAILURE
-            }
-
-            try {
-                val gattStatus = handler(deviceId, BleData(write.data), true)
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write (${write.data.size}B)",
-                        write.charUuid,
-                        gattStatus,
-                    ),
-                )
-                if (gattStatus != null && gattStatus != GattStatus.Success) {
-                    return BluetoothGatt.GATT_FAILURE
-                }
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                logEvent(
-                    BleLogEvent.ServerRequest(
-                        deviceId,
-                        "execute-write-failed (handler threw)",
-                        write.charUuid,
-                        GattStatus.Failure,
-                    ),
-                )
-                return BluetoothGatt.GATT_FAILURE
-            }
-        }
-        return BluetoothGatt.GATT_SUCCESS
-    }
-
-    // --- Safe response helper ---
-
-    private fun sendResponseSafe(
+    internal fun sendResponseSafe(
         device: BluetoothDevice,
         requestId: Int,
         status: Int,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerConnectionHandlers.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerConnectionHandlers.kt
@@ -1,0 +1,46 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothProfile
+import com.atruedev.kmpble.Identifier
+import kotlinx.coroutines.launch
+
+/**
+ * Extension functions for [AndroidGattServerCallback] that handle connection
+ * lifecycle callbacks (connect, disconnect, MTU change).
+ *
+ * Extracted from [AndroidGattServerCallback] during decomposition (PR #243).
+ */
+internal fun AndroidGattServerCallback.handleConnectionStateChange(
+    device: BluetoothDevice,
+    status: Int,
+    newState: Int,
+) {
+    state.scope.launch {
+        val deviceId = Identifier(device.address)
+        when (newState) {
+            BluetoothProfile.STATE_CONNECTED -> {
+                state.addConnection(deviceId, device)
+            }
+
+            BluetoothProfile.STATE_DISCONNECTED -> {
+                state.removeConnection(deviceId, device.address)
+                state.removeAllSubscriptions(deviceId)
+                state.cancelPendingNotify(device.address, "Device disconnected")
+            }
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handleMtuChanged(
+    device: BluetoothDevice,
+    mtu: Int,
+) {
+    state.scope.launch {
+        val deviceId = Identifier(device.address)
+        state.updateMtu(deviceId, mtu)
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerReadHandlers.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerReadHandlers.kt
@@ -1,0 +1,160 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * Extension functions for [AndroidGattServerCallback] that handle read requests,
+ * descriptor read requests, and prepared-write buffering.
+ *
+ * Extracted from [AndroidGattServerCallback] during decomposition (PR #243).
+ */
+
+internal fun AndroidGattServerCallback.handleCharacteristicReadRequest(
+    device: BluetoothDevice,
+    requestId: Int,
+    offset: Int,
+    characteristic: BluetoothGattCharacteristic,
+) {
+    state.scope.launch {
+        val deviceId = Identifier(device.address)
+        val charUuid = characteristic.uuid.toKotlinUuid()
+        val handler = state.readHandlers[charUuid]
+
+        if (handler == null) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "read-rejected (no handler)",
+                    charUuid,
+                    GattStatus.ReadNotPermitted,
+                ),
+            )
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+            return@launch
+        }
+
+        try {
+            val bleData = handler(deviceId)
+            val responseData =
+                if (offset > 0 && offset < bleData.size) {
+                    bleData.slice(offset, bleData.size).toByteArray()
+                } else if (offset >= bleData.size && offset > 0) {
+                    byteArrayOf()
+                } else {
+                    bleData.toByteArray()
+                }
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "read (${responseData.size}B, offset=$offset)",
+                    charUuid,
+                    GattStatus.Success,
+                ),
+            )
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseData)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "read-failed (handler threw)",
+                    charUuid,
+                    GattStatus.Failure,
+                ),
+            )
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handleDescriptorReadRequest(
+    device: BluetoothDevice,
+    requestId: Int,
+    offset: Int,
+    descriptor: BluetoothGattDescriptor,
+) {
+    state.scope.launch {
+        val descUuid = descriptor.uuid.toKotlinUuid()
+        if (descUuid == AndroidGattServer.CCCD_UUID) {
+            val deviceId = Identifier(device.address)
+            val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
+            val key = AndroidGattServerState.SubscriptionKey(charUuid, deviceId)
+            val cccdValue =
+                state.subscriptionModes[key]
+                    ?: BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, cccdValue)
+        } else {
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, byteArrayOf())
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handlePreparedWrite(
+    device: BluetoothDevice,
+    deviceId: Identifier,
+    requestId: Int,
+    charUuid: kotlin.uuid.Uuid,
+    offset: Int,
+    responseNeeded: Boolean,
+    value: ByteArray?,
+) {
+    if (state.writeHandlers[charUuid] == null) {
+        logEvent(
+            BleLogEvent.ServerRequest(
+                deviceId,
+                "prepared-write-rejected (no handler)",
+                charUuid,
+                GattStatus.WriteNotPermitted,
+            ),
+        )
+        if (responseNeeded) {
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+        }
+        return
+    }
+
+    val buffer = state.preparedWriteBuffer.getOrPut(device.address) { mutableListOf() }
+    val projectedSize = projectedBufferSize(buffer, offset, value?.size ?: 0)
+    if (projectedSize > MAX_PREPARED_WRITE_BUFFER_BYTES) {
+        state.preparedWriteBuffer.remove(device.address)
+        logEvent(
+            BleLogEvent.ServerRequest(
+                deviceId,
+                "prepared-write-rejected (${projectedSize}B exceeds limit)",
+                charUuid,
+                GattStatus.InvalidAttributeLength,
+            ),
+        )
+        if (responseNeeded) {
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
+        }
+        return
+    }
+
+    buffer.add(WriteFragment(charUuid, offset, value ?: byteArrayOf()))
+    logEvent(
+        BleLogEvent.ServerRequest(
+            deviceId,
+            "prepared-write (${value?.size ?: 0}B @$offset)",
+            charUuid,
+            GattStatus.Success,
+        ),
+    )
+    if (responseNeeded) {
+        sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerWriteHandlers.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerWriteHandlers.kt
@@ -1,0 +1,227 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.server
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.emptyBleData
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.peripheral.toAndroidGattStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * Extension functions for [AndroidGattServerCallback] that handle write requests,
+ * descriptor write requests, execute-write dispatch, and CCCD management.
+ *
+ * Extracted from [AndroidGattServerCallback] during decomposition (PR #243).
+ */
+
+internal fun AndroidGattServerCallback.handleCharacteristicWriteRequest(
+    device: BluetoothDevice,
+    requestId: Int,
+    characteristic: BluetoothGattCharacteristic,
+    preparedWrite: Boolean,
+    responseNeeded: Boolean,
+    offset: Int,
+    value: ByteArray?,
+) {
+    state.scope.launch {
+        val deviceId = Identifier(device.address)
+        val charUuid = characteristic.uuid.toKotlinUuid()
+
+        if (preparedWrite) {
+            handlePreparedWrite(device, deviceId, requestId, charUuid, offset, responseNeeded, value)
+            return@launch
+        }
+
+        val handler = state.writeHandlers[charUuid]
+        if (handler == null) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "write-rejected (no handler)",
+                    charUuid,
+                    GattStatus.WriteNotPermitted,
+                ),
+            )
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+            }
+            return@launch
+        }
+
+        try {
+            val bleData =
+                if (value != null && value.isNotEmpty()) {
+                    BleData(value)
+                } else {
+                    emptyBleData()
+                }
+            val gattStatus = handler(deviceId, bleData, responseNeeded)
+            logEvent(
+                BleLogEvent.ServerRequest(deviceId, "write (${value?.size ?: 0}B)", charUuid, gattStatus),
+            )
+            if (responseNeeded) {
+                val nativeStatus =
+                    gattStatus?.toAndroidGattStatus() ?: BluetoothGatt.GATT_SUCCESS
+                sendResponseSafe(device, requestId, nativeStatus, offset, null)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "write-failed (handler threw)",
+                    charUuid,
+                    GattStatus.Failure,
+                ),
+            )
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
+            }
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handleDescriptorWriteRequest(
+    device: BluetoothDevice,
+    requestId: Int,
+    descriptor: BluetoothGattDescriptor,
+    preparedWrite: Boolean,
+    responseNeeded: Boolean,
+    offset: Int,
+    value: ByteArray?,
+) {
+    state.scope.launch {
+        val descUuid = descriptor.uuid.toKotlinUuid()
+        if (descUuid == AndroidGattServer.CCCD_UUID && value != null) {
+            val charUuid = descriptor.characteristic.uuid.toKotlinUuid()
+            handleCccdWrite(device, charUuid, value)
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+        } else {
+            if (responseNeeded) {
+                sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handleExecuteWrite(
+    device: BluetoothDevice,
+    requestId: Int,
+    execute: Boolean,
+) {
+    state.scope.launch {
+        val fragments = state.preparedWriteBuffer.remove(device.address)
+        val deviceId = Identifier(device.address)
+
+        if (!execute || fragments.isNullOrEmpty()) {
+            logEvent(
+                BleLogEvent.ServerClientEvent(
+                    deviceId,
+                    if (execute) "execute-write (empty)" else "execute-write (cancelled)",
+                ),
+            )
+            sendResponseSafe(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+            return@launch
+        }
+
+        when (val result = assembleWriteFragments(fragments)) {
+            is AssemblyResult.PayloadTooLarge -> {
+                logEvent(
+                    BleLogEvent.ServerRequest(
+                        deviceId,
+                        "execute-write-rejected (${result.actualSize}B exceeds limit)",
+                        result.charUuid,
+                        GattStatus.InvalidAttributeLength,
+                    ),
+                )
+                sendResponseSafe(
+                    device,
+                    requestId,
+                    BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH,
+                    0,
+                    null,
+                )
+            }
+
+            is AssemblyResult.Success -> {
+                val gattStatus = dispatchAssembledWrites(deviceId, result.writes)
+                sendResponseSafe(device, requestId, gattStatus, 0, null)
+            }
+        }
+    }
+}
+
+internal fun AndroidGattServerCallback.handleCccdWrite(
+    device: BluetoothDevice,
+    characteristicUuid: Uuid,
+    value: ByteArray,
+) {
+    val deviceId = Identifier(device.address)
+    if (value.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)) {
+        state.removeSubscription(deviceId, characteristicUuid)
+    } else {
+        state.addSubscription(deviceId, characteristicUuid, value)
+    }
+}
+
+internal suspend fun AndroidGattServerCallback.dispatchAssembledWrites(
+    deviceId: Identifier,
+    writes: List<AssembledWrite>,
+): Int {
+    for (write in writes) {
+        val handler = state.writeHandlers[write.charUuid]
+        if (handler == null) {
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "execute-write-rejected (no handler)",
+                    write.charUuid,
+                    GattStatus.WriteNotPermitted,
+                ),
+            )
+            return BluetoothGatt.GATT_FAILURE
+        }
+
+        try {
+            val gattStatus = handler(deviceId, BleData(write.data), true)
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "execute-write (${write.data.size}B)",
+                    write.charUuid,
+                    gattStatus,
+                ),
+            )
+            if (gattStatus != null && gattStatus != GattStatus.Success) {
+                return BluetoothGatt.GATT_FAILURE
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            logEvent(
+                BleLogEvent.ServerRequest(
+                    deviceId,
+                    "execute-write-failed (handler threw)",
+                    write.charUuid,
+                    GattStatus.Failure,
+                ),
+            )
+            return BluetoothGatt.GATT_FAILURE
+        }
+    }
+    return BluetoothGatt.GATT_SUCCESS
+}


### PR DESCRIPTION
## Problem
AndroidGattServerCallback.kt was a 444-line God File handling 9 distinct Binder callback overrides plus helper methods for CCCD, prepared writes, and execute-write dispatch. This violated the <300 line target and mixed connection, read, write, and descriptor concerns in a single class.

## Approach
Applied Class Decomposition Pattern (Approach B: Extension Functions in same package):
- Made `state` and `sendResponseSafe` internal for same-package access
- Extracted connection handling → `AndroidGattServerConnectionHandlers.kt` (46 loc)
- Extracted read + prepared write handling → `AndroidGattServerReadHandlers.kt` (161 loc)
- Extracted write + CCCD + execute handling → `AndroidGattServerWriteHandlers.kt` (227 loc)
- Thinned callback wrapper down to 126 loc with delegation calls

## Files
| File | Before | After |
|------|--------|-------|
| AndroidGattServerCallback.kt | 444 | 126 |
| AndroidGattServerConnectionHandlers.kt | — | 46 |
| AndroidGattServerReadHandlers.kt | — | 161 |
| AndroidGattServerWriteHandlers.kt | — | 227 |

## Verification
- `./gradlew :compileKotlinJvm --rerun-tasks` ✓
- `./gradlew :compileKotlinIosSimulatorArm64` ✓
- `./gradlew ktlintFormat ktlintCheck` ✓
- Typography check: clean

Closes #241-P2