### PR TITLE
refactor(ios): decompose IosPeripheral 713->390 loc via extension functions

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -1,9 +1,7 @@
 package com.atruedev.kmpble.peripheral
 
-import com.atruedev.kmpble.BleData
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
-import com.atruedev.kmpble.bleDataFromNSData
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
@@ -15,29 +13,23 @@ import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.connection.internal.ReconnectionHandler
 import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
-import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.GattError
 import com.atruedev.kmpble.error.OperationFailed
-import com.atruedev.kmpble.error.StaleGattHandle
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
-import com.atruedev.kmpble.gatt.internal.GattResult
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
-import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.gatt.internal.PersistedObservation
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import com.atruedev.kmpble.internal.StateRestorationHandler
-import com.atruedev.kmpble.l2cap.DEFAULT_L2CAP_MTU
 import com.atruedev.kmpble.l2cap.IosL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
-import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
 import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
 import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
@@ -47,63 +39,41 @@ import com.atruedev.kmpble.peripheral.internal.awaitGatt
 import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
 import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.internal.findDescriptor
-import com.atruedev.kmpble.scanner.uuidFrom
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.getAndUpdate
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import platform.CoreBluetooth.CBCharacteristic
-import platform.CoreBluetooth.CBCharacteristicPropertyAuthenticatedSignedWrites
-import platform.CoreBluetooth.CBCharacteristicPropertyIndicate
-import platform.CoreBluetooth.CBCharacteristicPropertyNotify
-import platform.CoreBluetooth.CBCharacteristicPropertyRead
-import platform.CoreBluetooth.CBCharacteristicPropertyWrite
-import platform.CoreBluetooth.CBCharacteristicPropertyWriteWithoutResponse
 import platform.CoreBluetooth.CBCharacteristicWriteWithResponse
 import platform.CoreBluetooth.CBDescriptor
 import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreBluetooth.CBPeripheral
 import platform.CoreBluetooth.CBPeripheralStateConnected
-import platform.CoreBluetooth.CBService
-import platform.Foundation.NSData
-import platform.Foundation.NSError
 import kotlin.concurrent.Volatile
-import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-/** State for a single service discovery cycle, confined to the peripheral's serial dispatcher. */
-private data class DiscoveryCycle(
-    val generation: Int,
-    val pendingServices: Set<String>,
-    val discoveredServices: MutableList<DiscoveredService> = mutableListOf(),
-)
-
 @OptIn(ExperimentalUuidApi::class)
 public class IosPeripheral(
-    private val cbPeripheral: CBPeripheral,
+    internal val cbPeripheral: CBPeripheral,
 ) : Peripheral {
     override val identifier: Identifier = Identifier(cbPeripheral.identifier.UUIDString)
-    private val peripheralContext = PeripheralContext(identifier)
-    private val bridge = ApplePeripheralBridge(cbPeripheral)
+    internal val peripheralContext = PeripheralContext(identifier)
+    internal val bridge = ApplePeripheralBridge(cbPeripheral)
     private val centralDelegate = CentralManagerProvider.scanDelegate
 
-    private val pendingOps = PendingOperations()
-    private val observationManager = ObservationManager(peripheralContext.dispatcher)
-    private val slots = LifecycleSlots()
+    internal val pendingOps = PendingOperations()
+    internal val observationManager = ObservationManager(peripheralContext.dispatcher)
+    internal val slots = LifecycleSlots()
 
-    private val nativeCharMap = mutableMapOf<Characteristic, CBCharacteristic>()
-    private val nativeDescMap = mutableMapOf<Descriptor, CBDescriptor>()
+    internal val nativeCharMap = mutableMapOf<Characteristic, CBCharacteristic>()
+    internal val nativeDescMap = mutableMapOf<Descriptor, CBDescriptor>()
 
-    private var pendingL2capChannel: CompletableDeferred<CBL2CAPChannel>? = null
-    private val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
+    internal var pendingL2capChannel: CompletableDeferred<CBL2CAPChannel>? = null
+    internal val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
 
     override val state: StateFlow<State> get() = peripheralContext.state
     override val bondState: StateFlow<BondState> get() = peripheralContext.bondState
@@ -111,14 +81,14 @@ public class IosPeripheral(
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
 
     @Volatile
-    private var closed = false
+    internal var closed = false
 
     /** Discovery generation counter - increments on each new discovery cycle to detect stale callbacks. */
     @Volatile
-    private var discoveryGeneration = 0
+    internal var discoveryGeneration = 0
 
     /** Current discovery cycle state, confined to peripheralContext.dispatcher. */
-    private var currentDiscovery: DiscoveryCycle? = null
+    internal var currentDiscovery: DiscoveryCycle? = null
 
     private val reconnectionHandler =
         ReconnectionHandler(
@@ -240,222 +210,6 @@ public class IosPeripheral(
         descriptorUuid: Uuid,
     ): Descriptor? = services.value.findDescriptor(serviceUuid, characteristicUuid, descriptorUuid)
 
-    private fun handleConnectionCallback(
-        connected: Boolean,
-        error: NSError?,
-    ) {
-        peripheralContext.scope.launch {
-            if (connected) {
-                peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
-                // New discovery cycle on connect: increment generation and clear stale handles
-                discoveryGeneration++
-                nativeCharMap.clear()
-                nativeDescMap.clear()
-                bridge.discoverServices()
-                return@launch
-            }
-
-            val bleError =
-                if (error != null) {
-                    ConnectionFailed(error.localizedDescription, error.code.toInt())
-                } else {
-                    ConnectionLost("Disconnected")
-                }
-
-            if (peripheralContext.state.value is State.Disconnecting.Requested) {
-                peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
-                slots.completeDisconnect()
-            } else {
-                peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
-            }
-            onDisconnectCleanup()
-            slots.completeConnect()
-        }
-    }
-
-    private fun handleBridgeEvent(event: AppleCallbackEvent) {
-        peripheralContext.scope.launch {
-            when (event) {
-                is AppleCallbackEvent.DidDiscoverServices -> handleServicesDiscovered(event)
-                is AppleCallbackEvent.DidDiscoverCharacteristics -> handleCharacteristicsDiscovered(event)
-                is AppleCallbackEvent.DidUpdateValueForCharacteristic -> handleCharacteristicValue(event)
-                is AppleCallbackEvent.DidWriteValueForCharacteristic ->
-                    pendingOps.complete(PendingOp.CharacteristicWrite, event.error.toGattStatus())
-                is AppleCallbackEvent.DidUpdateValueForDescriptor -> handleDescriptorValue(event)
-                is AppleCallbackEvent.DidWriteValueForDescriptor ->
-                    pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
-                is AppleCallbackEvent.DidReadRSSI -> handleRssi(event)
-                is AppleCallbackEvent.DidOpenL2CAPChannel -> handleDidOpenL2CAPChannel(event)
-            }
-        }
-    }
-
-    /**
-     * K/N maps both `didUpdateValue` (read response, notification) and `didWriteValue`
-     * (write response) to this single signature. Disambiguate by which slot is armed:
-     * the GATT queue ensures only one read/write is pending.
-     */
-    private fun handleCharacteristicValue(event: AppleCallbackEvent.DidUpdateValueForCharacteristic) {
-        val cbChar = event.characteristic
-        val error = event.error
-        when {
-            pendingOps.has(PendingOp.CharacteristicWrite) ->
-                pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
-            pendingOps.has(PendingOp.CharacteristicRead) -> {
-                val value = cbChar.value?.toByteArray() ?: byteArrayOf()
-                pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, error.toGattStatus()))
-            }
-            else -> {
-                val value = cbChar.value?.toByteArray() ?: return
-                val svcUuid = uuidFrom(cbChar.service?.UUID?.UUIDString ?: return)
-                val charUuid = uuidFrom(cbChar.UUID.UUIDString)
-                observationManager.emitByUuid(svcUuid, charUuid, value)
-            }
-        }
-    }
-
-    private fun handleDescriptorValue(event: AppleCallbackEvent.DidUpdateValueForDescriptor) {
-        val error = event.error
-        if (pendingOps.has(PendingOp.DescriptorWrite)) {
-            pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
-        } else {
-            val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
-            pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
-        }
-    }
-
-    private fun handleRssi(event: AppleCallbackEvent.DidReadRSSI) {
-        if (event.error == null) {
-            pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
-        } else {
-            pendingOps.fail(
-                PendingOp.RssiRead,
-                BleException(GattError("readRssi", event.error.toGattStatus())),
-            )
-        }
-    }
-
-    private suspend fun handleServicesDiscovered(event: AppleCallbackEvent.DidDiscoverServices) {
-        if (event.error != null) {
-            val status = event.error.toGattStatus()
-            peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)))
-            slots.completeConnect()
-            slots.failDiscovery(BleException(GattError("discoverServices", status)))
-            currentDiscovery = null
-            return
-        }
-
-        val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
-        if (cbServices.isEmpty()) {
-            finishDiscovery(emptyList())
-            currentDiscovery = null
-            return
-        }
-
-        val generation = discoveryGeneration
-        val pending = cbServices.map { it.UUID.UUIDString }.toSet()
-        currentDiscovery = DiscoveryCycle(generation = generation, pendingServices = pending)
-
-        cbServices.forEach { bridge.discoverCharacteristics(it.UUID.UUIDString) }
-    }
-
-    private suspend fun handleCharacteristicsDiscovered(event: AppleCallbackEvent.DidDiscoverCharacteristics) {
-        val cycle = currentDiscovery
-        if (cycle == null) return // No active discovery cycle (discarded or completed)
-
-        // Ignore stale callbacks from previous discovery generations
-        if (cycle.generation != discoveryGeneration) return
-
-        (cycle.pendingServices as MutableSet<String>).remove(event.serviceUuid)
-
-        if (event.error != null) {
-            val status = event.error.toGattStatus()
-            peripheralContext.processEvent(
-                ConnectionEvent.DiscoveryFailed(GattError("discoverCharacteristics", status)),
-            )
-            currentDiscovery = null
-            slots.completeConnect()
-            slots.failDiscovery(BleException(GattError("discoverCharacteristics", status)))
-            return
-        }
-
-        if (cycle.pendingServices.isNotEmpty()) return
-
-        // All services' characteristics discovered - build final service list
-        val discovered =
-            cbPeripheral.services
-                ?.filterIsInstance<CBService>()
-                ?.map { it.toDiscoveredService() }
-                .orEmpty()
-        finishDiscovery(discovered)
-        currentDiscovery = null
-    }
-
-    private suspend fun finishDiscovery(discovered: List<DiscoveredService>) {
-        peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
-        peripheralContext.updateServices(discovered)
-        resubscribeObservations()
-        peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
-        slots.completeConnect()
-        slots.completeDiscovery(discovered)
-    }
-
-    private suspend fun resubscribeObservations() {
-        for (key in observationManager.getObservationsToResubscribe()) {
-            val char = findCharacteristic(key.serviceUuid, key.charUuid)
-            if (char != null) enableNotifications(char) else observationManager.completeObservation(key)
-        }
-    }
-
-    private fun CBService.toDiscoveredService(): DiscoveredService {
-        val serviceUuid = uuidFrom(UUID.UUIDString)
-        val chars =
-            characteristics
-                ?.filterIsInstance<CBCharacteristic>()
-                ?.map { cbChar ->
-                    val charUuid = uuidFrom(cbChar.UUID.UUIDString)
-                    val props = cbChar.properties.toInt()
-                    val descs = mutableListOf<Descriptor>()
-                    val char =
-                        Characteristic(
-                            serviceUuid = serviceUuid,
-                            uuid = charUuid,
-                            properties =
-                                Characteristic.Properties(
-                                    read = (props and CBCharacteristicPropertyRead.toInt()) != 0,
-                                    write = (props and CBCharacteristicPropertyWrite.toInt()) != 0,
-                                    writeWithoutResponse =
-                                        (props and CBCharacteristicPropertyWriteWithoutResponse.toInt()) != 0,
-                                    signedWrite =
-                                        (props and CBCharacteristicPropertyAuthenticatedSignedWrites.toInt()) != 0,
-                                    notify = (props and CBCharacteristicPropertyNotify.toInt()) != 0,
-                                    indicate = (props and CBCharacteristicPropertyIndicate.toInt()) != 0,
-                                ),
-                            descriptors = descs,
-                        )
-                    nativeCharMap[char] = cbChar
-                    cbChar.descriptors?.filterIsInstance<CBDescriptor>()?.forEach { cbDesc ->
-                        val desc = Descriptor(char, uuidFrom(cbDesc.UUID.UUIDString))
-                        descs.add(desc)
-                        nativeDescMap[desc] = cbDesc
-                    }
-                    char
-                }.orEmpty()
-
-        return DiscoveredService(uuid = serviceUuid, characteristics = chars)
-    }
-
-    private fun requireNativeCbChar(c: Characteristic): CBCharacteristic =
-        nativeCharMap[c]
-            ?: throw BleException(StaleGattHandle("characteristic", c.uuid.toString()))
-
-    private fun requireNativeCbDesc(d: Descriptor): CBDescriptor =
-        nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
-
-    private fun ByteArray.toNSData(): NSData = BleData(this).nsData
-
-    private fun NSData.toByteArray(): ByteArray = bleDataFromNSData(this).toByteArray()
-
     override suspend fun read(characteristic: Characteristic): ByteArray {
         checkNotClosed()
         return peripheralContext.gattQueue.enqueue {
@@ -528,7 +282,7 @@ public class IosPeripheral(
         )
     }
 
-    private fun enableNotifications(characteristic: Characteristic) {
+    internal fun enableNotifications(characteristic: Characteristic) {
         bridge.setNotifyValue(true, requireNativeCbChar(characteristic))
     }
 
@@ -602,73 +356,7 @@ public class IosPeripheral(
         psm: Int,
         secure: Boolean,
         mtu: Int?,
-    ): L2capChannel {
-        checkNotClosed()
-        if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
-        if (peripheralContext.state.value !is State.Connected) {
-            throw L2capException.NotConnected("Peripheral is not connected (state: ${peripheralContext.state.value})")
-        }
-
-        return withContext(peripheralContext.dispatcher) {
-            if (pendingL2capChannel != null) {
-                throw L2capException.OpenFailed(psm, "Another L2CAP channel open is already in progress")
-            }
-            val deferred = CompletableDeferred<CBL2CAPChannel>()
-            pendingL2capChannel = deferred
-            bridge.openL2CAPChannel(psm.toUShort())
-
-            try {
-                val cbChannel = withTimeout(L2CAP_OPEN_TIMEOUT) { deferred.await() }
-                val channel = IosL2capChannel(cbChannel, peripheralContext.scope, mtu ?: DEFAULT_L2CAP_MTU)
-                activeL2capChannels.update { it + channel }
-                channel
-            } catch (_: TimeoutCancellationException) {
-                pendingL2capChannel = null
-                throw L2capException.OpenFailed(psm, "Timeout waiting for L2CAP channel")
-            } catch (e: L2capException) {
-                pendingL2capChannel = null
-                throw e
-            } catch (e: CancellationException) {
-                pendingL2capChannel = null
-                throw e
-            } catch (e: Exception) {
-                pendingL2capChannel = null
-                throw L2capException.OpenFailed(psm, e.message ?: "Unknown error", e)
-            }
-        }
-    }
-
-    private fun handleDidOpenL2CAPChannel(event: AppleCallbackEvent.DidOpenL2CAPChannel) {
-        val deferred = pendingL2capChannel ?: return
-        pendingL2capChannel = null
-
-        when {
-            event.error != null ->
-                deferred.completeExceptionally(
-                    L2capException.OpenFailed(
-                        psm = event.channel?.PSM?.toInt() ?: -1,
-                        message = event.error.localizedDescription,
-                    ),
-                )
-            event.channel != null -> deferred.complete(event.channel)
-            else ->
-                deferred.completeExceptionally(
-                    L2capException.OpenFailed(psm = -1, message = "Channel is null with no error"),
-                )
-        }
-    }
-
-    private fun closeL2capChannels() {
-        activeL2capChannels.getAndUpdate { emptyList() }.forEach { it.close() }
-    }
-
-    private fun onDisconnectCleanup() {
-        nativeCharMap.clear()
-        nativeDescMap.clear()
-        closeL2capChannels()
-        observationManager.onDisconnect()
-        pendingOps.cancelAll(NotConnectedException())
-    }
+    ): L2capChannel = openL2capChannelInternal(psm, secure, mtu)
 
     /**
      * Restore this peripheral from iOS state restoration.
@@ -698,16 +386,5 @@ public class IosPeripheral(
                 }
             }
         }
-    }
-
-    private fun checkNotClosed() {
-        check(!closed) { "Peripheral is closed" }
-    }
-
-    private companion object {
-        val L2CAP_OPEN_TIMEOUT = 30.seconds
-        val DISCONNECT_TIMEOUT = 5.seconds
-        val DISCOVERY_TIMEOUT = 10.seconds
-        const val ATT_HEADER_SIZE = 3
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
@@ -1,0 +1,75 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.gatt.internal.GattResult
+import com.atruedev.kmpble.gatt.internal.PendingOp
+import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.launch
+import platform.Foundation.NSData
+
+/**
+ * Bridge event dispatch and value handling for [IosPeripheral].
+ */
+
+internal fun IosPeripheral.handleBridgeEvent(event: AppleCallbackEvent) {
+    peripheralContext.scope.launch {
+        when (event) {
+            is AppleCallbackEvent.DidDiscoverServices -> handleServicesDiscovered(event)
+            is AppleCallbackEvent.DidDiscoverCharacteristics -> handleCharacteristicsDiscovered(event)
+            is AppleCallbackEvent.DidUpdateValueForCharacteristic -> handleCharacteristicValue(event)
+            is AppleCallbackEvent.DidWriteValueForCharacteristic ->
+                pendingOps.complete(PendingOp.CharacteristicWrite, event.error.toGattStatus())
+            is AppleCallbackEvent.DidUpdateValueForDescriptor -> handleDescriptorValue(event)
+            is AppleCallbackEvent.DidWriteValueForDescriptor ->
+                pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
+            is AppleCallbackEvent.DidReadRSSI -> handleRssi(event)
+            is AppleCallbackEvent.DidOpenL2CAPChannel -> handleDidOpenL2CAPChannel(event)
+        }
+    }
+}
+
+/**
+ * K/N maps both `didUpdateValue` (read response, notification) and `didWriteValue`
+ * (write response) to this single signature. Disambiguate by which slot is armed:
+ * the GATT queue ensures only one read/write is pending.
+ */
+internal fun IosPeripheral.handleCharacteristicValue(event: AppleCallbackEvent.DidUpdateValueForCharacteristic) {
+    val cbChar = event.characteristic
+    val error = event.error
+    when {
+        pendingOps.has(PendingOp.CharacteristicWrite) ->
+            pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
+        pendingOps.has(PendingOp.CharacteristicRead) -> {
+            val value = cbChar.value?.toByteArray() ?: byteArrayOf()
+            pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, error.toGattStatus()))
+        }
+        else -> {
+            val value = cbChar.value?.toByteArray() ?: return
+            val svcUuid = uuidFrom(cbChar.service?.UUID?.UUIDString ?: return)
+            val charUuid = uuidFrom(cbChar.UUID.UUIDString)
+            observationManager.emitByUuid(svcUuid, charUuid, value)
+        }
+    }
+}
+
+internal fun IosPeripheral.handleDescriptorValue(event: AppleCallbackEvent.DidUpdateValueForDescriptor) {
+    val error = event.error
+    if (pendingOps.has(PendingOp.DescriptorWrite)) {
+        pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
+    } else {
+        val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
+        pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
+    }
+}
+
+internal fun IosPeripheral.handleRssi(event: AppleCallbackEvent.DidReadRSSI) {
+    if (event.error == null) {
+        pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
+    } else {
+        pendingOps.fail(
+            PendingOp.RssiRead,
+            BleException(GattError("readRssi", event.error.toGattStatus())),
+        )
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -1,0 +1,45 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.error.ConnectionFailed
+import com.atruedev.kmpble.error.ConnectionLost
+import kotlinx.coroutines.launch
+import platform.Foundation.NSError
+
+/**
+ * Connection callback handling for [IosPeripheral].
+ */
+
+internal fun IosPeripheral.handleConnectionCallback(
+    connected: Boolean,
+    error: NSError?,
+) {
+    peripheralContext.scope.launch {
+        if (connected) {
+            peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+            // New discovery cycle on connect: increment generation and clear stale handles
+            discoveryGeneration++
+            nativeCharMap.clear()
+            nativeDescMap.clear()
+            bridge.discoverServices()
+            return@launch
+        }
+
+        val bleError =
+            if (error != null) {
+                ConnectionFailed(error.localizedDescription, error.code.toInt())
+            } else {
+                ConnectionLost("Disconnected")
+            }
+
+        if (peripheralContext.state.value is State.Disconnecting.Requested) {
+            peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
+            slots.completeDisconnect()
+        } else {
+            peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
+        }
+        onDisconnectCleanup()
+        slots.completeConnect()
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -1,0 +1,150 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.Descriptor
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.peripheral.internal.findCharacteristic
+import com.atruedev.kmpble.scanner.uuidFrom
+import platform.CoreBluetooth.CBCharacteristic
+import platform.CoreBluetooth.CBCharacteristicPropertyAuthenticatedSignedWrites
+import platform.CoreBluetooth.CBCharacteristicPropertyIndicate
+import platform.CoreBluetooth.CBCharacteristicPropertyNotify
+import platform.CoreBluetooth.CBCharacteristicPropertyRead
+import platform.CoreBluetooth.CBCharacteristicPropertyWrite
+import platform.CoreBluetooth.CBCharacteristicPropertyWriteWithoutResponse
+import platform.CoreBluetooth.CBDescriptor
+import platform.CoreBluetooth.CBService
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * State for a single service discovery cycle, confined to the peripheral's serial dispatcher.
+ */
+internal data class DiscoveryCycle(
+    val generation: Int,
+    val pendingServices: Set<String>,
+    val discoveredServices: MutableList<DiscoveredService> = mutableListOf(),
+)
+
+/**
+ * Service discovery pipeline for [IosPeripheral].
+ */
+
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.handleServicesDiscovered(event: AppleCallbackEvent.DidDiscoverServices) {
+    if (event.error != null) {
+        val status = event.error.toGattStatus()
+        peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(GattError("discoverServices", status)))
+        slots.completeConnect()
+        slots.failDiscovery(BleException(GattError("discoverServices", status)))
+        currentDiscovery = null
+        return
+    }
+
+    val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
+    if (cbServices.isEmpty()) {
+        finishDiscovery(emptyList())
+        currentDiscovery = null
+        return
+    }
+
+    val generation = discoveryGeneration
+    val pending = cbServices.map { it.UUID.UUIDString }.toSet()
+    currentDiscovery = DiscoveryCycle(generation = generation, pendingServices = pending)
+
+    cbServices.forEach { bridge.discoverCharacteristics(it.UUID.UUIDString) }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.handleCharacteristicsDiscovered(
+    event: AppleCallbackEvent.DidDiscoverCharacteristics,
+) {
+    val cycle = currentDiscovery
+    if (cycle == null) return // No active discovery cycle (discarded or completed)
+
+    // Ignore stale callbacks from previous discovery generations
+    if (cycle.generation != discoveryGeneration) return
+
+    (cycle.pendingServices as MutableSet<String>).remove(event.serviceUuid)
+
+    if (event.error != null) {
+        val status = event.error.toGattStatus()
+        peripheralContext.processEvent(
+            ConnectionEvent.DiscoveryFailed(GattError("discoverCharacteristics", status)),
+        )
+        currentDiscovery = null
+        slots.completeConnect()
+        slots.failDiscovery(BleException(GattError("discoverCharacteristics", status)))
+        return
+    }
+
+    if (cycle.pendingServices.isNotEmpty()) return
+
+    // All services' characteristics discovered - build final service list
+    val discovered =
+        cbPeripheral.services
+            ?.filterIsInstance<CBService>()
+            ?.map { it.toDiscoveredService(this) }
+            .orEmpty()
+    finishDiscovery(discovered)
+    currentDiscovery = null
+}
+
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.finishDiscovery(discovered: List<DiscoveredService>) {
+    peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
+    peripheralContext.updateServices(discovered)
+    resubscribeObservations()
+    peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
+    slots.completeConnect()
+    slots.completeDiscovery(discovered)
+}
+
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.resubscribeObservations() {
+    for (key in observationManager.getObservationsToResubscribe()) {
+        val char = findCharacteristic(key.serviceUuid, key.charUuid)
+        if (char != null) enableNotifications(char) else observationManager.completeObservation(key)
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+internal fun CBService.toDiscoveredService(peripheral: IosPeripheral): DiscoveredService {
+    val serviceUuid = uuidFrom(UUID.UUIDString)
+    val chars =
+        characteristics
+            ?.filterIsInstance<CBCharacteristic>()
+            ?.map { cbChar ->
+                val charUuid = uuidFrom(cbChar.UUID.UUIDString)
+                val props = cbChar.properties.toInt()
+                val descs = mutableListOf<Descriptor>()
+                val char =
+                    Characteristic(
+                        serviceUuid = serviceUuid,
+                        uuid = charUuid,
+                        properties =
+                            Characteristic.Properties(
+                                read = (props and CBCharacteristicPropertyRead.toInt()) != 0,
+                                write = (props and CBCharacteristicPropertyWrite.toInt()) != 0,
+                                writeWithoutResponse =
+                                    (props and CBCharacteristicPropertyWriteWithoutResponse.toInt()) != 0,
+                                signedWrite =
+                                    (props and CBCharacteristicPropertyAuthenticatedSignedWrites.toInt()) != 0,
+                                notify = (props and CBCharacteristicPropertyNotify.toInt()) != 0,
+                                indicate = (props and CBCharacteristicPropertyIndicate.toInt()) != 0,
+                            ),
+                        descriptors = descs,
+                    )
+                peripheral.nativeCharMap[char] = cbChar
+                cbChar.descriptors?.filterIsInstance<CBDescriptor>()?.forEach { cbDesc ->
+                    val desc = Descriptor(char, uuidFrom(cbDesc.UUID.UUIDString))
+                    descs.add(desc)
+                    peripheral.nativeDescMap[desc] = cbDesc
+                }
+                char
+            }.orEmpty()
+
+    return DiscoveredService(uuid = serviceUuid, characteristics = chars)
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
@@ -1,0 +1,45 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.bleDataFromNSData
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.StaleGattHandle
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.Descriptor
+import com.atruedev.kmpble.gatt.internal.NotConnectedException
+import platform.CoreBluetooth.CBCharacteristic
+import platform.CoreBluetooth.CBDescriptor
+import platform.Foundation.NSData
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Internal helpers for [IosPeripheral] extracted to keep the facade under 300 lines.
+ */
+
+internal fun IosPeripheral.checkNotClosed() {
+    check(!closed) { "Peripheral is closed" }
+}
+
+internal fun IosPeripheral.requireNativeCbChar(c: Characteristic): CBCharacteristic =
+    nativeCharMap[c]
+        ?: throw BleException(StaleGattHandle("characteristic", c.uuid.toString()))
+
+internal fun IosPeripheral.requireNativeCbDesc(d: Descriptor): CBDescriptor =
+    nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
+
+internal fun IosPeripheral.onDisconnectCleanup() {
+    nativeCharMap.clear()
+    nativeDescMap.clear()
+    closeL2capChannels()
+    observationManager.onDisconnect()
+    pendingOps.cancelAll(NotConnectedException())
+}
+
+internal fun ByteArray.toNSData(): NSData = BleData(this).nsData
+
+internal fun NSData.toByteArray(): ByteArray = bleDataFromNSData(this).toByteArray()
+
+internal val L2CAP_OPEN_TIMEOUT = 30.seconds
+internal val DISCONNECT_TIMEOUT = 5.seconds
+internal val DISCOVERY_TIMEOUT = 10.seconds
+internal const val ATT_HEADER_SIZE = 3

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralL2cap.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralL2cap.kt
@@ -1,0 +1,83 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.l2cap.DEFAULT_L2CAP_MTU
+import com.atruedev.kmpble.l2cap.IosL2capChannel
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.l2cap.L2capException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import platform.CoreBluetooth.CBL2CAPChannel
+
+/**
+ * L2CAP channel management for [IosPeripheral].
+ */
+
+internal suspend fun IosPeripheral.openL2capChannelInternal(
+    psm: Int,
+    secure: Boolean,
+    mtu: Int?,
+): L2capChannel {
+    checkNotClosed()
+    if (mtu != null) require(mtu > 0) { "mtu must be positive, was $mtu" }
+    if (peripheralContext.state.value !is State.Connected) {
+        throw L2capException.NotConnected("Peripheral is not connected (state: ${peripheralContext.state.value})")
+    }
+
+    return withContext(peripheralContext.dispatcher) {
+        if (pendingL2capChannel != null) {
+            throw L2capException.OpenFailed(psm, "Another L2CAP channel open is already in progress")
+        }
+        val deferred = CompletableDeferred<CBL2CAPChannel>()
+        pendingL2capChannel = deferred
+        bridge.openL2CAPChannel(psm.toUShort())
+
+        try {
+            val cbChannel = withTimeout(L2CAP_OPEN_TIMEOUT) { deferred.await() }
+            val channel = IosL2capChannel(cbChannel, peripheralContext.scope, mtu ?: DEFAULT_L2CAP_MTU)
+            activeL2capChannels.update { it + channel }
+            channel
+        } catch (_: TimeoutCancellationException) {
+            pendingL2capChannel = null
+            throw L2capException.OpenFailed(psm, "Timeout waiting for L2CAP channel")
+        } catch (e: L2capException) {
+            pendingL2capChannel = null
+            throw e
+        } catch (e: CancellationException) {
+            pendingL2capChannel = null
+            throw e
+        } catch (e: Exception) {
+            pendingL2capChannel = null
+            throw L2capException.OpenFailed(psm, e.message ?: "Unknown error", e)
+        }
+    }
+}
+
+internal fun IosPeripheral.handleDidOpenL2CAPChannel(event: AppleCallbackEvent.DidOpenL2CAPChannel) {
+    val deferred = pendingL2capChannel ?: return
+    pendingL2capChannel = null
+
+    when {
+        event.error != null ->
+            deferred.completeExceptionally(
+                L2capException.OpenFailed(
+                    psm = event.channel?.PSM?.toInt() ?: -1,
+                    message = event.error.localizedDescription,
+                ),
+            )
+        event.channel != null -> deferred.complete(event.channel)
+        else ->
+            deferred.completeExceptionally(
+                L2capException.OpenFailed(psm = -1, message = "Channel is null with no error"),
+            )
+    }
+}
+
+internal fun IosPeripheral.closeL2capChannels() {
+    activeL2capChannels.getAndUpdate { emptyList() }.forEach { it.close() }
+}


### PR DESCRIPTION
## Summary
Decompose IosPeripheral.kt (713 lines) into a 390-line facade + 5 focused extension function files using Class Decomposition Pattern (Approach B).

## Files
- `IosPeripheral.kt` — 390 loc: thin facade delegating to extracted functions
- `IosPeripheralBridgeHandlers.kt` — 75 loc: bridge event dispatch, characteristic/descriptor value handling, RSSI
- `IosPeripheralConnection.kt` — 45 loc: connection callback handler
- `IosPeripheralDiscovery.kt` — 150 loc: DiscoveryCycle data class, service discovery pipeline, CBService mapping
- `IosPeripheralInternal.kt` — 45 loc: checkNotClosed, requireNativeCbChar/Desc, toNSData/toByteArray, timeout constants
- `IosPeripheralL2cap.kt` — 83 loc: openL2capChannelInternal, handleDidOpenL2CAPChannel, closeL2capChannels

## Changes
- Changed `private` fields to `internal` so extension functions can access them
- Moved `enableNotifications` from private to internal for discovery pipeline access
- Fixed `toDiscoveredService` to accept explicit `IosPeripheral` parameter (member extension -> file-level extension)
- Removed qualified name in `IosPeripheralDiscovery.kt`
- Removed unused imports from facade

## Validation
- `./gradlew :compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- `./gradlew :compileKotlinJvm` — BUILD SUCCESSFUL
- `./gradlew ktlintCheck` — BUILD SUCCESSFUL
- Typography grep — clean (no em-dash/smart-quotes)