### PR TITLE
fix(android): rethrow CancellationException in pairing handler scope.launch

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPairingRequestHandler.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPairingRequestHandler.kt
@@ -15,6 +15,7 @@ import com.atruedev.kmpble.bonding.PairingHandler
 import com.atruedev.kmpble.bonding.PairingResponse
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -76,6 +77,8 @@ internal class AndroidPairingRequestHandler(
                             try {
                                 val response = currentHandler.onPairingEvent(event)
                                 applyResponse(pairingDevice, response)
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
                                 logEvent(BleLogEvent.Error(identifier, "Pairing handler threw: ${e.message}", e))
                             }


### PR DESCRIPTION
## What

Adds explicit `CancellationException` catch-and-rethrow in `AndroidPairingRequestHandler.onReceive()`'s `scope.launch` catch block.

## Why

The `catch (e: Exception)` block was swallowing `CancellationException`, preventing the launched coroutine from detecting cancellation. This follows the same pattern already applied in PRs #208, #209, #241, #242, and in the StateRestorationHandler (KMP-302).

## Fix

- Added `import kotlinx.coroutines.CancellationException`
- Added explicit `catch (e: CancellationException) { throw e }` before the generic `catch (e: Exception)` block

Fixes #246