### PR TITLE
fix(android): convert expression-body overrides to block bodies for explicitApi()

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -119,12 +119,12 @@ public class AndroidPeripheral internal constructor(
     }
 
     @OptIn(ExperimentalBleApi::class)
-    override suspend fun connect(options: ConnectionOptions): Unit {
+    override suspend fun connect(options: ConnectionOptions) {
         connectInternal(options)
     }
 
     @OptIn(ExperimentalBleApi::class)
-    override suspend fun disconnect(): Unit {
+    override suspend fun disconnect() {
         disconnectInternal()
     }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -119,10 +119,14 @@ public class AndroidPeripheral internal constructor(
     }
 
     @OptIn(ExperimentalBleApi::class)
-    override suspend fun connect(options: ConnectionOptions): Unit = connectInternal(options)
+    override suspend fun connect(options: ConnectionOptions): Unit {
+        connectInternal(options)
+    }
 
     @OptIn(ExperimentalBleApi::class)
-    override suspend fun disconnect(): Unit = disconnectInternal()
+    override suspend fun disconnect(): Unit {
+        disconnectInternal()
+    }
 
     @OptIn(ExperimentalBleApi::class)
     override fun close() {


### PR DESCRIPTION
## Summary

Kotlin 2.4.0 explicitApi() rejects expression-body overrides that delegate to extension functions, even when the override has an explicit `:Unit` return type. This fix switches `connect()` and `disconnect()` overrides from expression bodies to block bodies, bypassing K2's stricter explicitApi() checking.

## Changes

- `AndroidPeripheral.kt`: convert `connect()` and `disconnect()` expression-body overrides to block bodies

## Impact

- Fixes Android CI compilation failure introduced by #244 decomposition
- Fixes #251
- Unblocks all subsequent PR merges (including #248)