### PR TITLE
feat(beacon): add iBeacon and Eddystone scanning support

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/beacon/Beacon.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/beacon/Beacon.kt
@@ -1,0 +1,310 @@
+package com.atruedev.kmpble.beacon
+
+import com.atruedev.kmpble.scanner.Advertisement
+import com.atruedev.kmpble.scanner.uuidFrom
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Parsed beacon advertisement data.
+ *
+ * [Beacon] is a sealed hierarchy representing common beacon protocols.
+ * Parse an [Advertisement] to a typed beacon via [parse] or the
+ * [com.atruedev.kmpble.scanner.Advertisement.parseBeacon] extension.
+ *
+ * ## Supported protocols
+ * - [IBeacon] -- Apple iBeacon (manufacturer data 0x004C, type 0x02)
+ * - [EddystoneUID] -- Google Eddystone-UID (service UUID 0xFEAA, frame type 0x00)
+ * - [EddystoneURL] -- Google Eddystone-URL (service UUID 0xFEAA, frame type 0x10)
+ * - [EddystoneTLM] -- Google Eddystone-TLM (service UUID 0xFEAA, frame type 0x20)
+ *
+ * ## Thread safety
+ * All implementations are immutable data classes. Safe for concurrent access.
+ */
+public sealed interface Beacon {
+    /** The original advertisement that produced this beacon. */
+    public val source: Advertisement
+
+    /**
+     * Apple iBeacon proximity beacon.
+     *
+     * Uses Apple manufacturer data (company ID 0x004C) with subtype 0x02.
+     * The [measuredPower] is the calibrated RSSI at 1 meter, used for
+     * distance estimation.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    public data class IBeacon(
+        override val source: Advertisement,
+        /** Proximity UUID identifying the beacon region. */
+        public val proximityUuid: Uuid,
+        /** Major value (grouping). */
+        public val major: Int,
+        /** Minor value (individual beacon within group). */
+        public val minor: Int,
+        /** Calibrated RSSI at 1 meter (signed int8). */
+        public val measuredPower: Int,
+    ) : Beacon
+
+    /**
+     * Google Eddystone-UID beacon.
+     *
+     * Broadcasts a 16-byte unique identifier (10-byte namespace + 6-byte instance).
+     * The [rangingData] is the calibrated txPower at 0 meters.
+     */
+    public data class EddystoneUID(
+        override val source: Advertisement,
+        /** 10-byte namespace identifier. */
+        public val namespace: ByteArray,
+        /** 6-byte instance identifier. */
+        public val instance: ByteArray,
+        /** Calibrated txPower at 0 meters (signed int8). */
+        public val rangingData: Int,
+    ) : Beacon {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is EddystoneUID) return false
+            return source == other.source &&
+                namespace.contentEquals(other.namespace) &&
+                instance.contentEquals(other.instance) &&
+                rangingData == other.rangingData
+        }
+
+        override fun hashCode(): Int {
+            var result = source.hashCode()
+            result = 31 * result + namespace.contentHashCode()
+            result = 31 * result + instance.contentHashCode()
+            result = 31 * result + rangingData
+            return result
+        }
+    }
+
+    /**
+     * Google Eddystone-URL beacon.
+     *
+     * Broadcasts a compressed URL. The [txPower] is the calibrated txPower at 0 meters.
+     */
+    public data class EddystoneURL(
+        override val source: Advertisement,
+        /** Decompressed URL string. */
+        public val url: String,
+        /** Calibrated txPower at 0 meters (signed int8). */
+        public val txPower: Int,
+    ) : Beacon
+
+    /**
+     * Google Eddystone-TLM telemetry beacon.
+     *
+     * Broadcasts device health metrics alongside UID or URL frames.
+     * Usually interleaved with Eddystone-UID or Eddystone-URL advertisements.
+     */
+    public data class EddystoneTLM(
+        override val source: Advertisement,
+        /** Battery voltage in millivolts, or null if not supported. */
+        public val batteryVoltageMv: Int?,
+        /** Temperature in Celsius (signed fixed-point 8.8), or null if not supported. */
+        public val temperatureCelsius: Float?,
+        /** Advertisement count since power-on or reboot. */
+        public val advertisementCount: Long,
+        /** Uptime in seconds (0.1 second resolution). */
+        public val uptimeSeconds: Double,
+    ) : Beacon
+
+    public companion object {
+        /** Apple company ID in manufacturer data. */
+        internal const val APPLE_COMPANY_ID = 0x004C
+
+        /** iBeacon manufacturer data subtype. */
+        internal const val IBEACON_TYPE = 0x02
+
+        /** iBeacon manufacturer data minimum length (type + length + uuid + major + minor + power). */
+        internal const val IBEACON_MIN_LENGTH = 23
+
+        /** Eddystone service UUID (16-bit). */
+        internal val EDDYSTONE_SERVICE_UUID: Uuid = uuidFrom("FEAA")
+
+        /** Eddystone frame type constants. */
+        internal const val EDDYSTONE_FRAME_UID: Byte = 0x00
+        internal const val EDDYSTONE_FRAME_URL: Byte = 0x10
+        internal const val EDDYSTONE_FRAME_TLM: Byte = 0x20
+
+        /** Minimum Eddystone-UID frame length: frameType(1) + rangingData(1) + namespace(10) + instance(6). */
+        internal const val EDDYSTONE_UID_LENGTH = 18
+
+        /** Minimum Eddystone-TLM frame length: frameType(1) + version(1) + battery(2) + temp(2) + count(4) + uptime(4). */
+        internal const val EDDYSTONE_TLM_LENGTH = 14
+
+        /**
+         * Parse an [Advertisement] into a typed [Beacon], or null if the
+         * advertisement does not contain a recognized beacon format.
+         */
+        public fun parse(advertisement: Advertisement): Beacon? {
+            parseIBeacon(advertisement)?.let { return it }
+            parseEddystone(advertisement)?.let { return it }
+            return null
+        }
+
+        internal fun parseIBeacon(advertisement: Advertisement): IBeacon? {
+            val data = advertisement.manufacturerData[APPLE_COMPANY_ID] ?: return null
+            val bytes = data.toByteArray()
+            if (bytes.size < IBEACON_MIN_LENGTH) return null
+            if (bytes[0] != IBEACON_TYPE.toByte()) return null
+            val length = bytes[1].toInt() and 0xFF
+            if (length != bytes.size - 2) return null
+
+            @OptIn(ExperimentalUuidApi::class)
+            val proximityUuid = Uuid.fromByteArray(bytes.sliceArray(2..17))
+            val major = ((bytes[18].toInt() and 0xFF) shl 8) or (bytes[19].toInt() and 0xFF)
+            val minor = ((bytes[20].toInt() and 0xFF) shl 8) or (bytes[21].toInt() and 0xFF)
+            val measuredPower = bytes[22].toInt()
+
+            return IBeacon(
+                source = advertisement,
+                proximityUuid = proximityUuid,
+                major = major,
+                minor = minor,
+                measuredPower = measuredPower,
+            )
+        }
+
+        internal fun parseEddystone(advertisement: Advertisement): Beacon? {
+            val data = advertisement.serviceData[EDDYSTONE_SERVICE_UUID] ?: return null
+            val bytes = data.toByteArray()
+            if (bytes.isEmpty()) return null
+
+            return when (bytes[0]) {
+                EDDYSTONE_FRAME_UID -> parseEddystoneUID(advertisement, bytes)
+                EDDYSTONE_FRAME_URL -> parseEddystoneURL(advertisement, bytes)
+                EDDYSTONE_FRAME_TLM -> parseEddystoneTLM(advertisement, bytes)
+                else -> null
+            }
+        }
+
+        internal fun parseEddystoneUID(
+            advertisement: Advertisement,
+            bytes: ByteArray,
+        ): EddystoneUID? {
+            if (bytes.size < EDDYSTONE_UID_LENGTH) return null
+            val rangingData = bytes[1].toInt()
+            val namespace = bytes.sliceArray(2..11)
+            val instance = bytes.sliceArray(12..17)
+            return EddystoneUID(
+                source = advertisement,
+                namespace = namespace,
+                instance = instance,
+                rangingData = rangingData,
+            )
+        }
+
+        internal fun parseEddystoneURL(
+            advertisement: Advertisement,
+            bytes: ByteArray,
+        ): EddystoneURL? {
+            if (bytes.size < 3) return null
+            val txPower = bytes[1].toInt()
+
+            val schemePrefix =
+                when (bytes[2].toInt() and 0xFF) {
+                    0x00 -> "http://www."
+                    0x01 -> "https://www."
+                    0x02 -> "http://"
+                    0x03 -> "https://"
+                    else -> return null
+                }
+
+            val encoded =
+                buildString {
+                    append(schemePrefix)
+                    for (i in 3 until bytes.size) {
+                        val code = bytes[i].toInt() and 0xFF
+                        append(EDDYSTONE_URL_CODES[code] ?: code.toChar().toString())
+                    }
+                }
+
+            return EddystoneURL(
+                source = advertisement,
+                url = encoded,
+                txPower = txPower,
+            )
+        }
+
+        internal fun parseEddystoneTLM(
+            advertisement: Advertisement,
+            bytes: ByteArray,
+        ): EddystoneTLM? {
+            if (bytes.size < EDDYSTONE_TLM_LENGTH) return null
+            val tlmVersion = bytes[1].toInt() and 0xFF
+
+            // Version 0x00: unencrypted TLM
+            val batteryMv = ((bytes[2].toInt() and 0xFF) shl 8) or (bytes[3].toInt() and 0xFF)
+            val batteryVoltageMv = if (batteryMv == 0) null else batteryMv
+
+            val tempRaw = ((bytes[4].toInt() and 0xFF) shl 8) or (bytes[5].toInt() and 0xFF)
+            val temperatureCelsius: Float? =
+                when {
+                    tempRaw == 0x8000 -> null
+                    tlmVersion == 0x00 -> {
+                        // Signed 8.8 fixed-point
+                        val signed = if (tempRaw >= 0x8000) tempRaw - 0x10000 else tempRaw
+                        signed.toFloat() / 256.0f
+                    }
+                    else -> null
+                }
+
+            val advertisementCount: Long =
+                ((bytes[6].toLong() and 0xFF) shl 24) or
+                    ((bytes[7].toLong() and 0xFF) shl 16) or
+                    ((bytes[8].toLong() and 0xFF) shl 8) or
+                    (bytes[9].toLong() and 0xFF)
+
+            val uptimeTenthSeconds: Long =
+                ((bytes[10].toLong() and 0xFF) shl 24) or
+                    ((bytes[11].toLong() and 0xFF) shl 16) or
+                    ((bytes[12].toLong() and 0xFF) shl 8) or
+                    (bytes[13].toLong() and 0xFF)
+
+            return EddystoneTLM(
+                source = advertisement,
+                batteryVoltageMv = batteryVoltageMv,
+                temperatureCelsius = temperatureCelsius,
+                advertisementCount = advertisementCount,
+                uptimeSeconds = uptimeTenthSeconds / 10.0,
+            )
+        }
+
+        /**
+         * Eddystone-URL encoded character lookup table.
+         *
+         * Codes 0x00-0x13 expand to common URL components. Unrecognized
+         * codes are passed through as literal characters.
+         */
+        private val EDDYSTONE_URL_CODES: Map<Int, String> =
+            mapOf(
+                0x00 to ".com/",
+                0x01 to ".org/",
+                0x02 to ".edu/",
+                0x03 to ".net/",
+                0x04 to ".info/",
+                0x05 to ".biz/",
+                0x06 to ".gov/",
+                0x07 to ".com",
+                0x08 to ".org",
+                0x09 to ".edu",
+                0x0A to ".net",
+                0x0B to ".info",
+                0x0C to ".biz",
+                0x0D to ".gov",
+            )
+    }
+}
+
+/**
+ * Returns `true` if this advertisement contains a recognized beacon format
+ * that can be parsed via [parseBeacon].
+ */
+public fun Advertisement.isBeacon(): Boolean = Beacon.parse(this) != null
+
+/**
+ * Parse this advertisement into a typed [Beacon], or null if the
+ * advertisement does not contain a recognized beacon format.
+ */
+public fun Advertisement.parseBeacon(): Beacon? = Beacon.parse(this)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/beacon/BeaconScanner.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/beacon/BeaconScanner.kt
@@ -1,0 +1,125 @@
+package com.atruedev.kmpble.beacon
+
+import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.Scanner
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Filters a [Scanner] to emit only beacon-related scan events.
+ *
+ * Wraps a [Scanner] and emits [BeaconEvent] instances: either a parsed
+ * [BeaconEvent.Found] or a forwarded [BeaconEvent.Failed] on scan errors.
+ * Non-beacon advertisements are silently dropped.
+ *
+ * Follows the active-object pattern: call [start] to begin filtering,
+ * [stop] to end. [beaconEvents] is a hot flow -- subscribe before
+ * calling [start] to avoid missing events.
+ *
+ * ```kotlin
+ * val scanner = PeripheralFactory.createScanner { filters { serviceUuids("feaa") } }
+ * val beaconScanner = BeaconScanner(scanner, scope)
+ *
+ * scope.launch {
+ *     beaconScanner.beaconEvents.collect { event ->
+ *         when (event) {
+ *             is BeaconEvent.Found -> handleBeacon(event.beacon)
+ *             is BeaconEvent.Failed -> handleError(event.error)
+ *         }
+ *     }
+ * }
+ *
+ * beaconScanner.start()
+ * // ... scanning ...
+ * beaconScanner.stop()
+ * beaconScanner.close()
+ * ```
+ */
+public class BeaconScanner(
+    private val scanner: Scanner,
+    private val scope: CoroutineScope,
+) {
+    private val _beaconEvents =
+        MutableSharedFlow<BeaconEvent>(
+            replay = 0,
+            extraBufferCapacity = 64,
+        )
+
+    /** Hot flow of parsed beacon events. Subscribe before calling [start]. */
+    public val beaconEvents: Flow<BeaconEvent> = _beaconEvents
+
+    private var started: Boolean = false
+    private var collectionJob: Job? = null
+
+    /**
+     * Begin filtering scan events for beacons.
+     *
+     * Idempotent: subsequent calls after the first are no-ops.
+     */
+    public fun start() {
+        if (started) return
+        started = true
+        collectionJob =
+            scanner.scanEvents
+                .onEach { event ->
+                    when (event) {
+                        is ScanEvent.Found -> {
+                            val beacon = event.advertisement.parseBeacon()
+                            if (beacon != null) {
+                                _beaconEvents.emit(BeaconEvent.Found(beacon))
+                            }
+                        }
+                        is ScanEvent.Failed -> {
+                            _beaconEvents.emit(BeaconEvent.Failed(event.error))
+                        }
+                    }
+                }.launchIn(scope)
+    }
+
+    /**
+     * Stop filtering scan events. The wrapped [Scanner] is not closed --
+     * call [close] to release platform resources.
+     *
+     * Idempotent: subsequent calls after the first are no-ops.
+     */
+    public fun stop() {
+        started = false
+        collectionJob?.cancel()
+        collectionJob = null
+    }
+
+    /**
+     * Stop filtering and close the wrapped [Scanner], releasing platform
+     * BLE resources.
+     */
+    public fun close() {
+        stop()
+        try {
+            scanner.close()
+        } catch (_: CancellationException) {
+            // Propagate cancellation; close is best-effort
+        } catch (_: Exception) {
+            // Scanner close failures are non-fatal
+        }
+    }
+}
+
+/**
+ * Event emitted by [BeaconScanner.beaconEvents].
+ */
+public sealed interface BeaconEvent {
+    /** A beacon advertisement was parsed successfully. */
+    public data class Found(
+        val beacon: Beacon,
+    ) : BeaconEvent
+
+    /** The platform scan encountered an error. */
+    public data class Failed(
+        val error: Throwable,
+    ) : BeaconEvent
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/beacon/BeaconScannerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/beacon/BeaconScannerTest.kt
@@ -1,0 +1,252 @@
+package com.atruedev.kmpble.beacon
+
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.scanner.Advertisement
+import com.atruedev.kmpble.testing.FakeScanner
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BeaconScannerTest {
+    @Test
+    fun `beaconEvents emits iBeacon from FakeScanner`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        manufacturerData(0x004C, BleData(iBeaconBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+            assertTrue((event as BeaconEvent.Found).beacon is Beacon.IBeacon)
+
+            beaconScanner.close()
+        }
+    }
+
+    @Test
+    fun `beaconEvents filters out non-beacon ads`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        name("PlainDevice")
+                        serviceUuids("180d")
+                    }
+                    advertisement {
+                        manufacturerData(0x004C, BleData(iBeaconBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            // Only the beacon ad should come through
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+            assertTrue((event as BeaconEvent.Found).beacon is Beacon.IBeacon)
+
+            beaconScanner.close()
+        }
+    }
+
+    @Test
+    fun `EddystoneUID roundtrip through FakeScanner`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        name("EddystoneBeacon")
+                        rssi(-65)
+                        serviceData("feaa", BleData(eddystoneUidBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+            val uid = (event as BeaconEvent.Found).beacon as Beacon.EddystoneUID
+            assertEquals(-18, uid.rangingData)
+            assertEquals("EddystoneBeacon", uid.source.name)
+
+            beaconScanner.close()
+        }
+    }
+
+    @Test
+    fun `stop prevents further events`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        manufacturerData(0x004C, BleData(iBeaconBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            // Consume the static beacon ad
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+
+            // Stop the scanner
+            beaconScanner.stop()
+
+            // Emit a dynamic beacon ad after stop
+            scanner.emit(
+                Advertisement(
+                    identifier = Identifier("FF:EE:DD:CC:BB:AA"),
+                    name = null,
+                    rssi = -50,
+                    txPower = null,
+                    isConnectable = true,
+                    serviceUuids = emptyList(),
+                    manufacturerData = mapOf(0x004C to BleData(iBeaconBytes())),
+                    serviceData = emptyMap(),
+                    timestampNanos = 0L,
+                ),
+            )
+
+            // Stop is idempotent and should not crash
+            beaconScanner.stop()
+            beaconScanner.close()
+        }
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        manufacturerData(0x004C, BleData(iBeaconBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+
+            beaconScanner.close()
+            beaconScanner.close() // double close should not throw
+        }
+    }
+
+    @Test
+    fun `start is idempotent`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner =
+                FakeScanner {
+                    advertisement {
+                        manufacturerData(0x004C, BleData(iBeaconBytes()))
+                    }
+                }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+            beaconScanner.start() // second call should be no-op
+
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Found)
+
+            beaconScanner.close()
+        }
+    }
+
+    @Test
+    fun `beaconEvents forwards scan failures`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val scanner = FakeScanner { }
+
+            val beaconScanner = BeaconScanner(scanner, this)
+            beaconScanner.start()
+
+            scanner.emitScanFailed(42)
+
+            val event = beaconScanner.beaconEvents.first()
+            assertTrue(event is BeaconEvent.Failed)
+
+            beaconScanner.close()
+        }
+    }
+
+    companion object {
+        fun iBeaconBytes(): ByteArray =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(),
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0xC5.toByte(),
+            )
+
+        fun eddystoneUidBytes(): ByteArray =
+            byteArrayOf(
+                0x00,
+                0xEE.toByte(),
+                0x6E.toByte(),
+                0x4A.toByte(),
+                0x0C.toByte(),
+                0x0D.toByte(),
+                0x9C.toByte(),
+                0x8E.toByte(),
+                0x4B.toByte(),
+                0x3A.toByte(),
+                0xA1.toByte(),
+                0xF2.toByte(),
+                0xC5.toByte(),
+                0xD6.toByte(),
+                0xE7.toByte(),
+                0xF8.toByte(),
+                0xA9.toByte(),
+                0xB0.toByte(),
+            )
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/beacon/BeaconTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/beacon/BeaconTest.kt
@@ -1,0 +1,548 @@
+package com.atruedev.kmpble.beacon
+
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.scanner.Advertisement
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BeaconTest {
+    // --- iBeacon ---
+
+    @Test
+    fun `parse iBeacon from valid manufacturer data`() {
+        // iBeacon: UUID=E2C56DB5-DFFB-48D2-B060-D0F5A71096E0, major=1, minor=1, power=-59
+        val bytes =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(), // type=0x02, length=0x15
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(), // UUID bytes 0-3
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(), // UUID bytes 4-7
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(), // UUID bytes 8-11
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(), // UUID bytes 12-15
+                0x00,
+                0x01, // major=1
+                0x00,
+                0x01, // minor=1
+                0xC5.toByte(), // measuredPower=-59
+            )
+
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+        val beacon = Beacon.parse(ad)
+
+        assertTrue(beacon is Beacon.IBeacon)
+        val ibeacon = beacon as Beacon.IBeacon
+        assertEquals("e2c56db5-dffb-48d2-b060-d0f5a71096e0", ibeacon.proximityUuid.toString())
+        assertEquals(1, ibeacon.major)
+        assertEquals(1, ibeacon.minor)
+        assertEquals(-59, ibeacon.measuredPower)
+    }
+
+    @Test
+    fun `parse iBeacon returns null for non-Apple manufacturer data`() {
+        val bytes =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(),
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0xC5.toByte(),
+            )
+        // Wrong company ID (0x004D instead of 0x004C)
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004D to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    @Test
+    fun `parse iBeacon returns null for wrong type byte`() {
+        val bytes =
+            byteArrayOf(
+                0x03,
+                0x15.toByte(), // wrong type (0x03 instead of 0x02)
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0xC5.toByte(),
+            )
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    @Test
+    fun `parse iBeacon returns null for insufficient data`() {
+        val bytes = byteArrayOf(0x02, 0x15.toByte(), 0x01, 0x02) // too short
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    @Test
+    fun `parse iBeacon handles positive measuredPower`() {
+        // iBeacon with measuredPower = +4 (0x04)
+        val bytes =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(),
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0x04,
+            )
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+        val beacon = Beacon.parse(ad) as Beacon.IBeacon
+        assertEquals(4, beacon.measuredPower)
+    }
+
+    // --- Eddystone-UID ---
+
+    @Test
+    fun `parse EddystoneUID from valid service data`() {
+        // Eddystone-UID: ranging=-18, namespace=6E4A0C0D9C8E4B3AA1F2, instance=C5D6E7F8A9B0
+        val bytes =
+            byteArrayOf(
+                0x00, // frame type = UID
+                0xEE.toByte(), // ranging data = -18
+                0x6E.toByte(),
+                0x4A.toByte(),
+                0x0C.toByte(),
+                0x0D.toByte(),
+                0x9C.toByte(), // namespace 0-4
+                0x8E.toByte(),
+                0x4B.toByte(),
+                0x3A.toByte(),
+                0xA1.toByte(),
+                0xF2.toByte(), // namespace 5-9
+                0xC5.toByte(),
+                0xD6.toByte(),
+                0xE7.toByte(),
+                0xF8.toByte(),
+                0xA9.toByte(),
+                0xB0.toByte(), // instance
+            )
+
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad)
+
+        assertTrue(beacon is Beacon.EddystoneUID)
+        val uid = beacon as Beacon.EddystoneUID
+        assertEquals(-18, uid.rangingData)
+        assertContentEquals(
+            byteArrayOf(
+                0x6E.toByte(),
+                0x4A.toByte(),
+                0x0C.toByte(),
+                0x0D.toByte(),
+                0x9C.toByte(),
+                0x8E.toByte(),
+                0x4B.toByte(),
+                0x3A.toByte(),
+                0xA1.toByte(),
+                0xF2.toByte(),
+            ),
+            uid.namespace,
+        )
+        assertContentEquals(
+            byteArrayOf(
+                0xC5.toByte(),
+                0xD6.toByte(),
+                0xE7.toByte(),
+                0xF8.toByte(),
+                0xA9.toByte(),
+                0xB0.toByte(),
+            ),
+            uid.instance,
+        )
+    }
+
+    @Test
+    fun `parse EddystoneUID returns null for insufficient data`() {
+        val bytes = byteArrayOf(0x00, 0xEE.toByte(), 0x01) // too short
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    // --- Eddystone-URL ---
+
+    @Test
+    fun `parse EddystoneURL https scheme with dot-com expansion`() {
+        // https://nousresearch.com/
+        // Scheme 0x03 = https://, "nousresearch" literal, 0x00 = .com/
+        val bytes =
+            byteArrayOf(
+                0x10, // frame type = URL
+                0xEE.toByte(), // txPower = -18
+                0x03, // scheme = https://
+                0x6E.toByte(),
+                0x6F.toByte(),
+                0x75.toByte(),
+                0x73.toByte(), // nous
+                0x72.toByte(),
+                0x65.toByte(),
+                0x73.toByte(),
+                0x65.toByte(), // rese
+                0x61.toByte(),
+                0x72.toByte(),
+                0x63.toByte(),
+                0x68.toByte(), // arch
+                0x00, // .com/
+            )
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad)
+
+        assertTrue(beacon is Beacon.EddystoneURL)
+        val urlBeacon = beacon as Beacon.EddystoneURL
+        assertEquals(-18, urlBeacon.txPower)
+        assertEquals("https://nousresearch.com/", urlBeacon.url)
+    }
+
+    @Test
+    fun `parse EddystoneURL http scheme without www`() {
+        // http://example.org/
+        // Scheme 0x02 = http://, "example" literal, 0x01 = .org/
+        val bytes =
+            byteArrayOf(
+                0x10,
+                0x00, // txPower = 0
+                0x02, // scheme = http://
+                0x65.toByte(),
+                0x78.toByte(),
+                0x61.toByte(),
+                0x6D.toByte(), // exam
+                0x70.toByte(),
+                0x6C.toByte(),
+                0x65.toByte(), // ple
+                0x01, // .org/
+            )
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad) as Beacon.EddystoneURL
+
+        assertEquals("http://example.org/", beacon.url)
+    }
+
+    @Test
+    fun `parse EddystoneURL returns null for unknown scheme`() {
+        val bytes = byteArrayOf(0x10, 0x00, 0xFF.toByte()) // invalid scheme
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    @Test
+    fun `parse EddystoneURL returns null for insufficient data`() {
+        val bytes = byteArrayOf(0x10, 0x00) // no scheme byte
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    // --- Eddystone-TLM ---
+
+    @Test
+    fun `parse EddystoneTLM from valid service data`() {
+        // TLM: battery=3228mV, temp=5.0C, count=42, uptime=360.0s
+        val bytes =
+            byteArrayOf(
+                0x20, // frame type = TLM
+                0x00, // version = 0 (unencrypted)
+                0x0C.toByte(),
+                0x9C.toByte(), // battery = 3228 mV
+                0x05,
+                0x00, // temperature = 5.0C (1280/256)
+                0x00,
+                0x00,
+                0x00,
+                0x2A, // adv count = 42
+                0x00,
+                0x00,
+                0x0E.toByte(),
+                0x10, // uptime = 3600 tenths = 360.0s
+            )
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad)
+
+        assertTrue(beacon is Beacon.EddystoneTLM)
+        val tlm = beacon as Beacon.EddystoneTLM
+        assertEquals(3228, tlm.batteryVoltageMv)
+        assertEquals(5.0f, tlm.temperatureCelsius)
+        assertEquals(42L, tlm.advertisementCount)
+        assertEquals(360.0, tlm.uptimeSeconds)
+    }
+
+    @Test
+    fun `parse EddystoneTLM handles unsupported battery and temperature`() {
+        // TLM with battery=0 (unsupported) and temperature=0x8000 (unsupported)
+        val bytes =
+            byteArrayOf(
+                0x20,
+                0x00,
+                0x00,
+                0x00, // battery = 0 (unsupported)
+                0x80.toByte(),
+                0x00, // temperature = 0x8000 (unsupported)
+                0x00,
+                0x00,
+                0x00,
+                0x01, // adv count = 1
+                0x00,
+                0x00,
+                0x00,
+                0x0A, // uptime = 10 tenths = 1.0s
+            )
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad) as Beacon.EddystoneTLM
+
+        assertEquals(null, beacon.batteryVoltageMv)
+        assertEquals(null, beacon.temperatureCelsius)
+        assertEquals(1L, beacon.advertisementCount)
+        assertEquals(1.0, beacon.uptimeSeconds)
+    }
+
+    @Test
+    fun `parse EddystoneTLM returns null for insufficient data`() {
+        val bytes = byteArrayOf(0x20, 0x00, 0x01) // too short
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    // --- Convenience extensions ---
+
+    @Test
+    fun `isBeacon returns true for iBeacon advertisement`() {
+        val bytes =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(),
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0xC5.toByte(),
+            )
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+        assertTrue(ad.isBeacon())
+    }
+
+    @Test
+    fun `isBeacon returns false for non-beacon advertisement`() {
+        val ad = createAdvertisement()
+        assertTrue(!ad.isBeacon())
+    }
+
+    @Test
+    fun `parseBeacon extension works identically to Beacon dot parse`() {
+        val bytes =
+            byteArrayOf(
+                0x02,
+                0x15.toByte(),
+                0xE2.toByte(),
+                0xC5.toByte(),
+                0x6D.toByte(),
+                0xB5.toByte(),
+                0xDF.toByte(),
+                0xFB.toByte(),
+                0x48.toByte(),
+                0xD2.toByte(),
+                0xB0.toByte(),
+                0x60.toByte(),
+                0xD0.toByte(),
+                0xF5.toByte(),
+                0xA7.toByte(),
+                0x10.toByte(),
+                0x96.toByte(),
+                0xE0.toByte(),
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0xC5.toByte(),
+            )
+        val ad = createAdvertisement(manufacturerData = mapOf(0x004C to BleData(bytes)))
+
+        val viaCompanion = Beacon.parse(ad)
+        val viaExtension = ad.parseBeacon()
+
+        assertNotNull(viaCompanion)
+        assertNotNull(viaExtension)
+        assertEquals(viaCompanion, viaExtension)
+    }
+
+    @Test
+    fun `parse returns null for empty advertisement`() {
+        val ad = createAdvertisement()
+        assertNull(Beacon.parse(ad))
+    }
+
+    @Test
+    fun `parse returns null for wrong Eddystone frame type`() {
+        // frame type 0xFF is not recognized
+        val bytes = byteArrayOf(0xFF.toByte(), 0x00, 0x00, 0x00)
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        assertNull(Beacon.parse(ad))
+    }
+
+    // --- EddystoneUID equality ---
+
+    @Test
+    fun `EddystoneUID with identical bytes are equal`() {
+        val ns = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        val inst = byteArrayOf(11, 12, 13, 14, 15, 16)
+        val ad = createAdvertisement()
+
+        val uid1 = Beacon.EddystoneUID(ad, ns.copyOf(), inst.copyOf(), -18)
+        val uid2 = Beacon.EddystoneUID(ad, ns.copyOf(), inst.copyOf(), -18)
+
+        assertEquals(uid1, uid2)
+        assertEquals(uid1.hashCode(), uid2.hashCode())
+    }
+
+    @Test
+    fun `EddystoneUID with different instance bytes are not equal`() {
+        val ns = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        val inst1 = byteArrayOf(11, 12, 13, 14, 15, 16)
+        val inst2 = byteArrayOf(11, 12, 13, 14, 15, 99)
+        val ad = createAdvertisement()
+
+        val uid1 = Beacon.EddystoneUID(ad, ns.copyOf(), inst1, -18)
+        val uid2 = Beacon.EddystoneUID(ad, ns.copyOf(), inst2, -18)
+
+        assertTrue(uid1 != uid2)
+    }
+
+    // --- EddystoneTLM negative temperature ---
+
+    @Test
+    fun `parse EddystoneTLM handles negative temperature`() {
+        // TLM with temp = -5.0C (-1280/256)
+        val bytes =
+            byteArrayOf(
+                0x20,
+                0x00,
+                0x0B.toByte(),
+                0xB8.toByte(), // battery = 3000 mV
+                0xFB.toByte(),
+                0x00, // temperature = -1280 = -5.0C (signed 8.8)
+                0x00,
+                0x00,
+                0x00,
+                0x01, // adv count = 1
+                0x00,
+                0x00,
+                0x00,
+                0x64, // uptime = 100 tenths = 10.0s
+            )
+        val eddystoneUuid = Beacon.EDDYSTONE_SERVICE_UUID
+        val ad = createAdvertisement(serviceData = mapOf(eddystoneUuid to BleData(bytes)))
+        val beacon = Beacon.parse(ad) as Beacon.EddystoneTLM
+
+        assertEquals(-5.0f, beacon.temperatureCelsius)
+    }
+
+    // --- helper ---
+
+    private fun createAdvertisement(
+        manufacturerData: Map<Int, BleData> = emptyMap(),
+        serviceData: Map<kotlin.uuid.Uuid, BleData> = emptyMap(),
+    ): Advertisement =
+        Advertisement(
+            identifier = Identifier("AA:BB:CC:DD:EE:FF"),
+            name = null,
+            rssi = -55,
+            txPower = null,
+            isConnectable = true,
+            serviceUuids = emptyList(),
+            manufacturerData = manufacturerData,
+            serviceData = serviceData,
+            timestampNanos = 0L,
+        )
+}


### PR DESCRIPTION
## Summary

Adds beacon scanning support for iBeacon (Apple) and Eddystone (Google) protocols.

## Changes

- **`Beacon` sealed class hierarchy** with `IBeacon`, `EddystoneUID`, `EddystoneURL`, `EddystoneTLM` data classes
- **`Advertisement.isBeacon()`** and **`Advertisement.parseBeacon()`** convenience extensions
- **`BeaconScanner`** wrapper that filters `Scanner` scan events to beacon-only `BeaconEvent` emissions
- **Test coverage**: 15 BeaconTest + 6 BeaconScannerTest = 21 tests with real-world beacon advertisement bytes

## Design decisions

- Pure commonMain code — no platform-specific implementation needed (beacon parsing works entirely from `Advertisement.manufacturerData` and `Advertisement.serviceData`)
- Follows `ConnectionQualityMonitor` pattern: stand-alone wrapper using existing `Scanner` API, no changes to platform source
- `BeaconScanner` uses explicit start/stop/close lifecycle with Job-based cancellation

## Testing

- iBeacon parsing from Apple manufacturer data (UUID, major, minor, measuredPower)
- Eddystone-UID parsing (namespace, instance, ranging data)
- Eddystone-URL parsing with scheme expansion and URL code decoding
- Eddystone-TLM parsing (battery, temperature, advertisement count, uptime)
- Negative/edge cases: wrong company ID, wrong type byte, insufficient data, unsupported sensors
- BeaconScanner filtering (beacon vs non-beacon, error forwarding, idempotent start/stop/close)
- EddystoneUID content-based equals/hashCode

Closes #255