### PR TITLE
feat(phy): add readPhy() and phyUpdate flow to Peripheral (#263)

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -71,6 +71,12 @@ internal sealed interface GattCallbackEvent {
         val rxPhy: Int,
         val status: Int,
     ) : GattCallbackEvent
+
+    data class PhyRead(
+        val txPhy: Int,
+        val rxPhy: Int,
+        val status: Int,
+    ) : GattCallbackEvent
 }
 
 internal class AndroidGattBridge(
@@ -167,6 +173,15 @@ internal class AndroidGattBridge(
             ) {
                 onEvent?.invoke(GattCallbackEvent.PhyUpdated(txPhy, rxPhy, status))
             }
+
+            override fun onPhyRead(
+                gatt: BluetoothGatt,
+                txPhy: Int,
+                rxPhy: Int,
+                status: Int,
+            ) {
+                onEvent?.invoke(GattCallbackEvent.PhyRead(txPhy, rxPhy, status))
+            }
         }
 
     internal fun connect(options: ConnectionOptions): BluetoothGatt? {
@@ -207,6 +222,12 @@ internal class AndroidGattBridge(
     ): Boolean {
         val g = gatt ?: return false
         g.setPreferredPhy(txPhyMask, rxPhyMask, phyOptions)
+        return true
+    }
+
+    internal fun readPhy(): Boolean {
+        val g = gatt ?: return false
+        g.readPhy()
         return true
     }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -15,6 +15,7 @@ import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ReconnectionHandler
@@ -46,6 +47,7 @@ import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.quirks.QuirkRegistry
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
@@ -72,6 +74,8 @@ public class AndroidPeripheral internal constructor(
 
     internal val nativeCharMap = mutableMapOf<Characteristic, BluetoothGattCharacteristic>()
     internal val nativeDescMap = mutableMapOf<Descriptor, BluetoothGattDescriptor>()
+
+    internal val _phyUpdate = MutableSharedFlow<PhyUpdate>(extraBufferCapacity = 16)
 
     internal val bondManager = AndroidBondManager(device, context, peripheralContext)
 
@@ -329,6 +333,25 @@ public class AndroidPeripheral internal constructor(
             )
         }
     }
+
+    @ExperimentalBleApi
+    override suspend fun readPhy(): PhyResult? {
+        checkNotClosed()
+        return peripheralContext.gattQueue.enqueue {
+            val result =
+                pendingOps.awaitGatt(PendingOp.PhyRead, "readPhy") {
+                    bridge.readPhy()
+                }
+            if (!result.status.isSuccess()) return@enqueue null
+            PhyResult(
+                tx = phyConstantToPhy(result.txPhyConstant),
+                rx = phyConstantToPhy(result.rxPhyConstant),
+            )
+        }
+    }
+
+    @ExperimentalBleApi
+    override val phyUpdate: Flow<PhyUpdate> = _phyUpdate
 
     override suspend fun openL2capChannel(
         psm: Int,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
@@ -4,6 +4,7 @@ package com.atruedev.kmpble.peripheral
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothGattCharacteristic
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.BleException
@@ -60,6 +61,7 @@ internal fun AndroidPeripheral.handleGattEvent(event: GattCallbackEvent) {
                 pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
             is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
             is GattCallbackEvent.PhyUpdated -> handlePhyUpdated(event)
+            is GattCallbackEvent.PhyRead -> handlePhyRead(event)
         }
     }
 }
@@ -104,13 +106,34 @@ internal fun AndroidPeripheral.handleRssiResult(event: GattCallbackEvent.ReadRem
 }
 
 internal fun AndroidPeripheral.handlePhyUpdated(event: GattCallbackEvent.PhyUpdated) {
+    val status = event.status.toGattStatus()
+    val phyUpdate =
+        PhyUpdate(
+            txPhy = phyConstantToPhy(event.txPhy),
+            rxPhy = phyConstantToPhy(event.rxPhy),
+        )
     if (pendingOps.has(PendingOp.PhyUpdate)) {
         pendingOps.complete(
             PendingOp.PhyUpdate,
             PhyUpdateResult(
                 txPhyConstant = event.txPhy,
                 rxPhyConstant = event.rxPhy,
-                status = event.status.toGattStatus(),
+                status = status,
+            ),
+        )
+    }
+    _phyUpdate.tryEmit(phyUpdate)
+}
+
+internal fun AndroidPeripheral.handlePhyRead(event: GattCallbackEvent.PhyRead) {
+    if (pendingOps.has(PendingOp.PhyRead)) {
+        val status = event.status.toGattStatus()
+        pendingOps.complete(
+            PendingOp.PhyRead,
+            PhyUpdateResult(
+                txPhyConstant = event.txPhy,
+                rxPhyConstant = event.rxPhy,
+                status = status,
             ),
         )
     }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/Phy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/Phy.kt
@@ -12,3 +12,15 @@ public enum class Phy {
     Le2M,
     LeCoded,
 }
+
+/**
+ * Notification that the active PHY for a connection has changed.
+ *
+ * Emitted by [com.atruedev.kmpble.peripheral.Peripheral.phyUpdate] when the
+ * controller negotiates a new PHY (spontaneously or in response to a
+ * [com.atruedev.kmpble.peripheral.Peripheral.setPreferredPhy] request).
+ */
+public data class PhyUpdate(
+    val txPhy: Phy,
+    val rxPhy: Phy,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -34,6 +34,8 @@ internal sealed interface PendingOp<T> {
     data object MtuRequest : PendingOp<Int>
 
     data object PhyUpdate : PendingOp<PhyUpdateResult>
+
+    data object PhyRead : PendingOp<PhyUpdateResult>
 }
 
 internal data class PhyUpdateResult(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -174,6 +175,37 @@ public interface Peripheral : AutoCloseable {
         tx: Phy,
         rx: Phy,
     ): PhyResult?
+
+    /**
+     * Actively read the current PHY for this connection.
+     *
+     * On Android, maps to [android.bluetooth.BluetoothGatt.readPhy] (API 26+).
+     * Suspends until the `onPhyRead` callback fires or times out.
+     *
+     * On iOS, returns `null`. CoreBluetooth does not expose PHY read-back
+     * through public API.
+     *
+     * @return [PhyResult] reflecting the current TX/RX PHYs, or `null` if
+     *         the platform does not support the operation.
+     */
+    @ExperimentalBleApi
+    public suspend fun readPhy(): PhyResult?
+
+    /**
+     * Flow of spontaneous PHY change events for this connection.
+     *
+     * Emits [PhyUpdate] when the controller negotiates a new PHY, whether
+     * triggered by a [setPreferredPhy] request or autonomously by the
+     * controller (e.g., range-based adaptation).
+     *
+     * The flow is **hot** -- it emits only while the peripheral is connected.
+     * Collectors will see no events during disconnects.
+     *
+     * On iOS, this flow never emits. CoreBluetooth does not expose PHY
+     * change notifications through public API.
+     */
+    @ExperimentalBleApi
+    public val phyUpdate: Flow<PhyUpdate>
 
     public val maximumWriteValueLength: StateFlow<Int>
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
@@ -2,6 +2,7 @@ package com.atruedev.kmpble.testing
 
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.GattError
@@ -23,6 +24,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -41,6 +43,28 @@ internal class FakeGattResponder(
     private val cccdWritesState: MutableStateFlow<List<FakePeripheral.CccdWrite>>,
     private val closedFlag: () -> Boolean,
 ) {
+    private val _phyUpdate = MutableSharedFlow<PhyUpdate>(extraBufferCapacity = 16)
+    internal val phyUpdate: Flow<PhyUpdate> = _phyUpdate
+
+    private var configuredTxPhy: Phy = Phy.Le1M
+    private var configuredRxPhy: Phy = Phy.Le1M
+
+    /** Configure the PHY values that [readPhy] returns. */
+    internal fun configurePhy(
+        tx: Phy,
+        rx: Phy,
+    ) {
+        configuredTxPhy = tx
+        configuredRxPhy = rx
+    }
+
+    internal suspend fun emitPhyUpdate(
+        tx: Phy,
+        rx: Phy,
+    ) {
+        _phyUpdate.emit(PhyUpdate(tx, rx))
+    }
+
     private fun checkNotClosed() {
         check(!closedFlag()) { "Peripheral is closed" }
     }
@@ -251,5 +275,11 @@ internal class FakeGattResponder(
         checkNotClosed()
         checkConnected()
         return PhyResult(tx, rx)
+    }
+
+    suspend fun readPhy(): PhyResult? {
+        checkNotClosed()
+        checkConnected()
+        return PhyResult(configuredTxPhy, configuredRxPhy)
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -4,6 +4,7 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.BleError
@@ -215,6 +216,12 @@ public class FakePeripheral internal constructor(
         rx: Phy,
     ): PhyResult? = gattResponder.setPreferredPhy(tx, rx)
 
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun readPhy(): PhyResult? = gattResponder.readPhy()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override val phyUpdate: Flow<PhyUpdate> = gattResponder.phyUpdate
+
     // --- Test Simulation Methods (delegated to FakeConnectionSimulator) ---
 
     /**
@@ -259,6 +266,22 @@ public class FakePeripheral internal constructor(
         value: ByteArray,
     ) {
         connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
+    }
+
+    /** Configure the PHY values returned by [readPhy]. */
+    public fun configurePhy(
+        tx: Phy,
+        rx: Phy,
+    ) {
+        gattResponder.configurePhy(tx, rx)
+    }
+
+    /** Simulate a spontaneous PHY update, which emits to [phyUpdate]. */
+    public suspend fun emitPhyUpdate(
+        tx: Phy,
+        rx: Phy,
+    ) {
+        gattResponder.emitPhyUpdate(tx, rx)
     }
 
     /** Returns all CCCD writes recorded during observation setup/teardown. */

--- a/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
@@ -1,6 +1,9 @@
 package com.atruedev.kmpble.conformance
 
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Observation
@@ -451,5 +454,82 @@ public abstract class BleConformanceTest {
             assertFailsWith<IllegalStateException> {
                 listener.simulateIncoming(FakeL2capChannel(psm = 0x82))
             }
+        }
+
+    // -- PHY conformance --
+
+    @Test
+    @OptIn(ExperimentalBleApi::class)
+    fun `setPreferredPhy returns PhyResult with requested PHY`() =
+        runTest {
+            val peripheral =
+                buildPeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect(ConnectionOptions())
+            val result = peripheral.setPreferredPhy(Phy.Le2M, Phy.Le2M)
+            assertEquals(Phy.Le2M, result?.tx)
+            assertEquals(Phy.Le2M, result?.rx)
+            peripheral.close()
+        }
+
+    @Test
+    @OptIn(ExperimentalBleApi::class)
+    fun `readPhy returns configured PHY values`() =
+        runTest {
+            val peripheral =
+                buildPeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.configurePhy(Phy.LeCoded, Phy.Le2M)
+            peripheral.connect(ConnectionOptions())
+            val result = peripheral.readPhy()
+            assertEquals(Phy.LeCoded, result?.tx)
+            assertEquals(Phy.Le2M, result?.rx)
+            peripheral.close()
+        }
+
+    @Test
+    @OptIn(ExperimentalBleApi::class)
+    fun `phyUpdate flow receives emitted updates`() =
+        runTest {
+            val peripheral =
+                buildPeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect(ConnectionOptions())
+            val updates = mutableListOf<PhyUpdate>()
+            val job = backgroundScope.launch { peripheral.phyUpdate.collect { updates.add(it) } }
+            testScheduler.runCurrent()
+            peripheral.emitPhyUpdate(Phy.Le2M, Phy.LeCoded)
+            testScheduler.runCurrent()
+            assertEquals(1, updates.size)
+            assertEquals(Phy.Le2M, updates[0].txPhy)
+            assertEquals(Phy.LeCoded, updates[0].rxPhy)
+            job.cancel()
+            peripheral.close()
+        }
+
+    @Test
+    @OptIn(ExperimentalBleApi::class)
+    fun `setPreferredPhy with LeCoded returns LeCoded`() =
+        runTest {
+            val peripheral =
+                buildPeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect(ConnectionOptions())
+            val result = peripheral.setPreferredPhy(Phy.LeCoded, Phy.LeCoded)
+            assertEquals(Phy.LeCoded, result?.tx)
+            assertEquals(Phy.LeCoded, result?.rx)
+            peripheral.close()
         }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
@@ -44,6 +45,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import platform.CoreBluetooth.CBCharacteristic
@@ -351,6 +353,15 @@ public class IosPeripheral(
         checkNotClosed()
         return null
     }
+
+    @ExperimentalBleApi
+    override suspend fun readPhy(): PhyResult? {
+        checkNotClosed()
+        return null
+    }
+
+    @ExperimentalBleApi
+    override val phyUpdate: Flow<PhyUpdate> = emptyFlow()
 
     override suspend fun openL2capChannel(
         psm: Int,

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -6,6 +6,7 @@ import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -95,6 +96,12 @@ internal class StubPeripheral(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override suspend fun readPhy(): PhyResult? = unsupported()
+
+    @com.atruedev.kmpble.ExperimentalBleApi
+    override val phyUpdate: Flow<PhyUpdate> = unsupported()
 
     override suspend fun openL2capChannel(
         psm: Int,


### PR DESCRIPTION
## Summary

Adds two new PHY capabilities to the `Peripheral` interface, filling the gaps identified in #263:

- **`readPhy()`** -- Active PHY read-back (Android: `BluetoothGatt.readPhy()` via new `onPhyRead` callback; iOS: returns `null`)
- **`phyUpdate: Flow<PhyUpdate>`** -- Hot flow of spontaneous PHY change events (Android: `onPhyUpdate` callback; iOS: never emits)
- **`PhyUpdate`** data class (`txPhy: Phy, rxPhy: Phy`) in `connection` package

## Changes

| File | Change |
|------|--------|
| `Phy.kt` | Add `PhyUpdate` data class |
| `Peripheral.kt` | Add `readPhy()` + `phyUpdate` to interface |
| `FakeGattResponder.kt` | Add `configurePhy()`, `emitPhyUpdate()`, `readPhy()` |
| `FakePeripheral.kt` | Delegate to responder + public test helpers |
| `AndroidGattBridge.kt` | Add `PhyRead` event, `onPhyRead` callback, `readPhy()` bridge method |
| `AndroidGattHandler.kt` | Handle `PhyRead` event, emit spontaneous `PhyUpdated` to flow |
| `AndroidPeripheral.kt` | Implement `readPhy()` + `phyUpdate` flow |
| `IosPeripheral.kt` | Stub: `readPhy()` returns null, `phyUpdate` is `emptyFlow()` |
| `BleConformanceTest.kt` | 4 new PHY conformance tests |
| `StubPeripheral.kt` | Stub implementations for Lincheck |

## Tests

- [x] `setPreferredPhy returns PhyResult with requested PHY`
- [x] `readPhy returns configured PHY values`
- [x] `phyUpdate flow receives emitted updates`
- [x] `setPreferredPhy with LeCoded returns LeCoded`
- [x] ktlintCheck passes all source sets
- [x] Typography check clean
- [x] `:compileKotlinJvm` and `:compileKotlinIosSimulatorArm64` pass