### PR TITLE
feat(server): add periodic advertising support to ExtendedAdvertiser

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -9,6 +9,7 @@ import android.bluetooth.le.AdvertisingSet
 import android.bluetooth.le.AdvertisingSetCallback
 import android.bluetooth.le.AdvertisingSetParameters
 import android.bluetooth.le.BluetoothLeAdvertiser
+import android.bluetooth.le.PeriodicAdvertisingParameters
 import android.content.Context
 import android.os.ParcelUuid
 import com.atruedev.kmpble.ExperimentalBleApi
@@ -54,6 +55,8 @@ internal class AndroidExtendedAdvertiser(
 
         val params = config.toParameters()
         val data = config.toAdvertiseData()
+        val periodicParams = config.periodicAdvertising?.toAndroidPeriodicParams()
+        val periodicData = if (config.periodicAdvertising != null) config.toPeriodicData() else null
 
         val setId = withContext(serialDispatcher) { ++nextSetId }
         lateinit var callbackRef: AdvertisingSetCallback
@@ -70,6 +73,28 @@ internal class AndroidExtendedAdvertiser(
                             advertisingSets[setId] = AdvertisingSetHandle(advertisingSet, callbackRef)
                             _activeSets.update { it + setId }
                             logEvent(BleLogEvent.ServerLifecycle("extended advertising set $setId started"))
+
+                            if (periodicParams != null && periodicData != null) {
+                                try {
+                                    advertisingSet.setPeriodicAdvertisingParameters(periodicParams)
+                                    advertisingSet.setPeriodicAdvertisingData(periodicData)
+                                    advertisingSet.setPeriodicAdvertisingEnabled(true)
+                                    logEvent(
+                                        BleLogEvent.ServerLifecycle(
+                                            "periodic advertising enabled for set $setId",
+                                        ),
+                                    )
+                                } catch (e: Exception) {
+                                    logEvent(
+                                        BleLogEvent.Error(
+                                            identifier = null,
+                                            message = "Failed to enable periodic advertising: ${e.message}",
+                                            cause = e,
+                                        ),
+                                    )
+                                }
+                            }
+
                             deferred.complete(setId)
                         } else {
                             deferred.completeExceptionally(
@@ -95,7 +120,7 @@ internal class AndroidExtendedAdvertiser(
         callbackRef = callback
 
         try {
-            advertiser.startAdvertisingSet(params, data, null, null, null, callback)
+            advertiser.startAdvertisingSet(params, data, null, periodicParams, periodicData, callback)
         } catch (e: SecurityException) {
             throw AdvertiserException.StartFailed("Missing BLUETOOTH_ADVERTISE permission", e)
         }
@@ -186,6 +211,31 @@ private fun ExtendedAdvertiseConfig.toAdvertiseData(): AdvertiseData {
         builder.addServiceData(ParcelUuid(uuid.toJavaUuid()), data)
     }
 
+    return builder.build()
+}
+
+@ExperimentalBleApi
+private fun ExtendedAdvertiseConfig.toPeriodicData(): AdvertiseData {
+    val builder = AdvertiseData.Builder()
+    for ((uuid, data) in serviceData) {
+        builder.addServiceData(ParcelUuid(uuid.toJavaUuid()), data)
+    }
+
+    val periodic = periodicAdvertising
+    if (periodic != null && periodic.includeTxPower) {
+        builder.setIncludeTxPower(true)
+    }
+
+    return builder.build()
+}
+
+@ExperimentalBleApi
+private fun PeriodicAdvertisingParameters.toAndroidPeriodicParams(): PeriodicAdvertisingParameters {
+    val builder =
+        PeriodicAdvertisingParameters
+            .Builder()
+            .setIncludeTxPower(includeTxPower)
+            .setInterval(interval.toAndroidInterval())
     return builder.build()
 }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -9,7 +9,6 @@ import android.bluetooth.le.AdvertisingSet
 import android.bluetooth.le.AdvertisingSetCallback
 import android.bluetooth.le.AdvertisingSetParameters
 import android.bluetooth.le.BluetoothLeAdvertiser
-import android.bluetooth.le.PeriodicAdvertisingParameters
 import android.content.Context
 import android.os.ParcelUuid
 import com.atruedev.kmpble.ExperimentalBleApi
@@ -220,19 +219,14 @@ private fun ExtendedAdvertiseConfig.toPeriodicData(): AdvertiseData {
     for ((uuid, data) in serviceData) {
         builder.addServiceData(ParcelUuid(uuid.toJavaUuid()), data)
     }
-
-    val periodic = periodicAdvertising
-    if (periodic != null && periodic.includeTxPower) {
-        builder.setIncludeTxPower(true)
-    }
-
     return builder.build()
 }
 
 @ExperimentalBleApi
-private fun PeriodicAdvertisingParameters.toAndroidPeriodicParams(): PeriodicAdvertisingParameters {
+private fun PeriodicAdvertisingParameters.toAndroidPeriodicParams():
+    android.bluetooth.le.PeriodicAdvertisingParameters {
     val builder =
-        PeriodicAdvertisingParameters
+        android.bluetooth.le.PeriodicAdvertisingParameters
             .Builder()
             .setIncludeTxPower(includeTxPower)
             .setInterval(interval.toAndroidInterval())

--- a/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/server/ExtendedAdvertiser.kt
@@ -50,6 +50,29 @@ public interface ExtendedAdvertiser : AutoCloseable {
 }
 
 /**
+ * Parameters for BLE 5.0 periodic advertising.
+ *
+ * When set on [ExtendedAdvertiseConfig], the advertiser broadcasts on
+ * secondary advertising channels at a fixed interval after the initial
+ * extended advertising burst on primary channels (37/38/39).
+ *
+ * Scanners use `PeriodicAdvertisingSync` to receive periodic advertising
+ * reports without continuous scanning.
+ *
+ * ## Platform Support
+ *
+ * - **Android**: Full support via `AdvertisingSet` API (API 26+).
+ * - **iOS**: Not supported by CoreBluetooth; silently ignored with a log warning.
+ */
+@ExperimentalBleApi
+public data class PeriodicAdvertisingParameters(
+    /** Whether to include TX power in periodic advertising data. */
+    public val includeTxPower: Boolean = false,
+    /** Periodic advertising interval controlling discovery speed vs power. */
+    public val interval: AdvertiseInterval = AdvertiseInterval.Balanced,
+)
+
+/**
  * Configuration for a BLE 5.0 extended advertising set.
  */
 @ExperimentalBleApi
@@ -65,6 +88,8 @@ public class ExtendedAdvertiseConfig(
     public val secondaryPhy: Phy = Phy.Le1M,
     public val interval: AdvertiseInterval = AdvertiseInterval.Balanced,
     public val txPower: AdvertiseTxPower = AdvertiseTxPower.Medium,
+    /** Enable periodic advertising on secondary channels (BLE 5.0+). */
+    public val periodicAdvertising: PeriodicAdvertisingParameters? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -79,6 +104,7 @@ public class ExtendedAdvertiseConfig(
             secondaryPhy == other.secondaryPhy &&
             interval == other.interval &&
             txPower == other.txPower &&
+            periodicAdvertising == other.periodicAdvertising &&
             manufacturerData.keys == other.manufacturerData.keys &&
             manufacturerData.all { (k, v) -> other.manufacturerData[k]?.contentEquals(v) == true } &&
             serviceData.keys == other.serviceData.keys &&
@@ -103,12 +129,14 @@ public class ExtendedAdvertiseConfig(
         result = 31 * result + secondaryPhy.hashCode()
         result = 31 * result + interval.hashCode()
         result = 31 * result + txPower.hashCode()
+        result = 31 * result + (periodicAdvertising?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String =
         "ExtendedAdvertiseConfig(name=$name, serviceUuids=$serviceUuids, " +
-            "connectable=$connectable, primaryPhy=$primaryPhy, secondaryPhy=$secondaryPhy)"
+            "connectable=$connectable, primaryPhy=$primaryPhy, secondaryPhy=$secondaryPhy, " +
+            "periodicAdvertising=$periodicAdvertising)"
 }
 
 /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeExtendedAdvertiser.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeExtendedAdvertiser.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.testing
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.server.ExtendedAdvertiseConfig
 import com.atruedev.kmpble.server.ExtendedAdvertiser
+import com.atruedev.kmpble.server.PeriodicAdvertisingParameters
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -52,4 +53,10 @@ public class FakeExtendedAdvertiser : ExtendedAdvertiser {
 
     /** Get all active configs. */
     public fun getAllConfigs(): Map<Int, ExtendedAdvertiseConfig> = configs.toMap()
+
+    /** Check if periodic advertising is active for a specific set. */
+    public fun isPeriodicAdvertisingActive(setId: Int): Boolean = configs[setId]?.periodicAdvertising != null
+
+    /** Get the periodic advertising parameters for a set, or null if not configured. */
+    public fun getPeriodicConfig(setId: Int): PeriodicAdvertisingParameters? = configs[setId]?.periodicAdvertising
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/server/FakeExtendedAdvertiserTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/server/FakeExtendedAdvertiserTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalBleApi::class)
@@ -85,5 +87,60 @@ class FakeExtendedAdvertiserTest {
         runTest {
             val advertiser = FakeExtendedAdvertiser()
             advertiser.stopAdvertisingSet(999)
+        }
+
+    @Test
+    fun periodicAdvertisingParametersStored() =
+        runTest {
+            val advertiser = FakeExtendedAdvertiser()
+            val periodic =
+                PeriodicAdvertisingParameters(
+                    includeTxPower = true,
+                    interval = AdvertiseInterval.LowLatency,
+                )
+            val config =
+                ExtendedAdvertiseConfig(
+                    name = "PeriodicDevice",
+                    periodicAdvertising = periodic,
+                )
+
+            val setId = advertiser.startAdvertisingSet(config)
+            assertTrue(advertiser.isPeriodicAdvertisingActive(setId))
+
+            val stored = advertiser.getPeriodicConfig(setId)
+            assertNotNull(stored)
+            assertEquals(true, stored.includeTxPower)
+            assertEquals(AdvertiseInterval.LowLatency, stored.interval)
+        }
+
+    @Test
+    fun periodicAdvertisingNullByDefault() =
+        runTest {
+            val advertiser = FakeExtendedAdvertiser()
+            val config = ExtendedAdvertiseConfig(name = "NoPeriodic")
+
+            val setId = advertiser.startAdvertisingSet(config)
+            assertTrue(!advertiser.isPeriodicAdvertisingActive(setId))
+            assertNull(advertiser.getPeriodicConfig(setId))
+        }
+
+    @Test
+    fun configEqualityIncludesPeriodicAdvertising() =
+        runTest {
+            val periodic = PeriodicAdvertisingParameters(interval = AdvertiseInterval.LowPower)
+            val configA =
+                ExtendedAdvertiseConfig(
+                    name = "Test",
+                    periodicAdvertising = periodic,
+                )
+            val configB =
+                ExtendedAdvertiseConfig(
+                    name = "Test",
+                    periodicAdvertising = PeriodicAdvertisingParameters(interval = AdvertiseInterval.LowPower),
+                )
+            val configC = ExtendedAdvertiseConfig(name = "Test")
+
+            assertEquals(configA, configB)
+            assertNotEquals(configA, configC)
         }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/server/IosExtendedAdvertiser.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/server/IosExtendedAdvertiser.kt
@@ -27,8 +27,9 @@ import platform.Foundation.NSError
  *
  * CoreBluetooth does not expose BLE 5.0 extended advertising parameters.
  * This implementation provides the [ExtendedAdvertiser] contract using
- * legacy `CBPeripheralManager` advertising. PHY, interval, and scannable
- * fields from [ExtendedAdvertiseConfig] are silently ignored with a log warning.
+ * legacy `CBPeripheralManager` advertising. PHY, interval, scannable,
+ * and periodic advertising fields from [ExtendedAdvertiseConfig] are
+ * silently ignored with a log warning.
  *
  * Only one advertising set is supported at a time (iOS limitation).
  *
@@ -122,6 +123,7 @@ internal class IosExtendedAdvertiser(
         if (config.manufacturerData.isNotEmpty()) warnUnsupported("manufacturerData")
         if (config.serviceData.isNotEmpty()) warnUnsupported("serviceData")
         if (config.scannable) warnUnsupported("scannable")
+        if (config.periodicAdvertising != null) warnUnsupported("periodicAdvertising")
     }
 
     private fun warnUnsupported(field: String) {


### PR DESCRIPTION
## Summary
Adds BLE 5.0 periodic advertising support to `ExtendedAdvertiser`.

### Changes
- **commonMain**: Add `PeriodicAdvertisingParameters` data class with `includeTxPower` and `interval` fields
- **commonMain**: Add `periodicAdvertising` parameter to `ExtendedAdvertiseConfig`
- **Android**: Configure periodic advertising params and data via `AdvertisingSet` API after set start
- **iOS**: Log unsupported warning for `periodicAdvertising` (CoreBluetooth limitation)
- **Fake**: Track periodic config with `isPeriodicAdvertisingActive()` and `getPeriodicConfig()` helpers
- **Tests**: 3 new tests covering periodic param storage, null default, and equality

Resolves #267