### PR TITLE
fix(android): rethrow CancellationException in periodic advertising callback scope.launch

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidExtendedAdvertiser.kt
@@ -15,6 +15,7 @@ import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -83,6 +84,8 @@ internal class AndroidExtendedAdvertiser(
                                             "periodic advertising enabled for set $setId",
                                         ),
                                     )
+                                } catch (e: CancellationException) {
+                                    throw e
                                 } catch (e: Exception) {
                                     logEvent(
                                         BleLogEvent.Error(


### PR DESCRIPTION
## Summary
Add explicit `CancellationException` rethrow in `onAdvertisingSetStarted` callback's `scope.launch` block to prevent structured cancellation from being swallowed during periodic advertising setup.

## Changes
- Add `import kotlinx.coroutines.CancellationException`
- Add `catch (e: CancellationException) { throw e }` before generic `catch (e: Exception)` in `AndroidExtendedAdvertiser.onAdvertisingSetStarted`

## Verification
- ktlintFormat + ktlintCheck pass
- Typography check clean
- JVM + iOS Simulator compilation passes
- Main CI green

Closes #275