### PR TITLE
feat(cache): add GattCache for fast GATT service reconnection

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
@@ -1,0 +1,49 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.DiscoveredService
+
+/**
+ * In-memory LRU cache for discovered GATT services.
+ *
+ * Uses [LinkedHashMap] with access-order eviction. When the cache exceeds
+ * [maxSize], the least-recently-accessed entry is removed.
+ *
+ * Thread-safe: all public methods synchronize on the internal map.
+ */
+internal class AndroidGattCache(
+    private val maxSize: Int,
+) : GattCache {
+    private val lock = Any()
+
+    @Suppress("UNCHECKED_CAST")
+    private val cache =
+        object : LinkedHashMap<Identifier, List<DiscoveredService>>(
+            16,
+            0.75f,
+            true,
+        ) {
+            override fun removeEldestEntry(
+                eldest: MutableMap.MutableEntry<Identifier, List<DiscoveredService>>?,
+            ): Boolean = size > maxSize
+        }
+
+    override fun get(identifier: Identifier): List<DiscoveredService>? = synchronized(lock) { cache[identifier] }
+
+    override fun put(
+        identifier: Identifier,
+        services: List<DiscoveredService>,
+    ) {
+        synchronized(lock) { cache[identifier] = services }
+    }
+
+    override fun invalidate(identifier: Identifier) {
+        synchronized(lock) { cache.remove(identifier) }
+    }
+
+    override fun clear() {
+        synchronized(lock) { cache.clear() }
+    }
+}
+
+public actual fun createGattCache(maxSize: Int): GattCache = AndroidGattCache(maxSize)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
@@ -1,0 +1,93 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.DiscoveredService
+
+/**
+ * Caches discovered GATT services per peripheral to skip service discovery
+ * on subsequent reconnections.
+ *
+ * Every major BLE SDK supports GATT caching: Nordic SoftDevice, TI BLE5-Stack,
+ * ST BlueNRG, and Apple CoreBluetooth all cache discovered services. This
+ * interface provides a consistent API across platforms.
+ *
+ * ## Platform behavior
+ *
+ * - **Android**: In-memory LRU cache with configurable max size. `BluetoothGatt`
+ *   always queries the device on `discoverServices()`, so caching is essential
+ *   for fast reconnection.
+ * - **iOS**: Transparent pass-through. CoreBluetooth automatically caches
+ *   discovered services and returns them without a GATT round-trip. [get]
+ *   always returns `null` (cache miss) so callers fall through to
+ *   [Peripheral.services][com.atruedev.kmpble.peripheral.Peripheral.services].
+ * - **JVM**: Stub that always returns `null`. No Bluetooth stack is available.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val cache: GattCache = createGattCache(maxSize = 32)
+ *
+ * suspend fun discover(peripheral: Peripheral): List<DiscoveredService> {
+ *     return cache.get(peripheral.identifier)
+ *         ?: peripheral.refreshServices().also { services ->
+ *             cache.put(peripheral.identifier, services)
+ *         }
+ * }
+ *
+ * // After disconnection for a known-broken device:
+ * cache.invalidate(peripheral.identifier)
+ * ```
+ *
+ * Thread-safe across coroutines on all platforms.
+ */
+public interface GattCache {
+    /**
+     * Retrieve cached services for [identifier], or `null` if no entry exists.
+     *
+     * On iOS this always returns `null` -- CoreBluetooth handles caching
+     * internally and [Peripheral.services] returns cached results directly.
+     */
+    public fun get(identifier: Identifier): List<DiscoveredService>?
+
+    /**
+     * Store discovered [services] for [identifier].
+     *
+     * Replaces any existing entry. Call after [Peripheral.refreshServices]
+     * completes so the cache stays current with the actual GATT database.
+     */
+    public fun put(
+        identifier: Identifier,
+        services: List<DiscoveredService>,
+    )
+
+    /**
+     * Remove the cache entry for [identifier].
+     *
+     * Call when the peripheral's GATT database changes (e.g., firmware update
+     * added a service) or when service discovery fails with a stale handle
+     * error, forcing a fresh discovery on next connect.
+     */
+    public fun invalidate(identifier: Identifier)
+
+    /**
+     * Remove all cached entries.
+     *
+     * Useful when the app resets Bluetooth state, or when switching between
+     * environments (development/production) where peripheral configurations differ.
+     */
+    public fun clear()
+}
+
+/**
+ * Create a platform-appropriate [GattCache].
+ *
+ * - **Android**: In-memory LRU cache evicting the least-recently-used entry
+ *   when size exceeds [maxSize].
+ * - **iOS**: Passthrough stub (CoreBluetooth handles caching natively).
+ * - **JVM**: Stub that always returns `null`.
+ *
+ * @param maxSize Maximum number of cached peripherals (Android only).
+ *   Defaults to 64. Ignored on iOS and JVM.
+ */
+@Suppress("FUNCTION_NAME")
+public expect fun createGattCache(maxSize: Int = 64): GattCache

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
@@ -1,0 +1,144 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.scanner.uuidFrom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Shared conformance test suite for [GattCache] implementations.
+ *
+ * Subclass in platform-specific test source sets (jvmTest, iosTest)
+ * to verify behavioral consistency across platforms.
+ *
+ * Platforms that do not support application-level caching (iOS/JVM)
+ * return `null` from [GattCache.get] for all identifiers. The conformance
+ * tests validate this contract.
+ */
+public abstract class GattCacheConformanceTest {
+    /** Create a cache instance under test. */
+    protected abstract fun buildCache(maxSize: Int = 64): GattCache
+
+    /**
+     * Whether this platform's cache stores entries.
+     *
+     * - `true`: Android (LRU cache stores and returns entries)
+     * - `false`: iOS (CoreBluetooth handles caching), JVM (no Bluetooth stack)
+     */
+    protected open val supportsCaching: Boolean = false
+
+    private val identifierA = Identifier("AA:BB:CC:DD:EE:FF")
+    private val identifierB = Identifier("11:22:33:44:55:66")
+
+    private fun buildServices(): List<DiscoveredService> =
+        listOf(
+            DiscoveredService(
+                uuid = uuidFrom("180d"),
+                characteristics =
+                    listOf(
+                        Characteristic(
+                            serviceUuid = uuidFrom("180d"),
+                            uuid = uuidFrom("2a37"),
+                            properties =
+                                Characteristic.Properties(
+                                    notify = true,
+                                ),
+                        ),
+                    ),
+            ),
+        )
+
+    @Test
+    fun `get returns null for unknown identifier`() {
+        val cache = buildCache()
+        assertNull(cache.get(identifierA))
+    }
+
+    @Test
+    fun `invalidate unknown identifier is no-op`() {
+        val cache = buildCache()
+        cache.invalidate(identifierA)
+        // No exception thrown
+    }
+
+    @Test
+    fun `clear empty cache is no-op`() {
+        val cache = buildCache()
+        cache.clear()
+        // No exception thrown
+    }
+
+    @Test
+    fun `put and get round-trip`() {
+        if (!supportsCaching) return
+        val cache = buildCache()
+        val services = buildServices()
+        cache.put(identifierA, services)
+        val cached = cache.get(identifierA)
+        assertNotNull(cached)
+        assertEquals(1, cached.size)
+        assertEquals(uuidFrom("180d"), cached[0].uuid)
+    }
+
+    @Test
+    fun `put replaces existing entry`() {
+        if (!supportsCaching) return
+        val cache = buildCache()
+        val services1 = buildServices()
+        val services2 =
+            listOf(
+                DiscoveredService(
+                    uuid = uuidFrom("180a"),
+                    characteristics = emptyList(),
+                ),
+            )
+        cache.put(identifierA, services1)
+        cache.put(identifierA, services2)
+        val cached = cache.get(identifierA)
+        assertNotNull(cached)
+        assertEquals(1, cached.size)
+        assertEquals(uuidFrom("180a"), cached[0].uuid)
+    }
+
+    @Test
+    fun `invalidate removes entry`() {
+        if (!supportsCaching) return
+        val cache = buildCache()
+        cache.put(identifierA, buildServices())
+        cache.invalidate(identifierA)
+        assertNull(cache.get(identifierA))
+    }
+
+    @Test
+    fun `clear removes all entries`() {
+        if (!supportsCaching) return
+        val cache = buildCache()
+        cache.put(identifierA, buildServices())
+        cache.put(identifierB, buildServices())
+        cache.clear()
+        assertNull(cache.get(identifierA))
+        assertNull(cache.get(identifierB))
+    }
+
+    @Test
+    fun `multiple identifiers independent`() {
+        if (!supportsCaching) return
+        val cache = buildCache()
+        val servicesA = buildServices()
+        val servicesB =
+            listOf(
+                DiscoveredService(
+                    uuid = uuidFrom("180f"),
+                    characteristics = emptyList(),
+                ),
+            )
+        cache.put(identifierA, servicesA)
+        cache.put(identifierB, servicesB)
+        assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
+        assertEquals(uuidFrom("180f"), cache.get(identifierB)!![0].uuid)
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/gatt/cache/IosGattCache.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/gatt/cache/IosGattCache.kt
@@ -1,0 +1,36 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.DiscoveredService
+
+/**
+ * Passthrough [GattCache] for iOS.
+ *
+ * CoreBluetooth caches discovered services and their characteristics/descriptors
+ * automatically. [CBPeripheral.discoverServices] returns cached results on
+ * reconnection without a GATT round-trip, so an application-level cache is
+ * unnecessary.
+ *
+ * [get] always returns `null` (cache miss), forcing callers to fall through
+ * to [Peripheral.services] which returns CoreBluetooth's internally cached data.
+ */
+internal object IosGattCache : GattCache {
+    override fun get(identifier: Identifier): List<DiscoveredService>? = null
+
+    override fun put(
+        identifier: Identifier,
+        services: List<DiscoveredService>,
+    ) {
+        // CoreBluetooth handles caching natively
+    }
+
+    override fun invalidate(identifier: Identifier) {
+        // CoreBluetooth handles cache invalidation on disconnect
+    }
+
+    override fun clear() {
+        // CoreBluetooth cache lifecycle is managed by the OS
+    }
+}
+
+public actual fun createGattCache(maxSize: Int): GattCache = IosGattCache

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCache.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCache.kt
@@ -1,0 +1,32 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.DiscoveredService
+
+/**
+ * Stub [GattCache] for JVM (no Bluetooth stack).
+ *
+ * Always returns `null` from [get]; all other methods are no-ops.
+ * JVM consumers that need a real cache (e.g., desktop BLE dongles via
+ * D-Bus or serial) should provide their own [GattCache] implementation.
+ */
+internal object JvmGattCache : GattCache {
+    override fun get(identifier: Identifier): List<DiscoveredService>? = null
+
+    override fun put(
+        identifier: Identifier,
+        services: List<DiscoveredService>,
+    ) {
+        // No Bluetooth stack available on JVM
+    }
+
+    override fun invalidate(identifier: Identifier) {
+        // No-op on JVM
+    }
+
+    override fun clear() {
+        // No-op on JVM
+    }
+}
+
+public actual fun createGattCache(maxSize: Int): GattCache = JvmGattCache

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
@@ -1,0 +1,156 @@
+package com.atruedev.kmpble.gatt.cache
+
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.scanner.uuidFrom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for the LRU eviction behavior of [AndroidGattCache].
+ *
+ * Uses a standalone LRU implementation that mirrors the Android production code.
+ * The LRU eviction cannot be tested through [createGattCache] on JVM because
+ * the JVM factory returns [JvmGattCache] (a stub).
+ */
+public class AndroidGattCacheTest {
+    private fun buildCache(maxSize: Int = 64): GattCache = LruGattCache(maxSize)
+
+    private val identifierA = Identifier("AA:BB:CC:DD:EE:FF")
+    private val identifierB = Identifier("11:22:33:44:55:66")
+    private val identifierC = Identifier("AA:BB:CC:DD:EE:00")
+
+    private fun buildServices(uuid: String = "180d"): List<DiscoveredService> =
+        listOf(
+            DiscoveredService(
+                uuid = uuidFrom(uuid),
+                characteristics =
+                    listOf(
+                        Characteristic(
+                            serviceUuid = uuidFrom(uuid),
+                            uuid = uuidFrom("2a37"),
+                            properties =
+                                Characteristic.Properties(
+                                    notify = true,
+                                ),
+                        ),
+                    ),
+            ),
+        )
+
+    @Test
+    fun `put and get round-trip`() {
+        val cache = buildCache()
+        cache.put(identifierA, buildServices())
+        val cached = cache.get(identifierA)
+        assertNotNull(cached)
+        assertEquals(1, cached.size)
+    }
+
+    @Test
+    fun `invalidate removes entry`() {
+        val cache = buildCache()
+        cache.put(identifierA, buildServices())
+        cache.invalidate(identifierA)
+        assertNull(cache.get(identifierA))
+    }
+
+    @Test
+    fun `clear removes all entries`() {
+        val cache = buildCache()
+        cache.put(identifierA, buildServices())
+        cache.put(identifierB, buildServices("180a"))
+        cache.clear()
+        assertNull(cache.get(identifierA))
+        assertNull(cache.get(identifierB))
+    }
+
+    @Test
+    fun `LRU evicts least recently used when capacity exceeded`() {
+        val cache = buildCache(maxSize = 2)
+        cache.put(identifierA, buildServices("180d"))
+        cache.put(identifierB, buildServices("180a"))
+        // Access A to make B the least-recently-used
+        cache.get(identifierA)
+        // Insert C -- B should be evicted
+        cache.put(identifierC, buildServices("180f"))
+        assertNotNull(cache.get(identifierA))
+        assertNotNull(cache.get(identifierC))
+        assertNull(cache.get(identifierB))
+    }
+
+    @Test
+    fun `LRU access order promotes entry`() {
+        val cache = buildCache(maxSize = 2)
+        cache.put(identifierA, buildServices("180d"))
+        cache.put(identifierB, buildServices("180a"))
+        // Access A multiple times
+        cache.get(identifierA)
+        cache.get(identifierA)
+        // Insert C -- B should be evicted (A was accessed most recently)
+        cache.put(identifierC, buildServices("180f"))
+        assertNotNull(cache.get(identifierA))
+        assertNotNull(cache.get(identifierC))
+        assertNull(cache.get(identifierB))
+    }
+
+    @Test
+    fun `put replaces existing entry`() {
+        val cache = buildCache()
+        cache.put(identifierA, buildServices("180d"))
+        cache.put(identifierA, buildServices("180a"))
+        val cached = cache.get(identifierA)
+        assertNotNull(cached)
+        assertEquals(uuidFrom("180a"), cached[0].uuid)
+    }
+
+    @Test
+    fun `multiple identifiers independent`() {
+        val cache = buildCache()
+        cache.put(identifierA, buildServices("180d"))
+        cache.put(identifierB, buildServices("180a"))
+        assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
+        assertEquals(uuidFrom("180a"), cache.get(identifierB)!![0].uuid)
+    }
+}
+
+/**
+ * Standalone LRU [GattCache] for testing -- mirrors [AndroidGattCache].
+ */
+internal class LruGattCache(
+    private val maxSize: Int,
+) : GattCache {
+    private val lock = Any()
+
+    @Suppress("UNCHECKED_CAST")
+    private val cache =
+        object : LinkedHashMap<Identifier, List<DiscoveredService>>(
+            16,
+            0.75f,
+            true,
+        ) {
+            override fun removeEldestEntry(
+                eldest: MutableMap.MutableEntry<Identifier, List<DiscoveredService>>?,
+            ): Boolean = size > maxSize
+        }
+
+    override fun get(identifier: Identifier): List<DiscoveredService>? = synchronized(lock) { cache[identifier] }
+
+    override fun put(
+        identifier: Identifier,
+        services: List<DiscoveredService>,
+    ) {
+        synchronized(lock) { cache[identifier] = services }
+    }
+
+    override fun invalidate(identifier: Identifier) {
+        synchronized(lock) { cache.remove(identifier) }
+    }
+
+    override fun clear() {
+        synchronized(lock) { cache.clear() }
+    }
+}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCacheConformanceTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCacheConformanceTest.kt
@@ -1,0 +1,11 @@
+package com.atruedev.kmpble.gatt.cache
+
+/**
+ * JVM-specific conformance test runner for [GattCache].
+ *
+ * Uses [createGattCache] which resolves to [JvmGattCache] on JVM.
+ * Run: ./gradlew :jvmTest --tests "*JvmGattCacheConformance*"
+ */
+public class JvmGattCacheConformanceTest : GattCacheConformanceTest() {
+    override fun buildCache(maxSize: Int): GattCache = createGattCache(maxSize)
+}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -16,6 +16,7 @@ import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
@@ -115,6 +116,11 @@ internal class StubPeripheral(
         secure: Boolean,
         mtu: Int?,
     ): L2capChannel = unsupported()
+
+    override suspend fun openIsochronousChannel(
+        secure: Boolean,
+        mtu: Int?,
+    ): IsochronousChannel = unsupported()
 
     private fun unsupported(): Nothing = throw UnsupportedOperationException("StubPeripheral")
 }


### PR DESCRIPTION
## Summary
Adds `GattCache` interface with platform-specific implementations for skipping GATT service discovery on reconnection.

## Changes
- **commonMain**: `GattCache` interface with `get`/`put`/`invalidate`/`clear`
- **Android**: LRU cache using `LinkedHashMap` access-order eviction
- **iOS**: Transparent pass-through (CoreBluetooth handles caching natively)
- **JVM**: Stub (no Bluetooth stack)
- **Tests**: Conformance tests (commonTest), LRU eviction tests (jvmTest), JVM runner
- **Fix**: `StubPeripheral` missing `openIsochronousChannel` (pre-existing #276)

## Usage
```kotlin
val cache: GattCache = createGattCache(maxSize = 32)

suspend fun discover(peripheral: Peripheral): List<DiscoveredService> {
    return cache.get(peripheral.identifier)
        ?: peripheral.refreshServices().also { cache.put(peripheral.identifier, it) }
}
```

Closes #279