### PR TITLE
fix(cache): replace synchronized blocks with Mutex in AndroidGattCache

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
@@ -2,6 +2,8 @@ package com.atruedev.kmpble.gatt.cache
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.gatt.DiscoveredService
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * In-memory LRU cache for discovered GATT services.
@@ -9,12 +11,13 @@ import com.atruedev.kmpble.gatt.DiscoveredService
  * Uses [LinkedHashMap] with access-order eviction. When the cache exceeds
  * [maxSize], the least-recently-accessed entry is removed.
  *
- * Thread-safe: all public methods synchronize on the internal map.
+ * Thread-safe: all public methods use [Mutex] for structured concurrency
+ * instead of [synchronized].
  */
 internal class AndroidGattCache(
     private val maxSize: Int,
 ) : GattCache {
-    private val lock = Any()
+    private val mutex = Mutex()
 
     @Suppress("UNCHECKED_CAST")
     private val cache =
@@ -28,21 +31,22 @@ internal class AndroidGattCache(
             ): Boolean = size > maxSize
         }
 
-    override fun get(identifier: Identifier): List<DiscoveredService>? = synchronized(lock) { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? =
+        mutex.withLock { cache[identifier] }
 
-    override fun put(
+    override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
-        synchronized(lock) { cache[identifier] = services }
+        mutex.withLock { cache[identifier] = services }
     }
 
-    override fun invalidate(identifier: Identifier) {
-        synchronized(lock) { cache.remove(identifier) }
+    override suspend fun invalidate(identifier: Identifier) {
+        mutex.withLock { cache.remove(identifier) }
     }
 
-    override fun clear() {
-        synchronized(lock) { cache.clear() }
+    override suspend fun clear() {
+        mutex.withLock { cache.clear() }
     }
 }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
@@ -31,8 +31,7 @@ internal class AndroidGattCache(
             ): Boolean = size > maxSize
         }
 
-    override suspend fun get(identifier: Identifier): List<DiscoveredService>? =
-        mutex.withLock { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = mutex.withLock { cache[identifier] }
 
     override suspend fun put(
         identifier: Identifier,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
@@ -39,6 +39,9 @@ import com.atruedev.kmpble.gatt.DiscoveredService
  * ```
  *
  * Thread-safe across coroutines on all platforms.
+ *
+ * Implementation uses [kotlinx.coroutines.sync.Mutex] for structured
+ * concurrency on Android, instead of [synchronized].
  */
 public interface GattCache {
     /**
@@ -47,7 +50,7 @@ public interface GattCache {
      * On iOS this always returns `null` -- CoreBluetooth handles caching
      * internally and [Peripheral.services] returns cached results directly.
      */
-    public fun get(identifier: Identifier): List<DiscoveredService>?
+    public suspend fun get(identifier: Identifier): List<DiscoveredService>?
 
     /**
      * Store discovered [services] for [identifier].
@@ -55,7 +58,7 @@ public interface GattCache {
      * Replaces any existing entry. Call after [Peripheral.refreshServices]
      * completes so the cache stays current with the actual GATT database.
      */
-    public fun put(
+    public suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     )
@@ -67,7 +70,7 @@ public interface GattCache {
      * added a service) or when service discovery fails with a stale handle
      * error, forcing a fresh discovery on next connect.
      */
-    public fun invalidate(identifier: Identifier)
+    public suspend fun invalidate(identifier: Identifier)
 
     /**
      * Remove all cached entries.
@@ -75,7 +78,7 @@ public interface GattCache {
      * Useful when the app resets Bluetooth state, or when switching between
      * environments (development/production) where peripheral configurations differ.
      */
-    public fun clear()
+    public suspend fun clear()
 }
 
 /**

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
@@ -4,6 +4,7 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -53,28 +54,28 @@ public abstract class GattCacheConformanceTest {
         )
 
     @Test
-    fun `get returns null for unknown identifier`() {
+    fun `get returns null for unknown identifier`() = runBlocking {
         val cache = buildCache()
         assertNull(cache.get(identifierA))
     }
 
     @Test
-    fun `invalidate unknown identifier is no-op`() {
+    fun `invalidate unknown identifier is no-op`() = runBlocking {
         val cache = buildCache()
         cache.invalidate(identifierA)
         // No exception thrown
     }
 
     @Test
-    fun `clear empty cache is no-op`() {
+    fun `clear empty cache is no-op`() = runBlocking {
         val cache = buildCache()
         cache.clear()
         // No exception thrown
     }
 
     @Test
-    fun `put and get round-trip`() {
-        if (!supportsCaching) return
+    fun `put and get round-trip`() = runBlocking {
+        if (!supportsCaching) return@runBlocking
         val cache = buildCache()
         val services = buildServices()
         cache.put(identifierA, services)
@@ -85,8 +86,8 @@ public abstract class GattCacheConformanceTest {
     }
 
     @Test
-    fun `put replaces existing entry`() {
-        if (!supportsCaching) return
+    fun `put replaces existing entry`() = runBlocking {
+        if (!supportsCaching) return@runBlocking
         val cache = buildCache()
         val services1 = buildServices()
         val services2 =
@@ -105,8 +106,8 @@ public abstract class GattCacheConformanceTest {
     }
 
     @Test
-    fun `invalidate removes entry`() {
-        if (!supportsCaching) return
+    fun `invalidate removes entry`() = runBlocking {
+        if (!supportsCaching) return@runBlocking
         val cache = buildCache()
         cache.put(identifierA, buildServices())
         cache.invalidate(identifierA)
@@ -114,8 +115,8 @@ public abstract class GattCacheConformanceTest {
     }
 
     @Test
-    fun `clear removes all entries`() {
-        if (!supportsCaching) return
+    fun `clear removes all entries`() = runBlocking {
+        if (!supportsCaching) return@runBlocking
         val cache = buildCache()
         cache.put(identifierA, buildServices())
         cache.put(identifierB, buildServices())
@@ -125,8 +126,8 @@ public abstract class GattCacheConformanceTest {
     }
 
     @Test
-    fun `multiple identifiers independent`() {
-        if (!supportsCaching) return
+    fun `multiple identifiers independent`() = runBlocking {
+        if (!supportsCaching) return@runBlocking
         val cache = buildCache()
         val servicesA = buildServices()
         val servicesB =

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/cache/GattCacheConformanceTest.kt
@@ -54,92 +54,100 @@ public abstract class GattCacheConformanceTest {
         )
 
     @Test
-    fun `get returns null for unknown identifier`() = runBlocking {
-        val cache = buildCache()
-        assertNull(cache.get(identifierA))
-    }
+    fun `get returns null for unknown identifier`() =
+        runBlocking {
+            val cache = buildCache()
+            assertNull(cache.get(identifierA))
+        }
 
     @Test
-    fun `invalidate unknown identifier is no-op`() = runBlocking {
-        val cache = buildCache()
-        cache.invalidate(identifierA)
-        // No exception thrown
-    }
+    fun `invalidate unknown identifier is no-op`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.invalidate(identifierA)
+            // No exception thrown
+        }
 
     @Test
-    fun `clear empty cache is no-op`() = runBlocking {
-        val cache = buildCache()
-        cache.clear()
-        // No exception thrown
-    }
+    fun `clear empty cache is no-op`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.clear()
+            // No exception thrown
+        }
 
     @Test
-    fun `put and get round-trip`() = runBlocking {
-        if (!supportsCaching) return@runBlocking
-        val cache = buildCache()
-        val services = buildServices()
-        cache.put(identifierA, services)
-        val cached = cache.get(identifierA)
-        assertNotNull(cached)
-        assertEquals(1, cached.size)
-        assertEquals(uuidFrom("180d"), cached[0].uuid)
-    }
+    fun `put and get round-trip`() =
+        runBlocking {
+            if (!supportsCaching) return@runBlocking
+            val cache = buildCache()
+            val services = buildServices()
+            cache.put(identifierA, services)
+            val cached = cache.get(identifierA)
+            assertNotNull(cached)
+            assertEquals(1, cached.size)
+            assertEquals(uuidFrom("180d"), cached[0].uuid)
+        }
 
     @Test
-    fun `put replaces existing entry`() = runBlocking {
-        if (!supportsCaching) return@runBlocking
-        val cache = buildCache()
-        val services1 = buildServices()
-        val services2 =
-            listOf(
-                DiscoveredService(
-                    uuid = uuidFrom("180a"),
-                    characteristics = emptyList(),
-                ),
-            )
-        cache.put(identifierA, services1)
-        cache.put(identifierA, services2)
-        val cached = cache.get(identifierA)
-        assertNotNull(cached)
-        assertEquals(1, cached.size)
-        assertEquals(uuidFrom("180a"), cached[0].uuid)
-    }
+    fun `put replaces existing entry`() =
+        runBlocking {
+            if (!supportsCaching) return@runBlocking
+            val cache = buildCache()
+            val services1 = buildServices()
+            val services2 =
+                listOf(
+                    DiscoveredService(
+                        uuid = uuidFrom("180a"),
+                        characteristics = emptyList(),
+                    ),
+                )
+            cache.put(identifierA, services1)
+            cache.put(identifierA, services2)
+            val cached = cache.get(identifierA)
+            assertNotNull(cached)
+            assertEquals(1, cached.size)
+            assertEquals(uuidFrom("180a"), cached[0].uuid)
+        }
 
     @Test
-    fun `invalidate removes entry`() = runBlocking {
-        if (!supportsCaching) return@runBlocking
-        val cache = buildCache()
-        cache.put(identifierA, buildServices())
-        cache.invalidate(identifierA)
-        assertNull(cache.get(identifierA))
-    }
+    fun `invalidate removes entry`() =
+        runBlocking {
+            if (!supportsCaching) return@runBlocking
+            val cache = buildCache()
+            cache.put(identifierA, buildServices())
+            cache.invalidate(identifierA)
+            assertNull(cache.get(identifierA))
+        }
 
     @Test
-    fun `clear removes all entries`() = runBlocking {
-        if (!supportsCaching) return@runBlocking
-        val cache = buildCache()
-        cache.put(identifierA, buildServices())
-        cache.put(identifierB, buildServices())
-        cache.clear()
-        assertNull(cache.get(identifierA))
-        assertNull(cache.get(identifierB))
-    }
+    fun `clear removes all entries`() =
+        runBlocking {
+            if (!supportsCaching) return@runBlocking
+            val cache = buildCache()
+            cache.put(identifierA, buildServices())
+            cache.put(identifierB, buildServices())
+            cache.clear()
+            assertNull(cache.get(identifierA))
+            assertNull(cache.get(identifierB))
+        }
 
     @Test
-    fun `multiple identifiers independent`() = runBlocking {
-        if (!supportsCaching) return@runBlocking
-        val cache = buildCache()
-        val servicesA = buildServices()
-        val servicesB =
-            listOf(
-                DiscoveredService(
-                    uuid = uuidFrom("180f"),
-                    characteristics = emptyList(),
-                ),
-            )
-        cache.put(identifierA, servicesA)
-        cache.put(identifierB, servicesB)
-        assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
-        assertEquals(uuidFrom("180f"), cache.get(identifierB)!![0].uuid)
-    }
+    fun `multiple identifiers independent`() =
+        runBlocking {
+            if (!supportsCaching) return@runBlocking
+            val cache = buildCache()
+            val servicesA = buildServices()
+            val servicesB =
+                listOf(
+                    DiscoveredService(
+                        uuid = uuidFrom("180f"),
+                        characteristics = emptyList(),
+                    ),
+                )
+            cache.put(identifierA, servicesA)
+            cache.put(identifierB, servicesB)
+            assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
+            assertEquals(uuidFrom("180f"), cache.get(identifierB)!![0].uuid)
+        }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/gatt/cache/IosGattCache.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/gatt/cache/IosGattCache.kt
@@ -15,20 +15,20 @@ import com.atruedev.kmpble.gatt.DiscoveredService
  * to [Peripheral.services] which returns CoreBluetooth's internally cached data.
  */
 internal object IosGattCache : GattCache {
-    override fun get(identifier: Identifier): List<DiscoveredService>? = null
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = null
 
-    override fun put(
+    override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
         // CoreBluetooth handles caching natively
     }
 
-    override fun invalidate(identifier: Identifier) {
+    override suspend fun invalidate(identifier: Identifier) {
         // CoreBluetooth handles cache invalidation on disconnect
     }
 
-    override fun clear() {
+    override suspend fun clear() {
         // CoreBluetooth cache lifecycle is managed by the OS
     }
 }

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCache.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/gatt/cache/JvmGattCache.kt
@@ -11,20 +11,20 @@ import com.atruedev.kmpble.gatt.DiscoveredService
  * D-Bus or serial) should provide their own [GattCache] implementation.
  */
 internal object JvmGattCache : GattCache {
-    override fun get(identifier: Identifier): List<DiscoveredService>? = null
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = null
 
-    override fun put(
+    override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
         // No Bluetooth stack available on JVM
     }
 
-    override fun invalidate(identifier: Identifier) {
+    override suspend fun invalidate(identifier: Identifier) {
         // No-op on JVM
     }
 
-    override fun clear() {
+    override suspend fun clear() {
         // No-op on JVM
     }
 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
@@ -45,79 +45,86 @@ public class AndroidGattCacheTest {
         )
 
     @Test
-    fun `put and get round-trip`() = runBlocking {
-        val cache = buildCache()
-        cache.put(identifierA, buildServices())
-        val cached = cache.get(identifierA)
-        assertNotNull(cached)
-        assertEquals(1, cached.size)
-    }
+    fun `put and get round-trip`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.put(identifierA, buildServices())
+            val cached = cache.get(identifierA)
+            assertNotNull(cached)
+            assertEquals(1, cached.size)
+        }
 
     @Test
-    fun `invalidate removes entry`() = runBlocking {
-        val cache = buildCache()
-        cache.put(identifierA, buildServices())
-        cache.invalidate(identifierA)
-        assertNull(cache.get(identifierA))
-    }
+    fun `invalidate removes entry`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.put(identifierA, buildServices())
+            cache.invalidate(identifierA)
+            assertNull(cache.get(identifierA))
+        }
 
     @Test
-    fun `clear removes all entries`() = runBlocking {
-        val cache = buildCache()
-        cache.put(identifierA, buildServices())
-        cache.put(identifierB, buildServices("180a"))
-        cache.clear()
-        assertNull(cache.get(identifierA))
-        assertNull(cache.get(identifierB))
-    }
+    fun `clear removes all entries`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.put(identifierA, buildServices())
+            cache.put(identifierB, buildServices("180a"))
+            cache.clear()
+            assertNull(cache.get(identifierA))
+            assertNull(cache.get(identifierB))
+        }
 
     @Test
-    fun `LRU evicts least recently used when capacity exceeded`() = runBlocking {
-        val cache = buildCache(maxSize = 2)
-        cache.put(identifierA, buildServices("180d"))
-        cache.put(identifierB, buildServices("180a"))
-        // Access A to make B the least-recently-used
-        cache.get(identifierA)
-        // Insert C -- B should be evicted
-        cache.put(identifierC, buildServices("180f"))
-        assertNotNull(cache.get(identifierA))
-        assertNotNull(cache.get(identifierC))
-        assertNull(cache.get(identifierB))
-    }
+    fun `LRU evicts least recently used when capacity exceeded`() =
+        runBlocking {
+            val cache = buildCache(maxSize = 2)
+            cache.put(identifierA, buildServices("180d"))
+            cache.put(identifierB, buildServices("180a"))
+            // Access A to make B the least-recently-used
+            cache.get(identifierA)
+            // Insert C -- B should be evicted
+            cache.put(identifierC, buildServices("180f"))
+            assertNotNull(cache.get(identifierA))
+            assertNotNull(cache.get(identifierC))
+            assertNull(cache.get(identifierB))
+        }
 
     @Test
-    fun `LRU access order promotes entry`() = runBlocking {
-        val cache = buildCache(maxSize = 2)
-        cache.put(identifierA, buildServices("180d"))
-        cache.put(identifierB, buildServices("180a"))
-        // Access A multiple times
-        cache.get(identifierA)
-        cache.get(identifierA)
-        // Insert C -- B should be evicted (A was accessed most recently)
-        cache.put(identifierC, buildServices("180f"))
-        assertNotNull(cache.get(identifierA))
-        assertNotNull(cache.get(identifierC))
-        assertNull(cache.get(identifierB))
-    }
+    fun `LRU access order promotes entry`() =
+        runBlocking {
+            val cache = buildCache(maxSize = 2)
+            cache.put(identifierA, buildServices("180d"))
+            cache.put(identifierB, buildServices("180a"))
+            // Access A multiple times
+            cache.get(identifierA)
+            cache.get(identifierA)
+            // Insert C -- B should be evicted (A was accessed most recently)
+            cache.put(identifierC, buildServices("180f"))
+            assertNotNull(cache.get(identifierA))
+            assertNotNull(cache.get(identifierC))
+            assertNull(cache.get(identifierB))
+        }
 
     @Test
-    fun `put replaces existing entry`() = runBlocking {
-        val cache = buildCache()
-        cache.put(identifierA, buildServices("180d"))
-        cache.put(identifierA, buildServices("180a"))
-        val cached = cache.get(identifierA)
-        assertNotNull(cached)
-        assertEquals(uuidFrom("180a"), cached[0].uuid)
-    }
+    fun `put replaces existing entry`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.put(identifierA, buildServices("180d"))
+            cache.put(identifierA, buildServices("180a"))
+            val cached = cache.get(identifierA)
+            assertNotNull(cached)
+            assertEquals(uuidFrom("180a"), cached[0].uuid)
+        }
 
     @Test
-    fun `multiple identifiers independent`() = runBlocking {
-        val cache = buildCache()
-        cache.put(identifierA, buildServices("180d"))
-        cache.put(identifierB, buildServices("180a"))
-        assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
-        assertEquals(uuidFrom("180a"), cache.get(identifierB)!![0].uuid)
-    }
+    fun `multiple identifiers independent`() =
+        runBlocking {
+            val cache = buildCache()
+            cache.put(identifierA, buildServices("180d"))
+            cache.put(identifierB, buildServices("180a"))
+            assertEquals(uuidFrom("180d"), cache.get(identifierA)!![0].uuid)
+            assertEquals(uuidFrom("180a"), cache.get(identifierB)!![0].uuid)
+        }
 }
 
 /**
@@ -142,8 +149,7 @@ internal class LruGattCache(
             ): Boolean = size > maxSize
         }
 
-    override suspend fun get(identifier: Identifier): List<DiscoveredService>? =
-        mutex.withLock { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = mutex.withLock { cache[identifier] }
 
     override suspend fun put(
         identifier: Identifier,

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
@@ -4,6 +4,9 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -42,7 +45,7 @@ public class AndroidGattCacheTest {
         )
 
     @Test
-    fun `put and get round-trip`() {
+    fun `put and get round-trip`() = runBlocking {
         val cache = buildCache()
         cache.put(identifierA, buildServices())
         val cached = cache.get(identifierA)
@@ -51,7 +54,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `invalidate removes entry`() {
+    fun `invalidate removes entry`() = runBlocking {
         val cache = buildCache()
         cache.put(identifierA, buildServices())
         cache.invalidate(identifierA)
@@ -59,7 +62,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `clear removes all entries`() {
+    fun `clear removes all entries`() = runBlocking {
         val cache = buildCache()
         cache.put(identifierA, buildServices())
         cache.put(identifierB, buildServices("180a"))
@@ -69,7 +72,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `LRU evicts least recently used when capacity exceeded`() {
+    fun `LRU evicts least recently used when capacity exceeded`() = runBlocking {
         val cache = buildCache(maxSize = 2)
         cache.put(identifierA, buildServices("180d"))
         cache.put(identifierB, buildServices("180a"))
@@ -83,7 +86,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `LRU access order promotes entry`() {
+    fun `LRU access order promotes entry`() = runBlocking {
         val cache = buildCache(maxSize = 2)
         cache.put(identifierA, buildServices("180d"))
         cache.put(identifierB, buildServices("180a"))
@@ -98,7 +101,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `put replaces existing entry`() {
+    fun `put replaces existing entry`() = runBlocking {
         val cache = buildCache()
         cache.put(identifierA, buildServices("180d"))
         cache.put(identifierA, buildServices("180a"))
@@ -108,7 +111,7 @@ public class AndroidGattCacheTest {
     }
 
     @Test
-    fun `multiple identifiers independent`() {
+    fun `multiple identifiers independent`() = runBlocking {
         val cache = buildCache()
         cache.put(identifierA, buildServices("180d"))
         cache.put(identifierB, buildServices("180a"))
@@ -119,11 +122,13 @@ public class AndroidGattCacheTest {
 
 /**
  * Standalone LRU [GattCache] for testing -- mirrors [AndroidGattCache].
+ *
+ * Uses [Mutex] for structured concurrency instead of [synchronized].
  */
 internal class LruGattCache(
     private val maxSize: Int,
 ) : GattCache {
-    private val lock = Any()
+    private val mutex = Mutex()
 
     @Suppress("UNCHECKED_CAST")
     private val cache =
@@ -137,20 +142,21 @@ internal class LruGattCache(
             ): Boolean = size > maxSize
         }
 
-    override fun get(identifier: Identifier): List<DiscoveredService>? = synchronized(lock) { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? =
+        mutex.withLock { cache[identifier] }
 
-    override fun put(
+    override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
-        synchronized(lock) { cache[identifier] = services }
+        mutex.withLock { cache[identifier] = services }
     }
 
-    override fun invalidate(identifier: Identifier) {
-        synchronized(lock) { cache.remove(identifier) }
+    override suspend fun invalidate(identifier: Identifier) {
+        mutex.withLock { cache.remove(identifier) }
     }
 
-    override fun clear() {
-        synchronized(lock) { cache.clear() }
+    override suspend fun clear() {
+        mutex.withLock { cache.clear() }
     }
 }


### PR DESCRIPTION
## Summary

Replaces `synchronized(lock)` blocks in `AndroidGattCache` with structured concurrency via `Mutex.withLock`. The `GattCache` interface methods are promoted to `suspend` to enable this.

## Changes

- **GattCache.kt** (commonMain): `get`/`put`/`invalidate`/`clear` → `suspend`
- **AndroidGattCache.kt** (androidMain): `synchronized(lock)` → `Mutex.withLock`
- **LruGattCache** (test): `synchronized(lock)` → `Mutex.withLock`
- **IosGattCache.kt** / **JvmGattCache.kt**: overrides as `suspend` (no-ops)
- **GattCacheConformanceTest.kt** / **AndroidGattCacheTest.kt**: wrap test bodies in `runBlocking`

## Verification

- `./gradlew :compileKotlinJvm` — pass
- `./gradlew :jvmTest --tests "*GattCache*"` — all 14 tests pass
- iOS Simulator compilation has pre-existing failures (IosPeripheralGatt.kt) on main, not caused by this PR

Closes #283