### PR TITLE
feat(monitoring): add PowerMonitor for LE path loss tracking

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PathLossReading.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PathLossReading.kt
@@ -1,0 +1,19 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.peripheral.Peripheral
+
+/**
+ * A single path loss reading computed from TX power and RSSI.
+ *
+ * Path loss (dB) = [txPower] - [rssi]. This metric is used by BLE stacks
+ * (Nordic SoftDevice, TI BLE5-Stack, ST BlueNRG) for adaptive frequency
+ * hopping, power management, and distance estimation.
+ */
+public data class PathLossReading(
+    /** Computed path loss in dB. */
+    val pathLoss: Int,
+    /** RSSI at time of reading in dBm. */
+    val rssi: Int,
+    /** Configured TX power level in dBm. */
+    val txPower: Int,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PathLossReading.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PathLossReading.kt
@@ -1,7 +1,5 @@
 package com.atruedev.kmpble.monitoring
 
-import com.atruedev.kmpble.peripheral.Peripheral
-
 /**
  * A single path loss reading computed from TX power and RSSI.
  *

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PowerMonitor.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PowerMonitor.kt
@@ -1,0 +1,101 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Monitors path loss between a central and [Peripheral] by computing
+ * `txPower - rssi` from RSSI readings.
+ *
+ * Path loss monitoring is a standard feature in BLE SDKs (Nordic
+ * SoftDevice, TI BLE5-Stack, ST BlueNRG) used for adaptive frequency
+ * hopping, dynamic TX power management, and proximity estimation.
+ *
+ * Since platform BLE APIs do not expose TX power directly, the monitor
+ * uses a configurable [txPower] value (default 0 dBm, typical for BLE).
+ * Callers that know their device's calibrated TX power should pass it.
+ *
+ * ## Usage
+ * ```
+ * val monitor = PowerMonitor(peripheral, scope, txPower = 4)
+ * monitor.start()
+ * // Periodically read RSSI and record:
+ * val rssi = peripheral.readRssi()
+ * monitor.recordRssi(rssi)
+ * monitor.pathLoss.collect { reading -> updateProximity(reading) }
+ * ```
+ */
+public class PowerMonitor(
+    private val peripheral: Peripheral,
+    private val scope: CoroutineScope,
+    /** Configured TX power level in dBm (default 0 dBm, typical BLE). */
+    private val txPower: Int = 0,
+) {
+    private val _pathLoss = MutableStateFlow<PathLossReading?>(null)
+    public val pathLoss: StateFlow<PathLossReading?> = _pathLoss.asStateFlow()
+
+    private var started = false
+    private var collectionJob: Job? = null
+
+    /**
+     * Begin monitoring the peripheral's connection lifecycle.
+     *
+     * Safe to call multiple times -- subsequent calls are no-ops.
+     * Does not block; launches a coroutine in [scope] to observe
+     * state changes and reset the reading on disconnect.
+     */
+    public fun start() {
+        if (started) return
+        started = true
+        collectionJob =
+            scope.launch {
+                try {
+                    peripheral.state.collect { state ->
+                        if (state !is State.Connected) {
+                            _pathLoss.update { null }
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    // State collection failed; leave last known reading intact
+                }
+            }
+    }
+
+    /**
+     * Stop monitoring. The [pathLoss] flow retains its last value.
+     *
+     * Cancels the active collection coroutine (does not cancel the scope).
+     * Call [start] to resume monitoring.
+     */
+    public fun stop() {
+        started = false
+        collectionJob?.cancel()
+        collectionJob = null
+    }
+
+    /**
+     * Record an RSSI reading and compute path loss.
+     *
+     * Call after [Peripheral.readRssi] to feed the result. Path loss
+     * is computed as [txPower] - [rssi].
+     */
+    public fun recordRssi(rssi: Int) {
+        _pathLoss.update {
+            PathLossReading(
+                pathLoss = txPower - rssi,
+                rssi = rssi,
+                txPower = txPower,
+            )
+        }
+    }
+}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -117,10 +117,5 @@ internal class StubPeripheral(
         mtu: Int?,
     ): L2capChannel = unsupported()
 
-    override suspend fun openIsochronousChannel(
-        secure: Boolean,
-        mtu: Int?,
-    ): IsochronousChannel = unsupported()
-
     private fun unsupported(): Nothing = throw UnsupportedOperationException("StubPeripheral")
 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -16,7 +16,6 @@ import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
-import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/PowerMonitorTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/PowerMonitorTest.kt
@@ -1,0 +1,169 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PowerMonitorTest {
+    @Test
+    fun initialReadingIsNull() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher))
+        assertNull(monitor.pathLoss.value)
+    }
+
+    @Test
+    fun recordRssiComputesPathLoss() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher), txPower = 0)
+
+        monitor.recordRssi(-55)
+        val reading = monitor.pathLoss.value
+        assertNotNull(reading)
+        assertEquals(55, reading.pathLoss)
+        assertEquals(-55, reading.rssi)
+        assertEquals(0, reading.txPower)
+    }
+
+    @Test
+    fun recordRssiWithCustomTxPower() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher), txPower = 4)
+
+        monitor.recordRssi(-60)
+        val reading = monitor.pathLoss.value
+        assertNotNull(reading)
+        assertEquals(64, reading.pathLoss)
+        assertEquals(-60, reading.rssi)
+        assertEquals(4, reading.txPower)
+    }
+
+    @Test
+    fun recordRssiOverwritesPreviousReading() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher))
+
+        monitor.recordRssi(-40)
+        assertEquals(40, monitor.pathLoss.value!!.pathLoss)
+
+        monitor.recordRssi(-80)
+        assertEquals(80, monitor.pathLoss.value!!.pathLoss)
+    }
+
+    @Test
+    fun disconnectClearsReading() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            monitor.recordRssi(-55)
+            assertNotNull(monitor.pathLoss.value)
+
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            assertNull(monitor.pathLoss.value)
+        }
+    }
+
+    @Test
+    fun startIsIdempotent() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+
+            monitor.start()
+            monitor.start()
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            monitor.recordRssi(-55)
+            assertNotNull(monitor.pathLoss.value)
+        }
+    }
+
+    @Test
+    fun stopPreventsDisconnectFromClearing() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            monitor.recordRssi(-55)
+            assertNotNull(monitor.pathLoss.value)
+
+            monitor.stop()
+
+            peripheral.disconnect()
+            scheduler.runCurrent()
+
+            assertNotNull(monitor.pathLoss.value)
+        }
+    }
+
+    @Test
+    fun zeroPathLossWhenRssiEqualsTxPower() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher), txPower = -55)
+
+        monitor.recordRssi(-55)
+        assertEquals(0, monitor.pathLoss.value!!.pathLoss)
+    }
+}


### PR DESCRIPTION
## Summary

Adds path loss monitoring via a standalone `PowerMonitor` wrapper class, matching capabilities in Nordic SoftDevice, TI BLE5-Stack, and ST BlueNRG BLE stacks.

## Changes

- **PathLossReading.kt** (commonMain): data class for path loss, RSSI, TX power
- **PowerMonitor.kt** (commonMain): standalone wrapper with start/stop lifecycle, exposes `pathLoss: StateFlow<PathLossReading?>`, auto-clears on disconnect
- **PowerMonitorTest.kt** (jvmTest): 8 tests covering path loss computation, custom txPower, disconnect clearing, idempotent start, stop prevents updates, zero path loss edge case
- **StubPeripheral.kt** (jvmTest): remove `openIsochronousChannel` stub (method not yet on Peripheral interface, from #276 WIP)

## Design

Follows the `ConnectionQualityMonitor` pattern — a stand-alone wrapper using only the existing `Peripheral` API (`readRssi()`, `state`). No changes to `Peripheral` interface. Path loss is computed as `txPower - rssi` with configurable `txPower` (default 0 dBm).

## Verification

- `./gradlew :compileKotlinJvm` — pass
- `./gradlew :jvmTest --tests "*PowerMonitor*"` — 8/8 pass

Closes #286