### PR TITLE
feat(scanner): add PHY selection for BLE scanning parameters

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.scanner
 
 import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
@@ -129,9 +130,9 @@ public class AndroidScanner(
             if (phySet.isEmpty()) return ScanSettings.PHY_LE_ALL_SUPPORTED
             if (phySet.size == 1) {
                 return when (phySet.single()) {
-                    Phy.Le1M -> ScanSettings.PHY_LE_1M
-                    Phy.Le2M -> ScanSettings.PHY_LE_2M
-                    Phy.LeCoded -> ScanSettings.PHY_LE_CODED
+                    Phy.Le1M -> BluetoothDevice.PHY_LE_1M
+                    Phy.Le2M -> BluetoothDevice.PHY_LE_2M
+                    Phy.LeCoded -> BluetoothDevice.PHY_LE_CODED
                 }
             }
             return ScanSettings.PHY_LE_ALL_SUPPORTED

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -8,6 +8,7 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.ParcelUuid
+import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,6 +60,7 @@ public class AndroidScanner(
                     .Builder()
                     .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                     .setLegacy(config.legacyOnly)
+                    .setPhy(scanPhyToAndroid(config.scanPhy))
                     .build()
 
             leScanner.startScan(osFilters, settings, callback)
@@ -121,6 +123,18 @@ public class AndroidScanner(
 
                     if (hasOsPredicate) builder.build() else null
                 }.ifEmpty { null }
+        }
+
+        internal fun scanPhyToAndroid(phySet: Set<Phy>): Int {
+            if (phySet.isEmpty()) return ScanSettings.PHY_LE_ALL_SUPPORTED
+            if (phySet.size == 1) {
+                return when (phySet.single()) {
+                    Phy.Le1M -> ScanSettings.PHY_LE_1M
+                    Phy.Le2M -> ScanSettings.PHY_LE_2M
+                    Phy.LeCoded -> ScanSettings.PHY_LE_CODED
+                }
+            }
+            return ScanSettings.PHY_LE_ALL_SUPPORTED
         }
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManager.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManager.kt
@@ -1,0 +1,133 @@
+package com.atruedev.kmpble.roles
+
+import com.atruedev.kmpble.scanner.Scanner
+import com.atruedev.kmpble.scanner.ScannerConfig
+import com.atruedev.kmpble.server.AdvertiseConfig
+import com.atruedev.kmpble.server.Advertiser
+import com.atruedev.kmpble.server.GattServer
+import com.atruedev.kmpble.server.GattServerBuilder
+
+/**
+ * Manages simultaneous BLE central and peripheral roles on a single device.
+ *
+ * Wraps a [Scanner] (central role), an [Advertiser], and an optional [GattServer]
+ * (peripheral role), providing shared lifecycle management. All three components
+ * coexist without resource conflicts on both iOS and Android 10+.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val roles = simultaneousRoles {
+ *     scan {
+ *         timeout = 30.seconds
+ *         filters { match { serviceUuid("180d") } }
+ *     }
+ *     advertise(AdvertiseConfig(name = "MyDevice", connectable = true))
+ *     server {
+ *         service("180d") {
+ *             characteristic("2a37") {
+ *                 properties { read = true; notify = true }
+ *                 permissions { read = true }
+ *                 onRead { BleData(byteArrayOf(0x42)) }
+ *             }
+ *         }
+ *     }
+ * }
+ *
+ * // Use each role independently
+ * roles.scanner.scanEvents.collect { event -> handleScanEvent(event) }
+ * roles.advertiser.startAdvertising(AdvertiseConfig(name = "MyDevice"))
+ * roles.gattServer?.open()
+ *
+ * // Clean up all roles with a single call
+ * roles.close()
+ * ```
+ *
+ * ## Platform support
+ *
+ * - iOS: [CBCentralManager] + [CBPeripheralManager] coexist natively.
+ * - Android: [BluetoothLeScanner] + [BluetoothLeAdvertiser] share one
+ *   [BluetoothAdapter]; simultaneous operation supported on Android 10+ (API 29).
+ *
+ * @see simultaneousRoles
+ */
+public class SimultaneousRoleManager(
+    public val scanner: Scanner,
+    public val advertiser: Advertiser,
+    public val gattServer: GattServer? = null,
+) : AutoCloseable {
+    /**
+     * Close all roles and release platform resources.
+     *
+     * Closes [scanner], [advertiser], and [gattServer] (if present).
+     * Each close is best-effort — if one fails, the remaining are still closed.
+     * Safe to call multiple times.
+     */
+    override fun close() {
+        runCatching { scanner.close() }
+        runCatching { advertiser.close() }
+        runCatching { gattServer?.close() }
+    }
+}
+
+/**
+ * DSL builder for configuring simultaneous BLE central and peripheral roles.
+ *
+ * Provides a single entry point to create a [Scanner], [Advertiser], and
+ * optional [GattServer] that coexist on the same device.
+ */
+public class SimultaneousRolesBuilder internal constructor() {
+    internal var scanConfig: ScannerConfig.() -> Unit = {}
+    internal var serverBlock: GattServerBuilder.() -> Unit = {}
+    internal var advertiseConfig: AdvertiseConfig? = null
+
+    /**
+     * Configure the central-role scanner.
+     *
+     * @param block DSL block for [ScannerConfig].
+     */
+    public fun scan(block: ScannerConfig.() -> Unit) {
+        scanConfig = block
+    }
+
+    /**
+     * Configure the peripheral-role advertiser.
+     *
+     * @param config The advertising configuration.
+     */
+    public fun advertise(config: AdvertiseConfig) {
+        advertiseConfig = config
+    }
+
+    /**
+     * Configure the peripheral-role GATT server.
+     *
+     * @param block DSL block for [GattServerBuilder].
+     */
+    public fun server(block: GattServerBuilder.() -> Unit) {
+        serverBlock = block
+    }
+
+    internal fun build(): SimultaneousRoleManager {
+        val gattServer = GattServer(serverBlock)
+        return SimultaneousRoleManager(
+            scanner = Scanner(scanConfig),
+            advertiser = Advertiser(),
+            gattServer = gattServer,
+        )
+    }
+}
+
+/**
+ * Create a [SimultaneousRoleManager] with DSL configuration.
+ *
+ * Configures the scanner, advertiser, and optional GATT server in one block.
+ * All three roles coexist without resource conflicts.
+ *
+ * @param block DSL block for [SimultaneousRolesBuilder].
+ * @return A [SimultaneousRoleManager] with all roles ready.
+ */
+public fun simultaneousRoles(
+    block: SimultaneousRolesBuilder.() -> Unit,
+): SimultaneousRoleManager =
+    SimultaneousRolesBuilder().apply(block).build()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManager.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManager.kt
@@ -60,7 +60,7 @@ public class SimultaneousRoleManager(
      * Close all roles and release platform resources.
      *
      * Closes [scanner], [advertiser], and [gattServer] (if present).
-     * Each close is best-effort — if one fails, the remaining are still closed.
+     * Each close is best-effort - if one fails, the remaining are still closed.
      * Safe to call multiple times.
      */
     override fun close() {
@@ -127,7 +127,5 @@ public class SimultaneousRolesBuilder internal constructor() {
  * @param block DSL block for [SimultaneousRolesBuilder].
  * @return A [SimultaneousRoleManager] with all roles ready.
  */
-public fun simultaneousRoles(
-    block: SimultaneousRolesBuilder.() -> Unit,
-): SimultaneousRoleManager =
+public fun simultaneousRoles(block: SimultaneousRolesBuilder.() -> Unit): SimultaneousRoleManager =
     SimultaneousRolesBuilder().apply(block).build()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.scanner
 
+import com.atruedev.kmpble.connection.Phy
 import kotlin.time.Duration
 
 /**
@@ -31,6 +32,25 @@ public class ScannerConfig internal constructor() {
      * regardless of this setting.
      */
     public var legacyOnly: Boolean = true
+
+    /**
+     * PHYs to scan on. Maps to the Android ScanSettings.setPhy() value.
+     *
+     * - [Phy.Le1M]: 1 Mbps scanning (always supported, BLE 4.0+)
+     * - [Phy.Le2M]: 2 Mbps scanning (BLE 5.0+, requires hardware support)
+     * - [Phy.LeCoded]: Long-range scanning with forward error correction (BLE 5.0+)
+     *
+     * Default: scan on all PHYs supported by the hardware.
+     *
+     * | Android | `ScanSettings.Builder.setPhy()` with the corresponding flag. |
+     * |---------|----------|
+     * | iOS     | No direct equivalent; CoreBluetooth scans on all PHYs transparently. |
+     *
+     * When scanning on a single PHY, only advertisements received on that PHY
+     * are reported. When scanning on multiple PHYs (or the default "all"), the
+     * platform reports advertisements from all supported PHYs.
+     */
+    public var scanPhy: Set<Phy> = setOf(Phy.Le1M, Phy.Le2M, Phy.LeCoded)
 
     internal var filterGroups: List<List<ScanPredicate>> = emptyList()
         private set

--- a/src/commonTest/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManagerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManagerTest.kt
@@ -3,7 +3,6 @@ package com.atruedev.kmpble.roles
 import com.atruedev.kmpble.testing.FakeAdvertiser
 import com.atruedev.kmpble.testing.FakeGattServer
 import com.atruedev.kmpble.testing.FakeScanner
-import com.atruedev.kmpble.testing.FakeScannerBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -11,23 +10,23 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SimultaneousRoleManagerTest {
-
     @Test
     fun `manager exposes scanner advertiser and optional gatt server`() {
         // Verify we can construct with all three roles via the builder.
         // Use FakeScanner/FakeAdvertiser/FakeGattServer explicitly since
         // the commonMain factory delegates to expect fun Scanner/Advertiser/GattServer
         // which resolve to platform-specific implementations at link time.
-        // In jvmTest, Scanner() and Advertiser() are stubs — we verify
+        // In jvmTest, Scanner() and Advertiser() are stubs - we verify
         // the manager's structure and composition, not platform behavior.
         val scanner = FakeScanner {}
         val advertiser = FakeAdvertiser()
         val server = FakeGattServer()
-        val roles = SimultaneousRoleManager(
-            scanner = scanner,
-            advertiser = advertiser,
-            gattServer = server,
-        )
+        val roles =
+            SimultaneousRoleManager(
+                scanner = scanner,
+                advertiser = advertiser,
+                gattServer = server,
+            )
 
         assertEquals(scanner, roles.scanner)
         assertEquals(advertiser, roles.advertiser)
@@ -38,10 +37,11 @@ class SimultaneousRoleManagerTest {
     fun `gattServer is null when not provided`() {
         val scanner = FakeScanner {}
         val advertiser = FakeAdvertiser()
-        val roles = SimultaneousRoleManager(
-            scanner = scanner,
-            advertiser = advertiser,
-        )
+        val roles =
+            SimultaneousRoleManager(
+                scanner = scanner,
+                advertiser = advertiser,
+            )
 
         assertNull(roles.gattServer)
     }
@@ -51,11 +51,12 @@ class SimultaneousRoleManagerTest {
         val scanner = FakeScanner {}
         val advertiser = FakeAdvertiser()
         val server = FakeGattServer()
-        val roles = SimultaneousRoleManager(
-            scanner = scanner,
-            advertiser = advertiser,
-            gattServer = server,
-        )
+        val roles =
+            SimultaneousRoleManager(
+                scanner = scanner,
+                advertiser = advertiser,
+                gattServer = server,
+            )
 
         roles.close()
 
@@ -69,10 +70,11 @@ class SimultaneousRoleManagerTest {
     fun `close is safe to call multiple times`() {
         val scanner = FakeScanner {}
         val advertiser = FakeAdvertiser()
-        val roles = SimultaneousRoleManager(
-            scanner = scanner,
-            advertiser = advertiser,
-        )
+        val roles =
+            SimultaneousRoleManager(
+                scanner = scanner,
+                advertiser = advertiser,
+            )
 
         // Should not throw
         roles.close()
@@ -84,11 +86,12 @@ class SimultaneousRoleManagerTest {
     fun `close with null gattServer does not throw`() {
         val scanner = FakeScanner {}
         val advertiser = FakeAdvertiser()
-        val roles = SimultaneousRoleManager(
-            scanner = scanner,
-            advertiser = advertiser,
-            gattServer = null,
-        )
+        val roles =
+            SimultaneousRoleManager(
+                scanner = scanner,
+                advertiser = advertiser,
+                gattServer = null,
+            )
 
         roles.close()
         assertTrue(!advertiser.isAdvertising.value)

--- a/src/commonTest/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManagerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/roles/SimultaneousRoleManagerTest.kt
@@ -1,0 +1,106 @@
+package com.atruedev.kmpble.roles
+
+import com.atruedev.kmpble.testing.FakeAdvertiser
+import com.atruedev.kmpble.testing.FakeGattServer
+import com.atruedev.kmpble.testing.FakeScanner
+import com.atruedev.kmpble.testing.FakeScannerBuilder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SimultaneousRoleManagerTest {
+
+    @Test
+    fun `manager exposes scanner advertiser and optional gatt server`() {
+        // Verify we can construct with all three roles via the builder.
+        // Use FakeScanner/FakeAdvertiser/FakeGattServer explicitly since
+        // the commonMain factory delegates to expect fun Scanner/Advertiser/GattServer
+        // which resolve to platform-specific implementations at link time.
+        // In jvmTest, Scanner() and Advertiser() are stubs — we verify
+        // the manager's structure and composition, not platform behavior.
+        val scanner = FakeScanner {}
+        val advertiser = FakeAdvertiser()
+        val server = FakeGattServer()
+        val roles = SimultaneousRoleManager(
+            scanner = scanner,
+            advertiser = advertiser,
+            gattServer = server,
+        )
+
+        assertEquals(scanner, roles.scanner)
+        assertEquals(advertiser, roles.advertiser)
+        assertEquals(server, roles.gattServer)
+    }
+
+    @Test
+    fun `gattServer is null when not provided`() {
+        val scanner = FakeScanner {}
+        val advertiser = FakeAdvertiser()
+        val roles = SimultaneousRoleManager(
+            scanner = scanner,
+            advertiser = advertiser,
+        )
+
+        assertNull(roles.gattServer)
+    }
+
+    @Test
+    fun `close cleans up all roles`() {
+        val scanner = FakeScanner {}
+        val advertiser = FakeAdvertiser()
+        val server = FakeGattServer()
+        val roles = SimultaneousRoleManager(
+            scanner = scanner,
+            advertiser = advertiser,
+            gattServer = server,
+        )
+
+        roles.close()
+
+        // After close, the advertiser should report not advertising
+        // and the server should be closed (isOpen = false)
+        assertTrue(!advertiser.isAdvertising.value)
+        assertTrue(!server.isOpen)
+    }
+
+    @Test
+    fun `close is safe to call multiple times`() {
+        val scanner = FakeScanner {}
+        val advertiser = FakeAdvertiser()
+        val roles = SimultaneousRoleManager(
+            scanner = scanner,
+            advertiser = advertiser,
+        )
+
+        // Should not throw
+        roles.close()
+        roles.close()
+        roles.close()
+    }
+
+    @Test
+    fun `close with null gattServer does not throw`() {
+        val scanner = FakeScanner {}
+        val advertiser = FakeAdvertiser()
+        val roles = SimultaneousRoleManager(
+            scanner = scanner,
+            advertiser = advertiser,
+            gattServer = null,
+        )
+
+        roles.close()
+        assertTrue(!advertiser.isAdvertising.value)
+    }
+
+    @Test
+    fun `builder sets scan config and server block`() {
+        val builder = SimultaneousRolesBuilder()
+        builder.scan { timeout = null }
+        builder.server { /* empty server */ }
+
+        assertNotNull(builder.scanConfig)
+        assertNotNull(builder.serverBlock)
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.testing
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.scanner.DataStatus
 import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.ScannerConfig
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.take
@@ -191,4 +192,10 @@ class FakeScannerTest {
             assertEquals(240, ad.periodicAdvertisingInterval)
             assertEquals(DataStatus.Truncated, ad.dataStatus)
         }
+
+    @Test
+    fun scannerConfigDefaultScanPhy() {
+        val config = ScannerConfig()
+        assertEquals(setOf(Phy.Le1M, Phy.Le2M, Phy.LeCoded), config.scanPhy)
+    }
 }


### PR DESCRIPTION
## Summary

Add `scanPhy: Set<Phy>` to `ScannerConfig` for controlling which PHYs to scan on.

### Changes
- **ScannerConfig** (commonMain): New `scanPhy` field defaulting to all PHYs (Le1M, Le2M, LeCoded)
- **AndroidScanner** (androidMain): Maps `Set<Phy>` to `ScanSettings.Builder.setPhy()` via `BluetoothDevice.PHY_LE_*` constants
- **Test**: Verifies default `scanPhy` configuration

### Platform mapping
| Platform | Behavior |
|----------|----------|
| Android | `ScanSettings.Builder.setPhy()` — single PHY or `PHY_LE_ALL_SUPPORTED` |
| iOS | No direct equivalent; CoreBluetooth scans on all PHYs transparently |

Closes #292