### PR TITLE
feat(power): add LePowerController for active peer power adjustment

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/LePowerController.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/LePowerController.kt
@@ -16,7 +16,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * Active LE Power Control (LEPC) for peer transmit power adjustment.
  *
  * Where [PowerMonitor] provides **passive** path-loss monitoring,
- * `LePowerController` enables **active** power adjustment requests —
+ * `LePowerController` enables **active** power adjustment requests -
  * asking the connected peer to change its transmit power level.
  *
  * Bluetooth 5.1+ defines LE Power Control as a GATT-based procedure.
@@ -52,7 +52,7 @@ import kotlin.time.Duration.Companion.milliseconds
  *   No fine-grained LEPC GATT procedure available yet.
  * - **iOS**: CoreBluetooth does not expose connection parameter
  *   negotiation or LE Power Control. Returns `accepted = false`.
- * - **JVM**: Stub — returns `accepted = false`.
+ * - **JVM**: Stub - returns `accepted = false`.
  *
  * @property incomingPowerRequests Flow of power change requests from the peer.
  *   Empty on current platforms (not surfaced by Android or iOS APIs).
@@ -72,7 +72,7 @@ public class LePowerController(
     /**
      * Begin monitoring for incoming power requests.
      *
-     * Safe to call multiple times — subsequent calls are no-ops.
+     * Safe to call multiple times - subsequent calls are no-ops.
      * Does not block; launches a coroutine in [scope] to observe
      * connection state for power control opportunities.
      */

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/LePowerController.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/LePowerController.kt
@@ -1,0 +1,166 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionParameters
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Active LE Power Control (LEPC) for peer transmit power adjustment.
+ *
+ * Where [PowerMonitor] provides **passive** path-loss monitoring,
+ * `LePowerController` enables **active** power adjustment requests —
+ * asking the connected peer to change its transmit power level.
+ *
+ * Bluetooth 5.1+ defines LE Power Control as a GATT-based procedure.
+ * This implementation uses the existing
+ * [Peripheral.requestConnectionParameterUpdate] API to translate
+ * target dBm into connection parameter requests. See platform notes
+ * for availability.
+ *
+ * ## Usage with PowerMonitor
+ * ```
+ * val monitor = PowerMonitor(peripheral, scope)
+ * val controller = LePowerController(peripheral, scope)
+ *
+ * monitor.start()
+ * controller.start()
+ *
+ * // PowerMonitor detects high path loss → alert
+ * monitor.pathLoss.collect { reading ->
+ *     if (reading != null && reading.pathLoss > 50) {
+ *         // Request peer to increase power
+ *         val response = controller.requestPeerPowerChange(-4)
+ *         if (response.accepted) {
+ *             // Monitor for RSSI improvement
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * ## Platform notes
+ *
+ * - **Android**: Uses `BluetoothGatt.requestConnectionPriority()`
+ *   (API 21+) for coarse power adjustment via connection parameters.
+ *   No fine-grained LEPC GATT procedure available yet.
+ * - **iOS**: CoreBluetooth does not expose connection parameter
+ *   negotiation or LE Power Control. Returns `accepted = false`.
+ * - **JVM**: Stub — returns `accepted = false`.
+ *
+ * @property incomingPowerRequests Flow of power change requests from the peer.
+ *   Empty on current platforms (not surfaced by Android or iOS APIs).
+ */
+public class LePowerController(
+    private val peripheral: Peripheral,
+    private val scope: CoroutineScope,
+) {
+    private val _incomingPowerRequests =
+        MutableSharedFlow<PeerPowerRequest>(replay = 0, extraBufferCapacity = 16)
+    public val incomingPowerRequests: SharedFlow<PeerPowerRequest> =
+        _incomingPowerRequests.asSharedFlow()
+
+    private var started = false
+    private var collectionJob: Job? = null
+
+    /**
+     * Begin monitoring for incoming power requests.
+     *
+     * Safe to call multiple times — subsequent calls are no-ops.
+     * Does not block; launches a coroutine in [scope] to observe
+     * connection state for power control opportunities.
+     */
+    public fun start() {
+        if (started) return
+        started = true
+        collectionJob =
+            scope.launch {
+                try {
+                    peripheral.state.collect { /* track connection for power control readiness */ }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    // State collection failed; leave controller in last known state
+                }
+            }
+    }
+
+    /**
+     * Stop monitoring. The [incomingPowerRequests] flow retains its buffer.
+     *
+     * Cancels the active collection coroutine (does not cancel the scope).
+     * Call [start] to resume monitoring.
+     */
+    public fun stop() {
+        started = false
+        collectionJob?.cancel()
+        collectionJob = null
+    }
+
+    /**
+     * Request the connected peer to change its transmit power to [targetDbm].
+     *
+     * Translates the target dBm into connection parameter hints and delegates to
+     * [Peripheral.requestConnectionParameterUpdate]. The peer may accept, reject,
+     * or negotiate alternative parameters.
+     *
+     * | targetDbm  | Connection strategy | Interval       | Latency |
+     * |------------|---------------------|----------------|---------|
+     * | >= -4      | High power / low latency | 11.25..15 ms | 0       |
+     * | >= -12     | Balanced                 | 30..50 ms    | 2       |
+     * | >= -20     | Power saving             | 100..125 ms  | 4       |
+     * | < -20      | Max power saving         | 300..400 ms  | 7       |
+     *
+     * @param targetDbm Desired peer transmit power in dBm. Higher (less negative)
+     *   values request more power and lower latency connections.
+     * @return [PeerPowerResponse] with acceptance status and negotiated parameters.
+     *   [PeerPowerResponse.accepted] is `false` on platforms that do not support
+     *   the operation.
+     */
+    @ExperimentalBleApi
+    public suspend fun requestPeerPowerChange(targetDbm: Int): PeerPowerResponse {
+        val params = powerToConnectionParams(targetDbm)
+        val result = peripheral.requestConnectionParameterUpdate(params)
+        return PeerPowerResponse(
+            accepted = result != null,
+            targetDbm = targetDbm,
+            negotiatedInterval = result?.negotiatedInterval,
+            negotiatedLatency = result?.negotiatedLatency,
+            negotiatedSupervisionTimeout = result?.negotiatedSupervisionTimeout,
+        )
+    }
+
+    private fun powerToConnectionParams(targetDbm: Int): ConnectionParameters =
+        when {
+            targetDbm >= -4 ->
+                ConnectionParameters(
+                    intervalRange = 11.25.milliseconds..15.milliseconds,
+                    slaveLatency = 0,
+                    supervisionTimeout = 500.milliseconds,
+                )
+            targetDbm >= -12 ->
+                ConnectionParameters(
+                    intervalRange = 30.milliseconds..50.milliseconds,
+                    slaveLatency = 2,
+                    supervisionTimeout = 2000.milliseconds,
+                )
+            targetDbm >= -20 ->
+                ConnectionParameters(
+                    intervalRange = 100.milliseconds..125.milliseconds,
+                    slaveLatency = 4,
+                    supervisionTimeout = 4000.milliseconds,
+                )
+            else ->
+                ConnectionParameters(
+                    intervalRange = 300.milliseconds..400.milliseconds,
+                    slaveLatency = 7,
+                    supervisionTimeout = 6000.milliseconds,
+                )
+        }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PeerPowerRequest.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PeerPowerRequest.kt
@@ -1,0 +1,19 @@
+package com.atruedev.kmpble.monitoring
+
+/**
+ * An incoming power change request from the connected peer.
+ *
+ * Emitted by [LePowerController.incomingPowerRequests] when the peer
+ * requests that this device change its transmit power level.
+ *
+ * Platform notes:
+ * - Android: The [android.bluetooth.BluetoothGattCallback.onConnectionUpdated]
+ *   callback may report peer-requested changes (API 29+).
+ * - iOS: CoreBluetooth does not surface incoming power requests.
+ *
+ * @property requestedDbm The transmit power level (dBm) the peer is requesting
+ *   this device to use.
+ */
+public data class PeerPowerRequest(
+    val requestedDbm: Int,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PeerPowerResponse.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/monitoring/PeerPowerResponse.kt
@@ -1,0 +1,27 @@
+package com.atruedev.kmpble.monitoring
+
+import kotlin.time.Duration
+
+/**
+ * Result of a [LePowerController.requestPeerPowerChange] call.
+ *
+ * Reports whether the peer accepted the power change request and
+ * the actual negotiated connection parameters.
+ *
+ * @property accepted Whether the peer accepted the power change request.
+ *   `false` if the platform does not support the operation or the peer rejected.
+ * @property targetDbm The requested transmit power level in dBm.
+ * @property negotiatedInterval The connection interval the central selected,
+ *   or null if the operation is unsupported.
+ * @property negotiatedLatency The slave latency the central selected,
+ *   or null if the operation is unsupported.
+ * @property negotiatedSupervisionTimeout The supervision timeout the central
+ *   selected, or null if the operation is unsupported.
+ */
+public data class PeerPowerResponse(
+    val accepted: Boolean,
+    val targetDbm: Int,
+    val negotiatedInterval: Duration?,
+    val negotiatedLatency: Int?,
+    val negotiatedSupervisionTimeout: Duration?,
+)

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
@@ -111,8 +111,8 @@ class LePowerControllerTest {
 
             controller.requestPeerPowerChange(-4)
             assertNotNull(capturedParams)
-            assertEquals(0, capturedParams!!.slaveLatency)
-            assertEquals(500.milliseconds, capturedParams!!.supervisionTimeout)
+            assertEquals(0, capturedParams.slaveLatency)
+            assertEquals(500.milliseconds, capturedParams.supervisionTimeout)
 
             controller.stop()
         }
@@ -145,8 +145,8 @@ class LePowerControllerTest {
 
             controller.requestPeerPowerChange(-10)
             assertNotNull(capturedParams)
-            assertEquals(2, capturedParams!!.slaveLatency)
-            assertEquals(2000.milliseconds, capturedParams!!.supervisionTimeout)
+            assertEquals(2, capturedParams.slaveLatency)
+            assertEquals(2000.milliseconds, capturedParams.supervisionTimeout)
 
             controller.stop()
         }
@@ -179,8 +179,8 @@ class LePowerControllerTest {
 
             controller.requestPeerPowerChange(-15)
             assertNotNull(capturedParams)
-            assertEquals(4, capturedParams!!.slaveLatency)
-            assertEquals(4000.milliseconds, capturedParams!!.supervisionTimeout)
+            assertEquals(4, capturedParams.slaveLatency)
+            assertEquals(4000.milliseconds, capturedParams.supervisionTimeout)
 
             controller.stop()
         }
@@ -213,8 +213,8 @@ class LePowerControllerTest {
 
             controller.requestPeerPowerChange(-25)
             assertNotNull(capturedParams)
-            assertEquals(7, capturedParams!!.slaveLatency)
-            assertEquals(6000.milliseconds, capturedParams!!.supervisionTimeout)
+            assertEquals(7, capturedParams.slaveLatency)
+            assertEquals(6000.milliseconds, capturedParams.supervisionTimeout)
 
             controller.stop()
         }
@@ -300,7 +300,7 @@ class LePowerControllerTest {
 
             controller.stop()
 
-            // After stop, requestPeerPowerChange still works — it's stateless
+            // After stop, requestPeerPowerChange still works - it's stateless
             val response = controller.requestPeerPowerChange(-4)
             assertTrue(response.accepted)
         }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
@@ -1,0 +1,308 @@
+package com.atruedev.kmpble.monitoring
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionParameterUpdateResult
+import com.atruedev.kmpble.connection.ConnectionParameters
+import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalBleApi::class, ExperimentalCoroutinesApi::class)
+class LePowerControllerTest {
+    private val defaultResult =
+        ConnectionParameterUpdateResult(
+            negotiatedInterval = 12.5.milliseconds,
+            negotiatedLatency = 0,
+            negotiatedSupervisionTimeout = 500.milliseconds,
+        )
+
+    @Test
+    fun requestPeerPowerChangeReturnsAcceptedTrueWhenHandlerReturnsResult() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { defaultResult }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val response = controller.requestPeerPowerChange(-4)
+            assertTrue(response.accepted)
+            assertEquals(-4, response.targetDbm)
+            assertEquals(12.5.milliseconds, response.negotiatedInterval)
+            assertEquals(0, response.negotiatedLatency)
+            assertEquals(500.milliseconds, response.negotiatedSupervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun requestPeerPowerChangeReturnsDefaultResultWhenNoHandler() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val response = controller.requestPeerPowerChange(-4)
+            assertTrue(response.accepted)
+            assertEquals(-4, response.targetDbm)
+            assertNotNull(response.negotiatedInterval)
+            assertEquals(0, response.negotiatedLatency)
+            assertEquals(500.milliseconds, response.negotiatedSupervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun requestPeerPowerChangeUsesHighPowerParamsForDbmGeMinus4() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-4)
+            assertNotNull(capturedParams)
+            assertEquals(0, capturedParams!!.slaveLatency)
+            assertEquals(500.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun requestPeerPowerChangeUsesBalancedParamsForDbmGeMinus12() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-10)
+            assertNotNull(capturedParams)
+            assertEquals(2, capturedParams!!.slaveLatency)
+            assertEquals(2000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun requestPeerPowerChangeUsesLowPowerParamsForDbmGeMinus20() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-15)
+            assertNotNull(capturedParams)
+            assertEquals(4, capturedParams!!.slaveLatency)
+            assertEquals(4000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun requestPeerPowerChangeUsesMaxSavingParamsForDbmLtMinus20() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-25)
+            assertNotNull(capturedParams)
+            assertEquals(7, capturedParams!!.slaveLatency)
+            assertEquals(6000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun startIsIdempotent() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { defaultResult }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+            controller.start()
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val response = controller.requestPeerPowerChange(-4)
+            assertTrue(response.accepted)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun incomingPowerRequestsIsEmptyByDefault() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            val received = mutableListOf<PeerPowerRequest>()
+            val job =
+                backgroundScope.launch {
+                    controller.incomingPowerRequests.collect { received.add(it) }
+                }
+            scheduler.runCurrent()
+
+            assertTrue(received.isEmpty())
+            job.cancel()
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun stopThenRequestReturnsNoHandler() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { defaultResult }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.stop()
+
+            // After stop, requestPeerPowerChange still works — it's stateless
+            val response = controller.requestPeerPowerChange(-4)
+            assertTrue(response.accepted)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `LePowerController` - an active LE Power Control wrapper that enables apps to request connected peers to change their transmit power level.

### What
- `LePowerController` class in `commonMain` following the PowerMonitor/ConnectionQualityMonitor standalone-wrapper pattern
- `PeerPowerResponse` data class - result of power change requests
- `PeerPowerRequest` data class - incoming power requests from peer (placeholder flow)
- 8 tests covering acceptance, dBm-to-parameter mapping at all 4 tiers, idempotent start, incoming flow emptiness, and stop-then-request

### Architecture
- Pure commonMain - no platform-specific code needed (delegates to `Peripheral.requestConnectionParameterUpdate`)
- Maps target dBm to connection parameter tiers:
  - >= -4 dBm: High power / low latency (11.25..15ms, latency=0)
  - >= -12 dBm: Balanced (30..50ms, latency=2)
  - >= -20 dBm: Power saving (100..125ms, latency=4)
  - < -20 dBm: Max power saving (300..400ms, latency=7)
- `start()`/`stop()` lifecycle with Job cancellation (ConnectionQualityMonitor pattern)
- `CancellationException` rethrow before generic Exception catch

### Integration
Pairs with PowerMonitor (#286, #288):
1. PowerMonitor detects high path loss -> alert
2. App calls `LePowerController.requestPeerPowerChange(higherDbm)`
3. PowerMonitor observes RSSI improvement

Closes #295