### PR TITLE
refactor(android): extract GattCallbackEvent sealed interface from AndroidGattBridge

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -8,7 +8,6 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
-import android.bluetooth.BluetoothGattService
 import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
@@ -17,67 +16,6 @@ import com.atruedev.kmpble.connection.TransportType
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import kotlin.concurrent.Volatile
-
-internal sealed interface GattCallbackEvent {
-    data class ConnectionStateChanged(
-        val status: Int,
-        val newState: Int,
-    ) : GattCallbackEvent
-
-    data class ServicesDiscovered(
-        val status: Int,
-        val services: List<BluetoothGattService>,
-    ) : GattCallbackEvent
-
-    data class MtuChanged(
-        val mtu: Int,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    class CharacteristicRead(
-        val characteristic: BluetoothGattCharacteristic,
-        val value: ByteArray,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    data class CharacteristicWrite(
-        val characteristic: BluetoothGattCharacteristic,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    class CharacteristicChanged(
-        val characteristic: BluetoothGattCharacteristic,
-        val value: ByteArray,
-    ) : GattCallbackEvent
-
-    class DescriptorRead(
-        val descriptor: BluetoothGattDescriptor,
-        val value: ByteArray,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    data class DescriptorWrite(
-        val descriptor: BluetoothGattDescriptor,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    data class ReadRemoteRssi(
-        val rssi: Int,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    data class PhyUpdated(
-        val txPhy: Int,
-        val rxPhy: Int,
-        val status: Int,
-    ) : GattCallbackEvent
-
-    data class PhyRead(
-        val txPhy: Int,
-        val rxPhy: Int,
-        val status: Int,
-    ) : GattCallbackEvent
-}
 
 internal class AndroidGattBridge(
     private val device: BluetoothDevice,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/GattCallbackEvent.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/GattCallbackEvent.kt
@@ -1,0 +1,70 @@
+package com.atruedev.kmpble.peripheral
+
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattService
+
+/**
+ * Events dispatched from Android's [android.bluetooth.BluetoothGattCallback]
+ * through the [AndroidGattBridge] to platform-specific handlers.
+ */
+internal sealed interface GattCallbackEvent {
+    data class ConnectionStateChanged(
+        val status: Int,
+        val newState: Int,
+    ) : GattCallbackEvent
+
+    data class ServicesDiscovered(
+        val status: Int,
+        val services: List<BluetoothGattService>,
+    ) : GattCallbackEvent
+
+    data class MtuChanged(
+        val mtu: Int,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    class CharacteristicRead(
+        val characteristic: BluetoothGattCharacteristic,
+        val value: ByteArray,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    data class CharacteristicWrite(
+        val characteristic: BluetoothGattCharacteristic,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    class CharacteristicChanged(
+        val characteristic: BluetoothGattCharacteristic,
+        val value: ByteArray,
+    ) : GattCallbackEvent
+
+    class DescriptorRead(
+        val descriptor: BluetoothGattDescriptor,
+        val value: ByteArray,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    data class DescriptorWrite(
+        val descriptor: BluetoothGattDescriptor,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    data class ReadRemoteRssi(
+        val rssi: Int,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    data class PhyUpdated(
+        val txPhy: Int,
+        val rxPhy: Int,
+        val status: Int,
+    ) : GattCallbackEvent
+
+    data class PhyRead(
+        val txPhy: Int,
+        val rxPhy: Int,
+        val status: Int,
+    ) : GattCallbackEvent
+}


### PR DESCRIPTION
## Summary

Extract `GattCallbackEvent` sealed interface hierarchy from AndroidGattBridge.kt to its own file, reducing the bridge from 315 to 253 lines (-20%).

### What
- Extracted 11 inner event types to `GattCallbackEvent.kt`
- Removed unused `BluetoothGattService` import
- No behavioral changes — all event types and call sites unchanged

### Result
- AndroidGattBridge.kt: 315 → 253 lines (below 300 threshold)
- GattCallbackEvent.kt: 70 lines (pure data types, no bridge dependencies)

Closes #270