### PR TITLE
refactor(android): decompose AndroidPeripheral 380->236 via extension functions (#306)

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -4,9 +4,6 @@ package com.atruedev.kmpble.peripheral
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGatt
-import android.bluetooth.BluetoothGattCharacteristic
-import android.bluetooth.BluetoothGattDescriptor
 import android.content.Context
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
@@ -21,30 +18,21 @@ import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.ReconnectionStrategy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ReconnectionHandler
-import com.atruedev.kmpble.error.BleException
-import com.atruedev.kmpble.error.GattError
-import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
-import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.ObservationManager
-import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
 import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
-import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
-import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
 import com.atruedev.kmpble.peripheral.internal.PeripheralRegistry
-import com.atruedev.kmpble.peripheral.internal.awaitGatt
-import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
 import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.internal.findDescriptor
 import com.atruedev.kmpble.quirks.QuirkRegistry
@@ -52,8 +40,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -154,27 +140,7 @@ public class AndroidPeripheral internal constructor(
         return bondManager.removeBond()
     }
 
-    override suspend fun refreshServices(): List<DiscoveredService> {
-        checkNotClosed()
-        return withContext(peripheralContext.dispatcher) {
-            // Invalidate the Android GATT cache before discovery so the platform
-            // performs a fresh radio-level service discovery instead of returning
-            // cached data instantly. Best-effort: refreshDeviceCache() uses
-            // reflection on the hidden BluetoothGatt.refresh() method and may
-            // fail silently on some OEMs.
-            bridge.refreshDeviceCache()
-            val deferred = slots.armDiscovery()
-            if (!bridge.discoverServices()) {
-                slots.clearDiscovery()
-                throw BleException(OperationFailed("discoverServices initiation failed"))
-            }
-            try {
-                withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
-            } finally {
-                slots.clearDiscovery()
-            }
-        }
-    }
+    override suspend fun refreshServices(): List<DiscoveredService> = refreshServicesGatt()
 
     override fun findCharacteristic(
         serviceUuid: Uuid,
@@ -187,187 +153,56 @@ public class AndroidPeripheral internal constructor(
         descriptorUuid: Uuid,
     ): Descriptor? = services.value.findDescriptor(serviceUuid, characteristicUuid, descriptorUuid)
 
-    override suspend fun read(characteristic: Characteristic): ByteArray {
-        checkNotClosed()
-        return peripheralContext.gattQueue.enqueue {
-            val native = requireNativeChar(characteristic)
-            val result =
-                pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
-                    bridge.readCharacteristic(native)
-                }
-            if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
-            result.value
-        }
-    }
+    override suspend fun read(characteristic: Characteristic): ByteArray = readCharacteristicGatt(characteristic)
 
     override suspend fun write(
         characteristic: Characteristic,
         data: ByteArray,
         writeType: WriteType,
     ) {
-        checkNotClosed()
-        LargeWriteHandler.validateForWriteType(data, maximumWriteValueLength.value, writeType)
-
-        val native = requireNativeChar(characteristic)
-        val androidWriteType = writeType.toAndroidWriteType()
-        val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
-
-        peripheralContext.gattQueue.enqueue {
-            for (chunk in chunks) {
-                val status =
-                    pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
-                        bridge.writeCharacteristic(native, chunk, androidWriteType)
-                    }
-                if (!status.isSuccess()) throw BleException(GattError("write", status))
-            }
-        }
+        writeCharacteristicGatt(characteristic, data, writeType)
     }
 
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<Observation> {
-        checkNotClosed()
-        return buildObservationFlow(
-            characteristic = characteristic,
-            backpressure = backpressure,
-            observationManager = observationManager,
-            isReady = { peripheralContext.state.value is State.Connected.Ready },
-            enable = ::enableNotifications,
-            disable = ::disableNotificationsBestEffort,
-            mapper = ObservationToObservation,
-        )
-    }
+    ): Flow<Observation> = observeGatt(characteristic, backpressure)
 
     override fun observeValues(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,
-    ): Flow<ByteArray> {
-        checkNotClosed()
-        return buildObservationFlow(
-            characteristic = characteristic,
-            backpressure = backpressure,
-            observationManager = observationManager,
-            isReady = { peripheralContext.state.value is State.Connected.Ready },
-            enable = ::enableNotifications,
-            disable = ::disableNotificationsBestEffort,
-            mapper = ObservationToBytes,
-        )
-    }
+    ): Flow<ByteArray> = observeValuesGatt(characteristic, backpressure)
 
-    override suspend fun readDescriptor(descriptor: Descriptor): ByteArray {
-        checkNotClosed()
-        return peripheralContext.gattQueue.enqueue {
-            val native = requireNativeDesc(descriptor)
-            val result =
-                pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
-                    bridge.readDescriptor(native)
-                }
-            if (!result.status.isSuccess()) throw BleException(GattError("descriptorRead", result.status))
-            result.value
-        }
-    }
+    override suspend fun readDescriptor(descriptor: Descriptor): ByteArray = readDescriptorGatt(descriptor)
 
     override suspend fun writeDescriptor(
         descriptor: Descriptor,
         data: ByteArray,
     ) {
-        checkNotClosed()
-        peripheralContext.gattQueue.enqueue {
-            val native = requireNativeDesc(descriptor)
-            val status =
-                pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
-                    bridge.writeDescriptor(native, data)
-                }
-            if (!status.isSuccess()) throw BleException(GattError("descriptorWrite", status))
-        }
+        writeDescriptorGatt(descriptor, data)
     }
 
-    override suspend fun readRssi(): Int {
-        checkNotClosed()
-        return peripheralContext.gattQueue.enqueue {
-            pendingOps.awaitGatt(PendingOp.RssiRead, "readRssi") { bridge.readRemoteRssi() }
-        }
-    }
+    override suspend fun readRssi(): Int = readRssiGatt()
 
-    override suspend fun requestMtu(mtu: Int): Int {
-        checkNotClosed()
-        return peripheralContext.gattQueue.enqueue {
-            pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
-        }
-    }
+    override suspend fun requestMtu(mtu: Int): Int = requestMtuGatt(mtu)
 
     @ExperimentalBleApi
-    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
-        checkNotClosed()
-        val androidPriority =
-            when (priority) {
-                ConnectionPriority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
-                ConnectionPriority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
-                ConnectionPriority.LowPower -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
-            }
-        return peripheralContext.gattQueue.enqueue {
-            bridge.requestConnectionPriority(androidPriority)
-        }
-    }
+    override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean =
+        requestConnectionPriorityGatt(priority)
 
     @ExperimentalBleApi
     override suspend fun requestConnectionParameterUpdate(
         params: ConnectionParameters,
-    ): ConnectionParameterUpdateResult? {
-        checkNotClosed()
-        val androidPriority = params.intervalRange.toAndroidConnectionPriority()
-        return peripheralContext.gattQueue.enqueue {
-            val dispatched = bridge.requestConnectionPriority(androidPriority)
-            if (!dispatched) return@enqueue null
-            ConnectionParameterUpdateResult(
-                negotiatedInterval = params.intervalRange.endInclusive,
-                negotiatedLatency = params.slaveLatency,
-                negotiatedSupervisionTimeout = params.supervisionTimeout,
-            )
-        }
-    }
+    ): ConnectionParameterUpdateResult? = requestConnectionParameterUpdateGatt(params)
 
     @ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
-    ): PhyResult? {
-        checkNotClosed()
-        val txMask = phyToMask(tx)
-        val rxMask = phyToMask(rx)
-        return peripheralContext.gattQueue.enqueue {
-            val result =
-                pendingOps.awaitGatt(PendingOp.PhyUpdate, "setPreferredPhy") {
-                    bridge.setPreferredPhy(
-                        txMask,
-                        rxMask,
-                        BluetoothDevice.PHY_OPTION_NO_PREFERRED,
-                    )
-                }
-            if (!result.status.isSuccess()) return@enqueue null
-            PhyResult(
-                tx = phyConstantToPhy(result.txPhyConstant),
-                rx = phyConstantToPhy(result.rxPhyConstant),
-            )
-        }
-    }
+    ): PhyResult? = setPreferredPhyGatt(tx, rx)
 
     @ExperimentalBleApi
-    override suspend fun readPhy(): PhyResult? {
-        checkNotClosed()
-        return peripheralContext.gattQueue.enqueue {
-            val result =
-                pendingOps.awaitGatt(PendingOp.PhyRead, "readPhy") {
-                    bridge.readPhy()
-                }
-            if (!result.status.isSuccess()) return@enqueue null
-            PhyResult(
-                tx = phyConstantToPhy(result.txPhyConstant),
-                rx = phyConstantToPhy(result.rxPhyConstant),
-            )
-        }
-    }
+    override suspend fun readPhy(): PhyResult? = readPhyGatt()
 
     @ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = _phyUpdate

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -4,6 +4,8 @@ package com.atruedev.kmpble.peripheral
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
 import android.content.Context
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnectionParams.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnectionParams.kt
@@ -1,0 +1,94 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.peripheral
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.connection.ConnectionParameterUpdateResult
+import com.atruedev.kmpble.connection.ConnectionParameters
+import com.atruedev.kmpble.connection.ConnectionPriority
+import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.gatt.internal.PendingOp
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+
+/**
+ * Connection parameter and PHY operation implementations for
+ * [AndroidPeripheral].
+ *
+ * Extracted during second-pass decomposition (380 -> ~260) to keep the facade
+ * under 300 lines.
+ */
+
+@OptIn(ExperimentalBleApi::class)
+internal suspend fun AndroidPeripheral.requestConnectionPriorityGatt(priority: ConnectionPriority): Boolean {
+    checkNotClosed()
+    val androidPriority =
+        when (priority) {
+            ConnectionPriority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+            ConnectionPriority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+            ConnectionPriority.LowPower -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+        }
+    return peripheralContext.gattQueue.enqueue {
+        bridge.requestConnectionPriority(androidPriority)
+    }
+}
+
+@OptIn(ExperimentalBleApi::class)
+internal suspend fun AndroidPeripheral.requestConnectionParameterUpdateGatt(
+    params: ConnectionParameters,
+): ConnectionParameterUpdateResult? {
+    checkNotClosed()
+    val androidPriority = params.intervalRange.toAndroidConnectionPriority()
+    return peripheralContext.gattQueue.enqueue {
+        val dispatched = bridge.requestConnectionPriority(androidPriority)
+        if (!dispatched) return@enqueue null
+        ConnectionParameterUpdateResult(
+            negotiatedInterval = params.intervalRange.endInclusive,
+            negotiatedLatency = params.slaveLatency,
+            negotiatedSupervisionTimeout = params.supervisionTimeout,
+        )
+    }
+}
+
+@OptIn(ExperimentalBleApi::class)
+internal suspend fun AndroidPeripheral.setPreferredPhyGatt(
+    tx: Phy,
+    rx: Phy,
+): PhyResult? {
+    checkNotClosed()
+    val txMask = phyToMask(tx)
+    val rxMask = phyToMask(rx)
+    return peripheralContext.gattQueue.enqueue {
+        val result =
+            pendingOps.awaitGatt(PendingOp.PhyUpdate, "setPreferredPhy") {
+                bridge.setPreferredPhy(
+                    txMask,
+                    rxMask,
+                    BluetoothDevice.PHY_OPTION_NO_PREFERRED,
+                )
+            }
+        if (!result.status.isSuccess()) return@enqueue null
+        PhyResult(
+            tx = phyConstantToPhy(result.txPhyConstant),
+            rx = phyConstantToPhy(result.rxPhyConstant),
+        )
+    }
+}
+
+@OptIn(ExperimentalBleApi::class)
+internal suspend fun AndroidPeripheral.readPhyGatt(): PhyResult? {
+    checkNotClosed()
+    return peripheralContext.gattQueue.enqueue {
+        val result =
+            pendingOps.awaitGatt(PendingOp.PhyRead, "readPhy") {
+                bridge.readPhy()
+            }
+        if (!result.status.isSuccess()) return@enqueue null
+        PhyResult(
+            tx = phyConstantToPhy(result.txPhyConstant),
+            rx = phyConstantToPhy(result.rxPhyConstant),
+        )
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattOps.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattOps.kt
@@ -1,0 +1,160 @@
+@file:SuppressLint("MissingPermission")
+
+package com.atruedev.kmpble.peripheral
+
+import android.annotation.SuppressLint
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.gatt.BackpressureStrategy
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.Descriptor
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.Observation
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
+import com.atruedev.kmpble.gatt.internal.PendingOp
+import com.atruedev.kmpble.peripheral.internal.ObservationToBytes
+import com.atruedev.kmpble.peripheral.internal.ObservationToObservation
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+import com.atruedev.kmpble.peripheral.internal.buildObservationFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+/**
+ * GATT read / write / notification / refresh implementations for
+ * [AndroidPeripheral].
+ *
+ * Extracted during second-pass decomposition (380 -> ~260) to keep the facade
+ * under 300 lines.  Companion event dispatch lives in
+ * [AndroidPeripheralGattHandler].
+ */
+
+internal suspend fun AndroidPeripheral.refreshServicesGatt(): List<DiscoveredService> {
+    checkNotClosed()
+    return withContext(peripheralContext.dispatcher) {
+        bridge.refreshDeviceCache()
+        val deferred = slots.armDiscovery()
+        if (!bridge.discoverServices()) {
+            slots.clearDiscovery()
+            throw BleException(OperationFailed("discoverServices initiation failed"))
+        }
+        try {
+            withTimeout(SERVICE_DISCOVERY_TIMEOUT) { deferred.await() }
+        } finally {
+            slots.clearDiscovery()
+        }
+    }
+}
+
+internal suspend fun AndroidPeripheral.readCharacteristicGatt(characteristic: Characteristic): ByteArray {
+    checkNotClosed()
+    return peripheralContext.gattQueue.enqueue {
+        val native = requireNativeChar(characteristic)
+        val result =
+            pendingOps.awaitGatt(PendingOp.CharacteristicRead, "read") {
+                bridge.readCharacteristic(native)
+            }
+        if (!result.status.isSuccess()) throw BleException(GattError("read", result.status))
+        result.value
+    }
+}
+
+internal suspend fun AndroidPeripheral.writeCharacteristicGatt(
+    characteristic: Characteristic,
+    data: ByteArray,
+    writeType: WriteType,
+) {
+    checkNotClosed()
+    LargeWriteHandler.validateForWriteType(data, maximumWriteValueLength.value, writeType)
+
+    val native = requireNativeChar(characteristic)
+    val androidWriteType = writeType.toAndroidWriteType()
+    val chunks = LargeWriteHandler.chunk(data, maximumWriteValueLength.value)
+
+    peripheralContext.gattQueue.enqueue {
+        for (chunk in chunks) {
+            val status =
+                pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "write") {
+                    bridge.writeCharacteristic(native, chunk, androidWriteType)
+                }
+            if (!status.isSuccess()) throw BleException(GattError("write", status))
+        }
+    }
+}
+
+internal fun AndroidPeripheral.observeGatt(
+    characteristic: Characteristic,
+    backpressure: BackpressureStrategy,
+): Flow<Observation> {
+    checkNotClosed()
+    return buildObservationFlow(
+        characteristic = characteristic,
+        backpressure = backpressure,
+        observationManager = observationManager,
+        isReady = { peripheralContext.state.value is State.Connected.Ready },
+        enable = ::enableNotifications,
+        disable = ::disableNotificationsBestEffort,
+        mapper = ObservationToObservation,
+    )
+}
+
+internal fun AndroidPeripheral.observeValuesGatt(
+    characteristic: Characteristic,
+    backpressure: BackpressureStrategy,
+): Flow<ByteArray> {
+    checkNotClosed()
+    return buildObservationFlow(
+        characteristic = characteristic,
+        backpressure = backpressure,
+        observationManager = observationManager,
+        isReady = { peripheralContext.state.value is State.Connected.Ready },
+        enable = ::enableNotifications,
+        disable = ::disableNotificationsBestEffort,
+        mapper = ObservationToBytes,
+    )
+}
+
+internal suspend fun AndroidPeripheral.readDescriptorGatt(descriptor: Descriptor): ByteArray {
+    checkNotClosed()
+    return peripheralContext.gattQueue.enqueue {
+        val native = requireNativeDesc(descriptor)
+        val result =
+            pendingOps.awaitGatt(PendingOp.DescriptorRead, "readDescriptor") {
+                bridge.readDescriptor(native)
+            }
+        if (!result.status.isSuccess()) throw BleException(GattError("descriptorRead", result.status))
+        result.value
+    }
+}
+
+internal suspend fun AndroidPeripheral.writeDescriptorGatt(
+    descriptor: Descriptor,
+    data: ByteArray,
+) {
+    checkNotClosed()
+    peripheralContext.gattQueue.enqueue {
+        val native = requireNativeDesc(descriptor)
+        val status =
+            pendingOps.awaitGatt(PendingOp.DescriptorWrite, "writeDescriptor") {
+                bridge.writeDescriptor(native, data)
+            }
+        if (!status.isSuccess()) throw BleException(GattError("descriptorWrite", status))
+    }
+}
+
+internal suspend fun AndroidPeripheral.readRssiGatt(): Int {
+    checkNotClosed()
+    return peripheralContext.gattQueue.enqueue {
+        pendingOps.awaitGatt(PendingOp.RssiRead, "readRssi") { bridge.readRemoteRssi() }
+    }
+}
+
+internal suspend fun AndroidPeripheral.requestMtuGatt(mtu: Int): Int {
+    checkNotClosed()
+    return peripheralContext.gattQueue.enqueue {
+        pendingOps.awaitGatt(PendingOp.MtuRequest, "requestMtu") { bridge.requestMtu(mtu) }
+    }
+}


### PR DESCRIPTION
## Summary

Second-pass decomposition of AndroidPeripheral.kt from 380 lines down to 236 (target <300).

### Changes

- **AndroidPeripheralGattOps.kt** (new, ~160 lines): Extracted GATT read/write/notify/refresh/descriptor/RSSI/MTU implementations as extension functions
- **AndroidPeripheralConnectionParams.kt** (new, ~95 lines): Extracted PHY and connection parameter operations (setPreferredPhy, readPhy, requestConnectionPriority, requestConnectionParameterUpdate)
- **AndroidPeripheral.kt**: Facade reduced from 380 to 236 lines via thin delegation to extracted extension functions. Cleaned up unused imports while preserving BluetoothGattCharacteristic/BluetoothGattDescriptor for internal field type declarations.

### Approach

Approach B (extension functions in same package), consistent with the first-pass decomposition in #244. All GATT/PHY/connection implementations are internal extension functions within com.atruedev.kmpble.peripheral.

Closes #306