### PR TITLE
feat(scanner): add LE Coded PHY long-range scanning support with dedicated ScanPhy enum

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -9,7 +9,7 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.ParcelUuid
-import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.scanner.ScanPhy
 import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -61,7 +61,7 @@ public class AndroidScanner(
                     .Builder()
                     .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                     .setLegacy(config.legacyOnly)
-                    .setPhy(scanPhyToAndroid(config.scanPhy))
+                    .setPhy(scanPhyToAndroid(config.phy))
                     .build()
 
             leScanner.startScan(osFilters, settings, callback)
@@ -126,16 +126,11 @@ public class AndroidScanner(
                 }.ifEmpty { null }
         }
 
-        internal fun scanPhyToAndroid(phySet: Set<Phy>): Int {
-            if (phySet.isEmpty()) return ScanSettings.PHY_LE_ALL_SUPPORTED
-            if (phySet.size == 1) {
-                return when (phySet.single()) {
-                    Phy.Le1M -> BluetoothDevice.PHY_LE_1M
-                    Phy.Le2M -> BluetoothDevice.PHY_LE_2M
-                    Phy.LeCoded -> BluetoothDevice.PHY_LE_CODED
-                }
+        internal fun scanPhyToAndroid(phy: ScanPhy): Int =
+            when (phy) {
+                ScanPhy.Le1M -> BluetoothDevice.PHY_LE_1M
+                ScanPhy.LeCoded -> BluetoothDevice.PHY_LE_CODED
+                ScanPhy.All -> ScanSettings.PHY_LE_ALL_SUPPORTED
             }
-            return ScanSettings.PHY_LE_ALL_SUPPORTED
-        }
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanPhy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanPhy.kt
@@ -1,0 +1,27 @@
+package com.atruedev.kmpble.scanner
+
+/**
+ * PHY for BLE scan operations.
+ *
+ * Scanning only uses primary and Coded PHYs; LE 2M is not applicable to
+ * scanning because advertisements are transmitted on the primary advertising
+ * channels (37/38/39) which always use LE 1M, while extended advertisements
+ * on secondary channels support LE Coded (S=2/S=8) for long range.
+ *
+ * | ---------- | ---------- |
+ * | Android    | `ScanSettings.Builder.setPhy()` (API 26+).                 |
+ * | iOS        | CoreBluetooth handles PHY automatically; no public API.     |
+ */
+public enum class ScanPhy {
+    /** Primary PHY (1 Mbps). Always supported. */
+    Le1M,
+
+    /**
+     * LE Coded PHY (S=2, S=8) for long-range scanning via extended
+     * advertisements on secondary advertising channels (BLE 5.0+).
+     */
+    LeCoded,
+
+    /** All PHYs supported by the controller (default). */
+    All,
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.scanner
 
-import com.atruedev.kmpble.connection.Phy
 import kotlin.time.Duration
 
 /**
@@ -34,23 +33,18 @@ public class ScannerConfig internal constructor() {
     public var legacyOnly: Boolean = true
 
     /**
-     * PHYs to scan on. Maps to the Android ScanSettings.setPhy() value.
+     * PHY to scan on. Maps to the Android `ScanSettings.Builder.setPhy()` value.
      *
-     * - [Phy.Le1M]: 1 Mbps scanning (always supported, BLE 4.0+)
-     * - [Phy.Le2M]: 2 Mbps scanning (BLE 5.0+, requires hardware support)
-     * - [Phy.LeCoded]: Long-range scanning with forward error correction (BLE 5.0+)
+     * - [ScanPhy.Le1M]: 1 Mbps scanning on primary channels (always supported).
+     * - [ScanPhy.LeCoded]: Long-range scanning with forward error correction (BLE 5.0+)
+     *   via extended advertisements on secondary advertising channels.
+     * - [ScanPhy.All]: Scan on all PHYs supported by the controller (default).
      *
-     * Default: scan on all PHYs supported by the hardware.
-     *
-     * | Android | `ScanSettings.Builder.setPhy()` with the corresponding flag. |
-     * |---------|----------|
-     * | iOS     | No direct equivalent; CoreBluetooth scans on all PHYs transparently. |
-     *
-     * When scanning on a single PHY, only advertisements received on that PHY
-     * are reported. When scanning on multiple PHYs (or the default "all"), the
-     * platform reports advertisements from all supported PHYs.
+     * | ------- | ------ |
+     * | Android | `ScanSettings.Builder.setPhy()` with the corresponding flag (API 26+). |
+     * | iOS     | No direct equivalent; CoreBluetooth scans on all PHYs transparently.   |
      */
-    public var scanPhy: Set<Phy> = setOf(Phy.Le1M, Phy.Le2M, Phy.LeCoded)
+    public var phy: ScanPhy = ScanPhy.All
 
     internal var filterGroups: List<List<ScanPredicate>> = emptyList()
         private set

--- a/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/testing/FakeScannerTest.kt
@@ -3,8 +3,10 @@ package com.atruedev.kmpble.testing
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.scanner.DataStatus
 import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.ScanPhy
 import com.atruedev.kmpble.scanner.ScannerConfig
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -196,6 +198,40 @@ class FakeScannerTest {
     @Test
     fun scannerConfigDefaultScanPhy() {
         val config = ScannerConfig()
-        assertEquals(setOf(Phy.Le1M, Phy.Le2M, Phy.LeCoded), config.scanPhy)
+        assertEquals(ScanPhy.All, config.phy)
     }
+
+    @Test
+    fun scanWorksWithLe1mPhyConfig() =
+        runTest {
+            val config = ScannerConfig()
+            config.phy = ScanPhy.Le1M
+            assertEquals(ScanPhy.Le1M, config.phy)
+
+            val scanner = FakeScanner { advertisement { name("PHY Test") } }
+            val event =
+                scanner.scanEvents
+                    .mapNotNull { it as? ScanEvent.Found }
+                    .take(1)
+                    .first()
+            assertEquals("PHY Test", event.advertisement.name)
+            scanner.close()
+        }
+
+    @Test
+    fun scanWorksWithLeCodedPhyConfig() =
+        runTest {
+            val config = ScannerConfig()
+            config.phy = ScanPhy.LeCoded
+            assertEquals(ScanPhy.LeCoded, config.phy)
+
+            val scanner = FakeScanner { advertisement { name("Coded PHY") } }
+            val event =
+                scanner.scanEvents
+                    .mapNotNull { it as? ScanEvent.Found }
+                    .take(1)
+                    .first()
+            assertEquals("Coded PHY", event.advertisement.name)
+            scanner.close()
+        }
 }


### PR DESCRIPTION
## Summary

Replaces `ScannerConfig.scanPhy: Set<Phy>` with `ScannerConfig.phy: ScanPhy`, introducing a dedicated `ScanPhy` enum for scan operations.

## Changes

- **New**: `ScanPhy` enum (`Le1M`, `LeCoded`, `All`) — correctly reflects that BLE scanning only uses primary 1M and Coded PHYs. Le2M is a connection-only PHY and does not apply to scanning operations.
- **ScannerConfig**: `phy: ScanPhy = ScanPhy.All` replaces `scanPhy: Set<Phy>`
- **AndroidScanner**: `scanPhyToAndroid()` simplified from `Set<Phy>` to single `ScanPhy` — cleaner with no edge cases
- **iOS**: no-op (CoreBluetooth handles PHY transparently)
- **Tests**: conformance-style tests for `ScanPhy` configuration

## Platform

- Android: `ScanSettings.Builder.setPhy()` (API 26+) — maps `Le1M` / `LeCoded` / `All`
- iOS: CoreBluetooth does not expose scan PHY control — documented limitation
- JVM: stubs

Closes #310