### PR TITLE
refactor(testing): extract FakePeripheral simulation methods to extension functions

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -9,9 +9,7 @@ import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
-import com.atruedev.kmpble.error.BleError
 import com.atruedev.kmpble.error.ConnectionFailed
-import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Characteristic
@@ -49,11 +47,11 @@ public class FakePeripheral internal constructor(
         ),
 ) : Peripheral {
     private val context = PeripheralContext(identifier)
-    private val observationManager = ObservationManager(observationDispatcher)
+    internal val observationManager = ObservationManager(observationDispatcher)
     private var closed = false
-    private val cccdWritesState = MutableStateFlow<List<CccdWrite>>(emptyList())
+    internal val cccdWritesState = MutableStateFlow<List<CccdWrite>>(emptyList())
 
-    private val connectionSimulator =
+    internal val connectionSimulator =
         FakeConnectionSimulator(
             context = context,
             observationManager = observationManager,
@@ -62,7 +60,7 @@ public class FakePeripheral internal constructor(
             closedFlag = { closed },
         )
 
-    private val gattResponder =
+    internal val gattResponder =
         FakeGattResponder(
             context = context,
             observationManager = observationManager,
@@ -101,33 +99,6 @@ public class FakePeripheral internal constructor(
                 )
             context.processEvent(ConnectionEvent.ConnectionLost(error))
         }
-    }
-
-    internal suspend fun simulateEvent(event: ConnectionEvent): State = connectionSimulator.simulateEvent(event)
-
-    /**
-     * Drives the state machine from [State.Connected.Ready] to
-     * [State.Connected.BondingChange].
-     */
-    public suspend fun simulateBondStateChange() {
-        connectionSimulator.simulateBondStateChange()
-    }
-
-    /**
-     * Drives the state machine from [State.Connected.Ready] to
-     * [State.Connected.ServiceChanged]. Services remain populated (now stale)
-     * until rediscovery completes.
-     */
-    public suspend fun simulateServiceChangedIndication() {
-        connectionSimulator.simulateServiceChangedIndication()
-    }
-
-    /**
-     * Drives the state machine from [State.Connected.ServiceChanged] back to
-     * [State.Connected.Ready].
-     */
-    public suspend fun simulateRediscoverySucceeded() {
-        connectionSimulator.simulateRediscoverySucceeded()
     }
 
     override suspend fun disconnect() {
@@ -232,86 +203,6 @@ public class FakePeripheral internal constructor(
 
     @com.atruedev.kmpble.ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = gattResponder.phyUpdate
-
-    // --- Test Simulation Methods (delegated to FakeConnectionSimulator) ---
-
-    /**
-     * Simulate a disconnect event. This will emit [Observation.Disconnected] to all active
-     * observations but NOT complete them - they persist for reconnection.
-     */
-    public suspend fun simulateDisconnect(error: BleError = ConnectionLost("Simulated disconnect")) {
-        connectionSimulator.simulateDisconnect(error)
-    }
-
-    /**
-     * Simulate a reconnection. This will:
-     * 1. Transition through connecting states
-     * 2. Re-discover services
-     * 3. Re-enable CCCD for all active observations
-     */
-    public suspend fun simulateReconnect(newServices: List<DiscoveredService>? = null) {
-        connectionSimulator.simulateReconnect(newServices)
-    }
-
-    /**
-     * Simulate permanent disconnect (max reconnection attempts exhausted).
-     * This will complete all observation flows.
-     */
-    public suspend fun simulatePermanentDisconnect() {
-        connectionSimulator.simulatePermanentDisconnect()
-    }
-
-    /** Simulate a characteristic notification by emitting [value] to active observers. */
-    public suspend fun emitObservationValue(
-        serviceUuid: Uuid,
-        charUuid: Uuid,
-        value: ByteArray,
-    ) {
-        connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
-    }
-
-    /** Convenience overload accepting short or full UUID strings. */
-    public suspend fun emitObservationValue(
-        serviceUuid: String,
-        charUuid: String,
-        value: ByteArray,
-    ) {
-        connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
-    }
-
-    /** Configure the PHY values returned by [readPhy]. */
-    public fun configurePhy(
-        tx: Phy,
-        rx: Phy,
-    ) {
-        gattResponder.configurePhy(tx, rx)
-    }
-
-    /** Simulate a spontaneous PHY update, which emits to [phyUpdate]. */
-    public suspend fun emitPhyUpdate(
-        tx: Phy,
-        rx: Phy,
-    ) {
-        gattResponder.emitPhyUpdate(tx, rx)
-    }
-
-    /** Returns all CCCD writes recorded during observation setup/teardown. */
-    public fun getCccdWrites(): List<CccdWrite> = cccdWritesState.value
-
-    /** Clears recorded CCCD writes. */
-    public fun clearCccdWrites() {
-        cccdWritesState.value = emptyList()
-    }
-
-    /** Returns `true` if there are active collectors for the given characteristic. */
-    public suspend fun hasCollectors(
-        serviceUuid: Uuid,
-        charUuid: Uuid,
-    ): Boolean = connectionSimulator.hasCollectors(serviceUuid, charUuid)
-
-    /** Expose ObservationManager for test debugging. */
-    internal fun getObservationManagerForTest(): com.atruedev.kmpble.gatt.internal.ObservationManager =
-        observationManager
 
     private fun checkNotClosed() {
         check(!closed) { "Peripheral is closed" }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralSimulation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralSimulation.kt
@@ -1,0 +1,129 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.connection.Phy
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.connection.internal.ConnectionEvent
+import com.atruedev.kmpble.error.BleError
+import com.atruedev.kmpble.error.ConnectionLost
+import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.internal.ObservationManager
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun FakePeripheral.simulateEvent(event: ConnectionEvent): State =
+    connectionSimulator.simulateEvent(event)
+
+/** Drives the state machine from [State.Connected.Ready] to [State.Connected.BondingChange]. */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulateBondStateChange() {
+    connectionSimulator.simulateBondStateChange()
+}
+
+/**
+ * Drives the state machine from [State.Connected.Ready] to
+ * [State.Connected.ServiceChanged]. Services remain populated (now stale)
+ * until rediscovery completes.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulateServiceChangedIndication() {
+    connectionSimulator.simulateServiceChangedIndication()
+}
+
+/**
+ * Drives the state machine from [State.Connected.ServiceChanged] back to
+ * [State.Connected.Ready].
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulateRediscoverySucceeded() {
+    connectionSimulator.simulateRediscoverySucceeded()
+}
+
+/**
+ * Simulate a disconnect event. This will emit
+ * [com.atruedev.kmpble.gatt.Observation.Disconnected] to all active
+ * observations but NOT complete them -- they persist for reconnection.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulateDisconnect(error: BleError = ConnectionLost("Simulated disconnect")) {
+    connectionSimulator.simulateDisconnect(error)
+}
+
+/**
+ * Simulate a reconnection. This will:
+ * 1. Transition through connecting states
+ * 2. Re-discover services
+ * 3. Re-enable CCCD for all active observations
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulateReconnect(newServices: List<DiscoveredService>? = null) {
+    connectionSimulator.simulateReconnect(newServices)
+}
+
+/**
+ * Simulate permanent disconnect (max reconnection attempts exhausted).
+ * This will complete all observation flows.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.simulatePermanentDisconnect() {
+    connectionSimulator.simulatePermanentDisconnect()
+}
+
+/** Simulate a characteristic notification by emitting [value] to active observers. */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.emitObservationValue(
+    serviceUuid: Uuid,
+    charUuid: Uuid,
+    value: ByteArray,
+) {
+    connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
+}
+
+/** Convenience overload accepting short or full UUID strings. */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.emitObservationValue(
+    serviceUuid: String,
+    charUuid: String,
+    value: ByteArray,
+) {
+    connectionSimulator.emitObservationValue(serviceUuid, charUuid, value)
+}
+
+/** Configure the PHY values returned by [com.atruedev.kmpble.peripheral.Peripheral.readPhy]. */
+@OptIn(ExperimentalUuidApi::class)
+public fun FakePeripheral.configurePhy(
+    tx: Phy,
+    rx: Phy,
+) {
+    gattResponder.configurePhy(tx, rx)
+}
+
+/** Simulate a spontaneous PHY update, which emits to [com.atruedev.kmpble.peripheral.Peripheral.phyUpdate]. */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.emitPhyUpdate(
+    tx: Phy,
+    rx: Phy,
+) {
+    gattResponder.emitPhyUpdate(tx, rx)
+}
+
+/** Returns all CCCD writes recorded during observation setup/teardown. */
+@OptIn(ExperimentalUuidApi::class)
+public fun FakePeripheral.getCccdWrites(): List<FakePeripheral.CccdWrite> = cccdWritesState.value
+
+/** Clears recorded CCCD writes. */
+@OptIn(ExperimentalUuidApi::class)
+public fun FakePeripheral.clearCccdWrites() {
+    cccdWritesState.value = emptyList()
+}
+
+/** Returns `true` if there are active collectors for the given characteristic. */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun FakePeripheral.hasCollectors(
+    serviceUuid: Uuid,
+    charUuid: Uuid,
+): Boolean = connectionSimulator.hasCollectors(serviceUuid, charUuid)
+
+/** Expose ObservationManager for test debugging. */
+@OptIn(ExperimentalUuidApi::class)
+internal fun FakePeripheral.getObservationManagerForTest(): ObservationManager = observationManager

--- a/src/commonTest/kotlin/com/atruedev/kmpble/bonding/FakePeripheralBondingTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/bonding/FakePeripheralBondingTest.kt
@@ -4,6 +4,7 @@ import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.testing.FakePeripheral
+import com.atruedev.kmpble.testing.simulateEvent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs

--- a/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
@@ -17,6 +17,9 @@ import com.atruedev.kmpble.testing.FakeL2capListener
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
 import com.atruedev.kmpble.testing.FakeScanner
 import com.atruedev.kmpble.testing.FakeScannerBuilder
+import com.atruedev.kmpble.testing.configurePhy
+import com.atruedev.kmpble.testing.emitObservationValue
+import com.atruedev.kmpble.testing.emitPhyUpdate
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull

--- a/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionTest.kt
@@ -8,6 +8,12 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.testing.FakePeripheral
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import com.atruedev.kmpble.testing.clearCccdWrites
+import com.atruedev.kmpble.testing.emitObservationValue
+import com.atruedev.kmpble.testing.getCccdWrites
+import com.atruedev.kmpble.testing.simulateDisconnect
+import com.atruedev.kmpble.testing.simulatePermanentDisconnect
+import com.atruedev.kmpble.testing.simulateReconnect
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
@@ -10,6 +10,7 @@ import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.testing.FakePeripheral
+import com.atruedev.kmpble.testing.simulateEvent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -290,7 +290,7 @@ public class IosPeripheral(
         bridge.setNotifyValue(true, requireNativeCbChar(characteristic))
     }
 
-    private fun disableNotifications(characteristic: Characteristic) {
+    internal fun disableNotifications(characteristic: Characteristic) {
         if (peripheralContext.state.value !is State.Connected) return
         val native = nativeCharMap[characteristic] ?: return
         bridge.setNotifyValue(false, native)

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionJvmTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/observation/ObservationReconnectionJvmTest.kt
@@ -5,6 +5,8 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.testing.FakePeripheral
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import com.atruedev.kmpble.testing.emitObservationValue
+import com.atruedev.kmpble.testing.getCccdWrites
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/peripheral/BleIntegrationJvmTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/peripheral/BleIntegrationJvmTest.kt
@@ -8,6 +8,9 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.scanner.ScanEvent
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
 import com.atruedev.kmpble.testing.IntegrationTestFixtures
+import com.atruedev.kmpble.testing.emitObservationValue
+import com.atruedev.kmpble.testing.simulateDisconnect
+import com.atruedev.kmpble.testing.simulateReconnect
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull


### PR DESCRIPTION
## Summary

Decompose FakePeripheral.kt from 319 lines to 210 lines by extracting non-override test simulation methods to extension functions in the same package.

## Changes

- **New file: `FakePeripheralSimulation.kt`** — 16 extension functions (simulateEvent, simulateDisconnect, simulateReconnect, emitObservationValue, getCccdWrites, etc.)
- **FakePeripheral.kt** — 319→210 lines. Made 4 internal fields (`connectionSimulator`, `gattResponder`, `cccdWritesState`, `observationManager`) accessible to extension functions. Removed unused imports.
- **6 test files** — added explicit imports for extension functions (different packages need imports)
- **IosPeripheral.kt** — `disableNotifications` visibility change (private→internal) for untracked WIP compilation compatibility

## Design

Follows Approach B (extension functions in same package) from the kmp-ble-dev skill. The extracted methods are test simulation helpers, not `Peripheral` interface overrides, so extension functions preserve identical call-site syntax with explicit imports.

Refs: #315