### PR TITLE
chore: add .hermes/ and TODO.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,6 @@ xcuserdata/
 # Planning artifacts
 TODOS.md
 
-# Agent pipeline (private — managed in gary-quinn/agent-pipeline)
+# Agent pipeline (private - managed in gary-quinn/agent-pipeline)
 .hermes/
 TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ xcuserdata/
 
 # Planning artifacts
 TODOS.md
+
+# Agent pipeline (private — managed in gary-quinn/agent-pipeline)
+.hermes/
+TODO.md


### PR DESCRIPTION
Prevent accidental commits of agent pipeline artifacts. Pipeline config lives in private repo gary-quinn/agent-pipeline.