### PR TITLE
feat(ios): add IosPairingRequestHandler for GATT server pairing parity

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPairingRequestHandler.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPairingRequestHandler.kt
@@ -1,0 +1,44 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.Identifier
+import com.atruedev.kmpble.bonding.PairingHandler
+import com.atruedev.kmpble.logging.BleLogEvent
+import com.atruedev.kmpble.logging.logEvent
+
+/**
+ * Accepts a [PairingHandler] for API parity with Android but does not
+ * intercept pairing requests. CoreBluetooth manages pairing transparently
+ * via the system UI and does not expose a programmatic pairing API.
+ *
+ * All mutable state is confined to [serialDispatcher] inherited from
+ * [PeripheralContext][com.atruedev.kmpble.peripheral.internal.PeripheralContext].
+ */
+@ExperimentalBleApi
+internal class IosPairingRequestHandler(
+    private val identifier: Identifier,
+) {
+    private var handler: PairingHandler? = null
+
+    fun setHandler(pairingHandler: PairingHandler?) {
+        handler = pairingHandler
+        if (pairingHandler != null) {
+            logEvent(
+                BleLogEvent.BondEvent(
+                    identifier,
+                    "PairingHandler set but iOS CoreBluetooth handles pairing " +
+                        "transparently; programmatic pairing responses are not available.",
+                ),
+            )
+        }
+    }
+
+    /** No-op: CoreBluetooth manages pairing lifecycle. */
+    fun start() {}
+
+    /** No-op: CoreBluetooth manages pairing lifecycle. */
+    fun stop() {}
+
+    /** No-op: CoreBluetooth manages pairing lifecycle. */
+    fun closeSync() {}
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -69,6 +69,9 @@ public class IosPeripheral(
     internal var pendingL2capChannel: CompletableDeferred<CBL2CAPChannel>? = null
     internal val activeL2capChannels = MutableStateFlow<List<IosL2capChannel>>(emptyList())
 
+    @ExperimentalBleApi
+    internal val pairingRequestHandler = IosPairingRequestHandler(identifier)
+
     override val state: StateFlow<State> get() = peripheralContext.state
     override val bondState: StateFlow<BondState> get() = peripheralContext.bondState
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
@@ -108,6 +111,7 @@ public class IosPeripheral(
 
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
+        pairingRequestHandler.setHandler(options.pairingHandler)
         reconnectionHandler.start(options)
         withContext(peripheralContext.dispatcher) {
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
@@ -160,6 +164,7 @@ public class IosPeripheral(
         if (closed) return
         closed = true
         reconnectionHandler.stop()
+        pairingRequestHandler.closeSync()
         closeL2capChannels()
         centralDelegate.unregisterConnectionCallback(identifier.value)
 


### PR DESCRIPTION
Closes #327

## Changes
- Add `IosPairingRequestHandler` — accepts `PairingHandler` for API parity with Android
- CoreBluetooth handles pairing transparently via system UI; no programmatic API
- Logs a `BondEvent` when a handler is set, acknowledging the platform limitation
- Wired into `IosPeripheral.connect()` and `IosPeripheral.close()`

## Build
- [x] `./gradlew :compileKotlinJvm` - PASS
- [x] `./gradlew :compileKotlinIosSimulatorArm64` - PASS
- [x] `./gradlew ktlintFormat` - PASS
- [x] Typography check - CLEAN