### PR TITLE
docs(setup): add platform setup guides and troubleshooting for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,15 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design details and [STREAMS.md](STREA
 - iOS 15+
 - kotlinx-coroutines 1.10+
 
+## Documentation
+
+- [Platform Setup: iOS](docs/platform-setup-ios.md) -- Info.plist keys, background modes, entitlements
+- [Platform Setup: Android](docs/platform-setup-android.md) -- manifest permissions, runtime permission flow, location
+- [Troubleshooting](docs/troubleshooting.md) -- common BLE errors and their fixes
+- [Architecture](ARCHITECTURE.md) -- state machine, concurrency, GATT queue design
+- [L2CAP Architecture](docs/L2CAP.md) -- Connection-Oriented Channel subsystem
+- [API Reference](https://gary-quinn.github.io/kmp-ble/) -- KDoc-generated API docs
+
 ## Contributing
 
 After cloning, enable the repo's pre-commit hooks once:

--- a/docs/platform-setup-android.md
+++ b/docs/platform-setup-android.md
@@ -1,0 +1,208 @@
+# Platform Setup: Android
+
+This guide covers the Gradle and manifest configuration required to use kmp-ble
+on Android.
+
+## Requirements
+
+- Android minSdk 33 (Android 13)
+- Kotlin 2.3.0+
+- kotlinx-coroutines 1.10+
+
+## Gradle Setup
+
+```kotlin
+// build.gradle.kts (module)
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.atruedev:kmp-ble:0.8.5")
+        }
+    }
+}
+```
+
+## Library Initialization
+
+Initialize the library once, typically in `Application.onCreate()`:
+
+```kotlin
+class MyApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        KmpBle.init(this)
+    }
+}
+```
+
+Register in your manifest:
+
+```xml
+<application
+    android:name=".MyApp"
+    ...>
+</application>
+```
+
+The library also ships an `InitializationProvider` via AndroidX Startup.
+If you use that path, no manual `KmpBle.init()` call is needed.
+
+## Manifest Permissions
+
+### Core BLE Permissions (API 31+)
+
+On Android 12 (API 31) and above, BLE permissions are separate from location:
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+```
+
+- **BLUETOOTH_SCAN** -- Required for `Scanner` to discover nearby devices.
+- **BLUETOOTH_CONNECT** -- Required for `Peripheral.connect()`, read/write,
+  and observe operations.
+
+### Advertising Permission (API 31+)
+
+If your app advertises via `Advertiser` or `ExtendedAdvertiser`:
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+```
+
+### Location Permissions (API 30 and below)
+
+On Android 11 (API 30) and below, BLE scanning requires location permission:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+For apps with `minSdk 33`, location permissions are not needed for BLE.
+Include `android:maxSdkVersion="30"` to limit them to older API levels:
+
+```xml
+<uses-permission
+    android:name="android.permission.ACCESS_FINE_LOCATION"
+    android:maxSdkVersion="30" />
+<uses-permission
+    android:name="android.permission.ACCESS_COARSE_LOCATION"
+    android:maxSdkVersion="30" />
+```
+
+### Location Services Requirement (API 30 and below)
+
+On Android 11 and below, BLE scanning only works when **Location** is enabled
+in system settings (GPS does not need to be active -- only the Location toggle).
+
+kmp-ble mitigates this: on API < 31, a `NeverForLocation` scan is attempted
+first. If it fails, the scanner automatically falls back to requesting
+location-enabled scanning. This means most apps do not need to handle this
+manually. However, if your users report scan failures on older devices, tell
+them to enable Location in system settings.
+
+### Hardware Feature Declaration
+
+Declare BLE hardware as optional so your app remains installable on devices
+without BLE (e.g., Android TV, some tablets):
+
+```xml
+<uses-feature
+    android:name="android.hardware.bluetooth_le"
+    android:required="false" />
+```
+
+Use `required="true"` only if your app cannot function without BLE.
+
+### Complete Manifest Snippet
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- BLE (API 31+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+    <!-- Location (API 30 and below) -->
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
+
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="false" />
+
+    <application ...>
+        ...
+    </application>
+</manifest>
+```
+
+## Runtime Permission Flow
+
+On Android 12+, BLE permissions are runtime permissions. Use the library's
+built-in permission check:
+
+```kotlin
+when (val result = checkBlePermissions()) {
+    is PermissionResult.Granted -> {
+        // Start scanning or connect
+    }
+    is PermissionResult.Denied -> {
+        // Request permissions via your preferred method
+        // (ActivityResultContracts, Accompanist, etc.)
+    }
+    is PermissionResult.PermanentlyDenied -> {
+        // Direct user to Settings > Apps > Your App > Permissions
+    }
+}
+```
+
+The specific permissions to request at runtime:
+
+```kotlin
+// API 31+
+arrayOf(
+    Manifest.permission.BLUETOOTH_SCAN,
+    Manifest.permission.BLUETOOTH_CONNECT,
+)
+
+// API 30 and below
+arrayOf(
+    Manifest.permission.ACCESS_FINE_LOCATION,
+)
+```
+
+## Bluetooth Adapter State
+
+Before scanning, check that Bluetooth is enabled:
+
+```kotlin
+val adapter = BluetoothAdapter()
+adapter.state.collect { state ->
+    when (state) {
+        BluetoothAdapterState.On -> { /* ready */ }
+        BluetoothAdapterState.Off -> { /* prompt user to enable */ }
+        BluetoothAdapterState.Unauthorized -> { /* permission denied */ }
+        else -> {}
+    }
+}
+```
+
+## Known Android Limitations
+
+- **Samsung devices** may return cached GATT services. Disconnect and
+  reconnect, or call `BluetoothGatt.refresh()` to force rediscovery.
+  kmp-ble handles this via the quirks subsystem.
+- **Xiaomi/Huawei** devices sometimes kill BLE scans after 5 minutes.
+  Restart the scan if you need longer discovery windows.
+- Background BLE scanning on Android 8+ (API 26+) is throttled by the OS.
+  Use a foreground service for long-running scans.
+- On some devices, `BluetoothGatt.connect()` returns `true` but the
+  connection never completes. Always use a connection timeout.

--- a/docs/platform-setup-ios.md
+++ b/docs/platform-setup-ios.md
@@ -1,0 +1,140 @@
+# Platform Setup: iOS
+
+This guide covers the Xcode project configuration required to use kmp-ble on iOS.
+
+## Requirements
+
+- iOS 15.0+
+- Xcode 15.0+
+- Physical device (BLE is not available in the iOS simulator)
+
+## Info.plist Keys
+
+Add these keys to your app's `Info.plist`. All are required for BLE operations.
+
+### NSBluetoothAlwaysUsageDescription
+
+Required on iOS 13+. Describes why your app needs Bluetooth access.
+Shown in the system permission dialog the first time your app uses Bluetooth.
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app uses Bluetooth to communicate with BLE devices.</string>
+```
+
+### NSBluetoothPeripheralUsageDescription
+
+Required on iOS 12 and earlier. Apple recommends including it for backward
+compatibility even when targeting iOS 13+.
+
+```xml
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>This app uses Bluetooth to communicate with BLE devices.</string>
+```
+
+### Complete Info.plist snippet
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app uses Bluetooth to communicate with BLE devices.</string>
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>This app uses Bluetooth to communicate with BLE devices.</string>
+```
+
+## Background Modes
+
+If your app needs to scan, connect, or maintain BLE connections while in the
+background, add these to the Signing & Capabilities tab in Xcode:
+
+### Uses Bluetooth LE accessories (acts-as-central)
+
+Enable this for scanning and connecting to peripherals in the background.
+
+In Xcode:
+1. Select your target > Signing & Capabilities
+2. Click "+ Capability" > Background Modes
+3. Check "Uses Bluetooth LE accessories"
+
+Equivalent plist entry:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>bluetooth-central</string>
+</array>
+```
+
+### Acts as a Bluetooth LE accessory (acts-as-peripheral)
+
+Enable this if your app advertises or operates a GATT server in the background.
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>bluetooth-peripheral</string>
+</array>
+```
+
+### Both modes
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>bluetooth-central</string>
+    <string>bluetooth-peripheral</string>
+</array>
+```
+
+## Entitlements
+
+### com.apple.developer.bluetooth-central
+
+Required for CoreBluetooth central role. Usually added automatically when you
+enable the "Uses Bluetooth LE accessories" background mode.
+If Xcode does not add it, create an entitlements file with:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.bluetooth-central</key>
+    <true/>
+</dict>
+</plist>
+```
+
+## Swift Package Manager
+
+Add kmp-ble via SPM in Xcode:
+
+1. **File > Add Package Dependencies**
+2. Enter: `https://github.com/gary-quinn/kmp-ble`
+3. Select the version and add `KmpBle` to your target
+
+In your Swift code:
+
+```swift
+import KmpBle
+```
+
+## Permission Request Flow
+
+CoreBluetooth automatically requests permission when your app first accesses
+Bluetooth. No manual permission request call is needed on iOS.
+
+The `BluetoothAdapterState.Unauthorized` state signals that permission was
+denied. Direct the user to Settings > Privacy > Bluetooth.
+
+## Known iOS Limitations
+
+- BLE scanning in the background is rate-limited by iOS. Scan results arrive
+  less frequently than in the foreground.
+- iOS caches service/characteristic discovery. If a peripheral's GATT
+  structure changes, toggle Bluetooth off/on on the iOS device to clear
+  the cache.
+- The iOS simulator does not support BLE. Always test on a physical device.
+- Maximum ATT MTU is negotiated automatically by CoreBluetooth. The library
+  exposes the negotiated MTU via `Peripheral.mtu` but cannot force a
+  specific value.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,183 @@
+# Troubleshooting
+
+Common BLE setup and runtime errors, and how to fix them.
+
+## Scan produces no results
+
+### Android
+
+1. **Bluetooth is off.** Check `BluetoothAdapter().state`. Prompt user to
+   enable Bluetooth in system settings.
+2. **Permissions not granted.** Call `checkBlePermissions()`. On API 31+,
+   require `BLUETOOTH_SCAN`. On API 30 and below, require
+   `ACCESS_FINE_LOCATION`.
+3. **Location is disabled (API 30 and below).** On older Android versions,
+   the Location toggle must be ON in system settings. kmp-ble attempts
+   a `NeverForLocation` scan automatically to work around this on most
+   devices.
+4. **Scan timeout too short.** Increase the timeout in the `Scanner` builder:
+   ```kotlin
+   val scanner = Scanner { timeout = 60.seconds }
+   ```
+5. **Wi-Fi scanning throttling (Android 8+).** Android limits background
+   scans to one every 30 minutes. Use a foreground service for
+   long-running scans.
+
+### iOS
+
+1. **Simulator.** BLE is not available on the iOS simulator. Test on a
+   physical device.
+2. **Bluetooth permission denied.** Check Settings > Privacy > Bluetooth.
+   Your app must be listed and enabled.
+3. **Background scan throttling.** iOS rate-limits background scan results.
+   Move the app to the foreground for faster discovery.
+4. **Bluetooth is off.** Toggle Bluetooth off/on in Control Center or
+   Settings.
+
+## Connection fails with timeout
+
+1. **Device is out of range.** Move closer. BLE range is typically 10-30
+   meters but varies by environment.
+2. **Device is already connected to another central.** Many BLE peripherals
+   accept only one connection. Disconnect from other apps first.
+3. **Bluetooth stack is in a bad state.** Toggle Bluetooth off/on on the
+   phone, or restart the device.
+4. **Incorrect connection parameters.** Try `ConnectionRecipe.IOT` for
+   devices that are picky about connection intervals.
+5. **Android: `BluetoothDevice.connectGatt()` returns true but never
+   connects.** Use `ConnectionOptions(connectionTimeout = 10.seconds)`.
+
+## GATT error 133 / 0x85 (Android)
+
+GATT error 133 is Android's generic "something went wrong" status. Common
+causes:
+
+1. **Peripheral disconnected during an operation.** Handle the disconnect and
+   retry. kmp-ble's reconnection strategy handles this automatically if
+   configured: `ConnectionOptions(reconnectionStrategy = ...)`.
+2. **Too many concurrent GATT operations.** Each `Peripheral` serializes
+   operations internally. Do not share a `Peripheral` across heavy
+   concurrent workloads.
+3. **Bluetooth stack overflow.** Samsung devices are particularly prone.
+   Add a small delay between operations (e.g., 50ms) or create a fresh
+   `Peripheral` instance.
+4. **Bonding state mismatch.** If bonds were removed from system settings
+   but the peripheral still expects a bond, clear the bond on both sides.
+
+## GATT error 257 (iOS)
+
+On iOS, error 257 means the connection timed out. Common causes:
+
+1. **Peripheral went out of range.**
+2. **Peripheral stopped advertising.**
+3. **Peripheral refused the connection** (e.g., already connected to
+   another device).
+
+kmp-ble surfaces this as `ConnectionLost(cause = ConnectionError.Timeout)`.
+
+## `BluetoothAdapterState.Unauthorized`
+
+### Android
+
+The user denied the `BLUETOOTH_CONNECT` permission. Call
+`checkBlePermissions()` and direct them to system settings if
+`PermanentlyDenied`.
+
+### iOS
+
+The user denied Bluetooth access in the system dialog. They must go to
+**Settings > Privacy > Bluetooth** and enable your app manually.
+
+## `SecurityException: Need BLUETOOTH_CONNECT permission`
+
+Your app is missing the `BLUETOOTH_CONNECT` permission in the manifest
+or at runtime (Android 12+).
+
+**Fix:** Add to manifest:
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+```
+And request at runtime before calling `peripheral.connect()`.
+
+## `CBCentralManager.state == .unsupported` (iOS)
+
+The device does not support BLE. This happens on:
+- iOS Simulator
+- iPad 2 and older
+- iPod touch 4th gen and older
+
+Check `BluetoothAdapter().state` and handle `BluetoothAdapterState.Unsupported`
+gracefully.
+
+## Services discovery returns empty
+
+1. **Peripheral needs bond before service discovery.** Some peripherals hide
+   services until bonded. Use `ConnectionOptions(bondingPreference =
+   BondingPreference.Required)`.
+2. **iOS caching stale services.** CoreBluetooth caches discovered services.
+   Toggle Bluetooth off/on on the iOS device to clear the cache.
+3. **Android: Samsung cached services.** Samsung devices aggressively cache
+   GATT services. kmp-ble's quirks subsystem detects Samsung devices and
+   calls `BluetoothGatt.refresh()` automatically. If services are still
+   missing, try disconnecting and reconnecting.
+
+## `CancellationException` is silently swallowed
+
+kmp-ble follows structured concurrency rules. CancellationException is
+always rethrown. If you see behavior that suggests it is not, ensure your
+coroutine scope is not catching it:
+
+```kotlin
+// WRONG -- swallows cancellation
+try {
+    peripheral.observeValues(char).collect { ... }
+} catch (e: Exception) {
+    // CancellationException extends Exception in Kotlin
+    // This catch block swallows it
+}
+
+// CORRECT
+try {
+    peripheral.observeValues(char).collect { ... }
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Exception) {
+    // Handle real errors
+}
+```
+
+## Observe stops emitting
+
+1. **Peripheral disconnected.** Check `peripheral.connectionState`.
+   Observations are scoped to the connection. Re-subscribe after
+   reconnecting.
+2. **CCCD was not written.** Verify the characteristic has `notify` or
+   `indicate` in its properties. kmp-ble writes the CCCD automatically
+   on `observe()`.
+3. **Android: background service killed.** Android may kill background
+   processes. Use a foreground service for long-running observations.
+
+## Build error: `Unresolved reference: KmpBle`
+
+The kmp-ble framework is not linked. For iOS via SPM, ensure the package
+is added in Xcode and `KmpBle` is listed under "Frameworks, Libraries, and
+Embedded Content."
+
+## Build error: `minSdk 33 expected`
+
+kmp-ble requires Android API 33+. Set `minSdk = 33` in your module's
+`build.gradle.kts`:
+
+```kotlin
+android {
+    defaultConfig {
+        minSdk = 33
+    }
+}
+```
+
+## `IllegalStateException: BT Adapter not present`
+
+The device does not have Bluetooth hardware. Check
+`BluetoothAdapter().state` for `BluetoothAdapterState.Unsupported` before
+attempting BLE operations.


### PR DESCRIPTION
Closes #256

- docs/platform-setup-ios.md: Info.plist keys, background modes, entitlements, SPM setup
- docs/platform-setup-android.md: manifest permissions by API level, runtime permission flow, location requirements
- docs/troubleshooting.md: top 10+ common BLE errors with platform-specific fixes
- README: new Documentation section linking all guides