### PR TITLE
fix(cache): replace Mutex with single-threaded dispatcher in AndroidGattCache

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCache.kt
@@ -2,8 +2,8 @@ package com.atruedev.kmpble.gatt.cache
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.gatt.DiscoveredService
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.withContext
 
 /**
  * In-memory LRU cache for discovered GATT services.
@@ -11,13 +11,14 @@ import kotlinx.coroutines.sync.withLock
  * Uses [LinkedHashMap] with access-order eviction. When the cache exceeds
  * [maxSize], the least-recently-accessed entry is removed.
  *
- * Thread-safe: all public methods use [Mutex] for structured concurrency
- * instead of [synchronized].
+ * Thread-safe: all public methods are confined to a single-threaded
+ * [newSingleThreadContext] dispatcher, serializing access to the
+ * non-thread-safe [LinkedHashMap] without locks or atomics.
  */
 internal class AndroidGattCache(
     private val maxSize: Int,
 ) : GattCache {
-    private val mutex = Mutex()
+    private val cacheContext = newSingleThreadContext("gatt-cache")
 
     @Suppress("UNCHECKED_CAST")
     private val cache =
@@ -31,21 +32,22 @@ internal class AndroidGattCache(
             ): Boolean = size > maxSize
         }
 
-    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = mutex.withLock { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? =
+        withContext(cacheContext) { cache[identifier] }
 
     override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
-        mutex.withLock { cache[identifier] = services }
+        withContext(cacheContext) { cache[identifier] = services }
     }
 
     override suspend fun invalidate(identifier: Identifier) {
-        mutex.withLock { cache.remove(identifier) }
+        withContext(cacheContext) { cache.remove(identifier) }
     }
 
     override suspend fun clear() {
-        mutex.withLock { cache.clear() }
+        withContext(cacheContext) { cache.clear() }
     }
 }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/cache/GattCache.kt
@@ -40,8 +40,9 @@ import com.atruedev.kmpble.gatt.DiscoveredService
  *
  * Thread-safe across coroutines on all platforms.
  *
- * Implementation uses [kotlinx.coroutines.sync.Mutex] for structured
- * concurrency on Android, instead of [synchronized].
+ * The Android implementation confines all cache operations to a
+ * single-threaded dispatcher, serializing access to the non-thread-safe
+ * [LinkedHashMap] without locks.
  */
 public interface GattCache {
     /**

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/gatt/cache/AndroidGattCacheTest.kt
@@ -5,8 +5,6 @@ import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -130,13 +128,12 @@ public class AndroidGattCacheTest {
 /**
  * Standalone LRU [GattCache] for testing -- mirrors [AndroidGattCache].
  *
- * Uses [Mutex] for structured concurrency instead of [synchronized].
+ * Thread-safety is not needed in tests since all test coroutines run
+ * on the single-threaded [runBlocking] dispatcher.
  */
 internal class LruGattCache(
     private val maxSize: Int,
 ) : GattCache {
-    private val mutex = Mutex()
-
     @Suppress("UNCHECKED_CAST")
     private val cache =
         object : LinkedHashMap<Identifier, List<DiscoveredService>>(
@@ -149,20 +146,20 @@ internal class LruGattCache(
             ): Boolean = size > maxSize
         }
 
-    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = mutex.withLock { cache[identifier] }
+    override suspend fun get(identifier: Identifier): List<DiscoveredService>? = cache[identifier]
 
     override suspend fun put(
         identifier: Identifier,
         services: List<DiscoveredService>,
     ) {
-        mutex.withLock { cache[identifier] = services }
+        cache[identifier] = services
     }
 
     override suspend fun invalidate(identifier: Identifier) {
-        mutex.withLock { cache.remove(identifier) }
+        cache.remove(identifier)
     }
 
     override suspend fun clear() {
-        mutex.withLock { cache.clear() }
+        cache.clear()
     }
 }


### PR DESCRIPTION
## Summary

Removes the banned `kotlinx.coroutines.sync.Mutex` from `AndroidGattCache` and replaces it with a single-threaded dispatcher (`newSingleThreadContext`), complying with the project concurrency policy.

## Changes

- **AndroidGattCache.kt**: Replace `Mutex` with `newSingleThreadContext("gatt-cache")` + `withContext` to serialize access to the `LinkedHashMap`
- **GattCache.kt**: Update KDoc to describe dispatcher-based serialization instead of Mutex
- **AndroidGattCacheTest.kt**: Remove `Mutex` from `LruGattCache` test double (single-threaded `runBlocking` already provides serialization)

## Why

The project concurrency policy explicitly bans `Mutex`, `synchronized`, `@Volatile`, `GlobalScope`, and `ReentrantLock`. `Mutex` introduces unnecessary suspension points for in-memory `LinkedHashMap` operations and can leave state inconsistent if a coroutine is cancelled while holding the lock.

## Test Plan

- [x] JVM tests pass (including all 6 `AndroidGattCacheTest` cases)
- [x] ktlint format check passes
- [x] Compiles on JVM and iOS Simulator targets

Closes #314