### PR TITLE
fix(concurrency): replace @Volatile with kotlinx-atomicfu in commonMain

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -1,12 +1,12 @@
 package com.atruedev.kmpble.gatt.internal
 
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
-import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,7 +19,8 @@ import kotlin.time.Duration.Companion.seconds
  *
  * [start], [drain], and [close] are confined to the owning peripheral's
  * serialized dispatcher (`limitedParallelism(1)`).
- * [enqueue] reads the `@Volatile` [state] snapshot from any coroutine context.
+ * [enqueue] reads the [kotlinx.atomicfu.atomic] [state] snapshot from any
+ * coroutine context.
  */
 internal class GattOperationQueue(
     private val scope: CoroutineScope,
@@ -35,16 +36,17 @@ internal class GattOperationQueue(
         val operationTimeout: Duration,
     )
 
-    @Volatile
-    private var state =
-        QueueState(
-            channel = Channel(Channel.UNLIMITED),
-            drainJob = null,
-            operationTimeout = DEFAULT_OPERATION_TIMEOUT,
+    private val state =
+        atomic(
+            QueueState(
+                channel = Channel(Channel.UNLIMITED),
+                drainJob = null,
+                operationTimeout = DEFAULT_OPERATION_TIMEOUT,
+            ),
         )
 
     fun start(timeout: Duration? = null) {
-        val prev = state
+        val prev = state.value
         drainChannel(prev.channel)
         prev.drainJob?.cancel()
 
@@ -55,7 +57,7 @@ internal class GattOperationQueue(
                     entry.action()
                 }
             }
-        state =
+        state.value =
             QueueState(
                 channel = ch,
                 drainJob = job,
@@ -64,7 +66,7 @@ internal class GattOperationQueue(
     }
 
     suspend fun <T> enqueue(
-        timeout: Duration = state.operationTimeout,
+        timeout: Duration = state.value.operationTimeout,
         block: suspend () -> T,
     ): T {
         val deferred = CompletableDeferred<T>()
@@ -80,7 +82,12 @@ internal class GattOperationQueue(
                 cancel = { deferred.completeExceptionally(it) },
             )
 
-        if (!state.channel.trySend(entry).isSuccess) throw NotConnectedException()
+        if (!state.value.channel
+                .trySend(entry)
+                .isSuccess
+        ) {
+            throw NotConnectedException()
+        }
 
         return withTimeout(timeout) {
             deferred.await()
@@ -88,11 +95,11 @@ internal class GattOperationQueue(
     }
 
     fun drain() {
-        drainChannel(state.channel)
+        drainChannel(state.value.channel)
     }
 
     fun close() {
-        val s = state
+        val s = state.value
         drainChannel(s.channel)
         s.drainJob?.cancel()
     }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationEmitter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationEmitter.kt
@@ -54,7 +54,7 @@ internal class ObservationEmitter(
     /**
      * Emit a value to observation flow. Non-suspend version for use from GATT callbacks.
      *
-     * Thread-safety: Reads from an immutable @Volatile snapshot from the registry,
+     * Thread-safety: Reads from an immutable atomic snapshot from the registry,
      * so no serialization needed. tryEmit on MutableSharedFlow is thread-safe.
      * Worst case during concurrent subscribe/unsubscribe is a missed emit
      * (acceptable for transient race windows).
@@ -72,7 +72,7 @@ internal class ObservationEmitter(
      * Called on disconnect. Emits [ObservationEvent.Disconnected] to all active observations.
      * Does NOT clear observations - they persist for reconnection.
      *
-     * Thread-safety: Reads from an immutable @Volatile snapshot from the registry.
+     * Thread-safety: Reads from an immutable atomic snapshot from the registry.
      */
     fun onDisconnect() {
         for (tracked in registry.snapshot().values) {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationRegistry.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.gatt.internal
 
 import com.atruedev.kmpble.gatt.BackpressureStrategy
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow
@@ -10,7 +11,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.withContext
-import kotlin.concurrent.Volatile
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -64,8 +64,8 @@ internal data class TrackedObservation(
  *
  * Serialization: Mutable state is accessed exclusively via [serialDispatcher]
  * (`limitedParallelism(1)`), consistent with the rest of the codebase.
- * The @Volatile [observationsSnapshot] provides lock-free reads from non-suspend
- * contexts (platform callback threads).
+ * [observationsSnapshot] uses [kotlinx.atomicfu.atomic] for lock-free reads
+ * from non-suspend contexts (platform callback threads).
  */
 @OptIn(ExperimentalUuidApi::class)
 internal class ObservationRegistry(
@@ -81,21 +81,21 @@ internal class ObservationRegistry(
     /**
      * Snapshot of observations for lock-free reads from non-suspend contexts.
      * Updated on [serialDispatcher] whenever [observations] changes. Reads are safe
-     * from any thread because the reference is @Volatile and the Map is immutable.
+     * from any thread because the reference is held in a [kotlinx.atomicfu.atomic]
+     * and the Map is immutable.
      */
-    @Volatile
-    private var observationsSnapshot = mapOf<ObservationKey, TrackedObservation>()
+    private val observationsSnapshot = atomic(mapOf<ObservationKey, TrackedObservation>())
 
     /** Optional callback invoked when the set of active observations changes. */
     internal var onObservationsChanged: ((Set<PersistedObservation>) -> Unit)? = null
 
     private fun updateSnapshot() {
-        observationsSnapshot = observations.toMap()
+        observationsSnapshot.value = observations.toMap()
     }
 
     private fun notifyObservationsChanged() {
         onObservationsChanged?.invoke(
-            observationsSnapshot.values
+            observationsSnapshot.value.values
                 .map { tracked ->
                     PersistedObservation(tracked.key, tracked.backpressure)
                 }.toSet(),
@@ -200,7 +200,7 @@ internal class ObservationRegistry(
     }
 
     /** Provides read-only access to the immutable snapshot for non-suspend contexts. */
-    fun snapshot(): Map<ObservationKey, TrackedObservation> = observationsSnapshot
+    fun snapshot(): Map<ObservationKey, TrackedObservation> = observationsSnapshot.value
 
     /** Serial dispatcher for mutable state access. */
     internal val dispatcher: CoroutineDispatcher = serialDispatcher

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
@@ -10,6 +10,7 @@ import com.atruedev.kmpble.gatt.internal.GattOperationQueue
 import com.atruedev.kmpble.logging.BleLogConfig
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +21,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
-import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.time.TimeSource
 
@@ -47,8 +47,7 @@ internal class PeripheralContext(
 
     val gattQueue = GattOperationQueue(scope)
 
-    @Volatile
-    private var closed = false
+    private val closed = atomic(false)
 
     /**
      * Tracks when the current state was entered, for connection timeline logging.
@@ -65,7 +64,7 @@ internal class PeripheralContext(
      */
     suspend fun processEvent(event: ConnectionEvent): State =
         withContext(dispatcher) {
-            check(!closed) { "PeripheralContext is closed" }
+            check(!closed.value) { "PeripheralContext is closed" }
 
             val previousState = _state.value
             val result = StateMachine.transition(previousState, event)
@@ -117,8 +116,8 @@ internal class PeripheralContext(
 
     /** Terminal - non-suspend for ViewModel.onCleared() / deinit. Idempotent. */
     fun close() {
-        if (closed) return
-        closed = true
+        if (closed.value) return
+        closed.value = true
         gattQueue.close()
         scope.cancel()
     }


### PR DESCRIPTION
## Summary

Replaces all `@Volatile` annotations in `commonMain` with `kotlinx-atomicfu` atomic references, complying with the project concurrency policy which bans `@Volatile` outside of platform boundary code.

## Changes

| File | Change |
|------|--------|
| `GattOperationQueue.kt` | `@Volatile var state` -> `val state = atomic(QueueState(...))`; all reads/writes use `.value` |
| `ObservationRegistry.kt` | `@Volatile var observationsSnapshot` -> `val observationsSnapshot = atomic(mapOf(...))`; all accessors use `.value` |
| `PeripheralContext.kt` | `@Volatile var closed` -> `val closed = atomic(false)`; reads `.value` |
| `ObservationEmitter.kt` | KDoc only: replace `@Volatile` references with `atomic` |

## Why not platform sources?

Per the project concurrency policy (`kmp-library-development` skill), `@Volatile` at platform boundaries is explicitly acceptable when bridging between Android binder threads / iOS CoreBluetooth delegate callbacks and KMP coroutine code. The iOS and Android `@Volatile` annotations are platform boundary fields connecting non-coroutine platform threads to coroutine dispatchers and are left unchanged.

## Test Plan

- [x] ktlint format check passes
- [x] Compiles on JVM and iOS Simulator targets
- [x] Pre-existing `PeripheralRegistryLincheckTest` failures unchanged (4 tests, all pre-existing)

Closes #342