### PR TITLE
fix(test): use buildPeripheral factory in Gatt notification test

### DIFF
--- a/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/conformance/BleConformanceTest.kt
@@ -1,8 +1,10 @@
 package com.atruedev.kmpble.conformance
 
+import com.atruedev.kmpble.testing.FakePeripheral
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
 import com.atruedev.kmpble.testing.FakeScanner
 import com.atruedev.kmpble.testing.FakeScannerBuilder
+import kotlinx.coroutines.CoroutineDispatcher
 
 /**
  * Shared conformance test base for core BLE flows.
@@ -35,7 +37,22 @@ public abstract class BleConformanceTest {
     /** Factory for scanner instances. Override to inject platform behavior. */
     protected open fun buildScanner(block: FakeScannerBuilder.() -> Unit = {}): FakeScanner = FakeScanner(block)
 
-    /** Factory for peripheral builder. Override to inject platform behavior. */
-    protected open fun buildPeripheral(block: FakePeripheralBuilder.() -> Unit = {}) =
-        FakePeripheralBuilder().apply(block).build()
+    /**
+     * Factory for peripheral instances. Override to inject platform behavior.
+     *
+     * @param observationDispatcher Optional dispatcher for observation flows.
+     *   Pass a [kotlinx.coroutines.test.TestDispatcher] when tests need to
+     *   control observation delivery timing with [kotlinx.coroutines.test.runCurrent].
+     * @param block Builder DSL for configuring services and characteristics.
+     */
+    protected open fun buildPeripheral(
+        observationDispatcher: CoroutineDispatcher? = null,
+        block: FakePeripheralBuilder.() -> Unit = {},
+    ): FakePeripheral {
+        val builder = FakePeripheralBuilder()
+        if (observationDispatcher != null) {
+            builder.observationDispatcher(observationDispatcher)
+        }
+        return builder.apply(block).build()
+    }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/conformance/GattConformanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/conformance/GattConformanceTest.kt
@@ -5,7 +5,6 @@ import com.atruedev.kmpble.gatt.BackpressureStrategy
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.scanner.uuidFrom
-import com.atruedev.kmpble.testing.FakePeripheralBuilder
 import com.atruedev.kmpble.testing.emitObservationValue
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -109,13 +108,11 @@ public abstract class GattConformanceTest : BleConformanceTest() {
         val dispatcher = StandardTestDispatcher(scheduler)
         runTest(scheduler) {
             val peripheral =
-                FakePeripheralBuilder()
-                    .observationDispatcher(dispatcher)
-                    .apply {
-                        service("180d") {
-                            characteristic("2a37") { properties(notify = true) }
-                        }
-                    }.build()
+                buildPeripheral(observationDispatcher = dispatcher) {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
 
             peripheral.connect(ConnectionOptions())
             scheduler.runCurrent()


### PR DESCRIPTION
## Summary

Fixes the GATT notification observation test in `GattConformanceTest` to use the `buildPeripheral()` factory method instead of constructing `FakePeripheralBuilder` directly, restoring the extension point for platform subclasses.

## Changes

- **BleConformanceTest.kt**: Add optional `observationDispatcher` parameter to `buildPeripheral()` factory, with KDoc explaining its use for test dispatchers
- **GattConformanceTest.kt**: Replace direct `FakePeripheralBuilder()` usage with `buildPeripheral(observationDispatcher = dispatcher) { ... }`

## Why

Every other test in the conformance suite uses `buildPeripheral { ... }`. The notification test was the only one bypassing the factory, which meant platform subclasses (iOS/nativeTest) could not inject platform-specific behavior via overriding `buildPeripheral()`.

## Test Plan

- [x] ktlint format check passes
- [x] JVM compilation passes
- [x] All GattConformanceTest tests pass on JVM

Closes #341