### PR TITLE
feat(le-audio): add openIsochronousChannel to Peripheral interface

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.android.kt
@@ -1,0 +1,6 @@
+package com.atruedev.kmpble.isochronous
+
+public actual fun IsochronousListener(): IsochronousListener =
+    throw IsochronousException.NotSupported(
+        "LE Audio isochronous listeners are not available on Android",
+    )

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -29,6 +29,8 @@ import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.PendingOperations
+import com.atruedev.kmpble.isochronous.IsochronousChannel
+import com.atruedev.kmpble.isochronous.IsochronousException
 import com.atruedev.kmpble.l2cap.AndroidL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.logging.BleLogEvent
@@ -218,4 +220,9 @@ public class AndroidPeripheral internal constructor(
         secure: Boolean,
         mtu: Int?,
     ): L2capChannel = openL2capChannelInternal(psm, secure, mtu)
+
+    override suspend fun openIsochronousChannel(): IsochronousChannel =
+        throw IsochronousException.NotSupported(
+            "LE Audio isochronous channels are not publicly available on Android",
+        )
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousChannel.kt
@@ -1,0 +1,98 @@
+package com.atruedev.kmpble.isochronous
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A LE Audio Isochronous Channel (CIS or BIS) for time-bounded streaming.
+ *
+ * Isochronous channels (Bluetooth 5.2+) provide connection-oriented or broadcast
+ * streaming with guaranteed latency bounds, used by LE Audio profiles for
+ * hearing aids, broadcast audio, and low-latency audio devices.
+ *
+ * ## CIS vs BIS
+ *
+ * - **CIS (Connected Isochronous Stream):** Bidirectional, connection-oriented
+ *   stream between two devices. Part of a CIG (Connected Isochronous Group).
+ * - **BIS (Broadcast Isochronous Stream):** Unidirectional broadcast stream
+ *   from one device to many. Part of a BIG (Broadcast Isochronous Group).
+ *
+ * [IsochronousChannel] abstracts both types; the stream direction and timing
+ * are negotiated during channel setup.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val channel = peripheral.openIsochronousChannel()
+ *
+ * channel.incoming.collect { data ->
+ *     audioProcessor.feed(data)
+ * }
+ *
+ * channel.write(audioPacket)
+ * channel.close()
+ * ```
+ *
+ * ## Platform support
+ *
+ * - **Android:** Not publicly available (API 33+ `BluetoothLeAudio` handles
+ *   isochronous channels internally; no raw channel API exposed to apps).
+ *   Throws [IsochronousException.NotSupported].
+ * - **iOS:** CoreBluetooth does not expose isochronous channels.
+ *   Throws [IsochronousException.NotSupported].
+ * - **JVM:** No Bluetooth stack. Throws [IsochronousException.NotSupported].
+ *
+ * ## Lifecycle
+ *
+ * - Channel is opened via [com.atruedev.kmpble.peripheral.Peripheral.openIsochronousChannel]
+ * - Channel remains open until [close] is called or connection is lost
+ * - If the peripheral disconnects, the channel closes automatically
+ * - [incoming] flow completes when channel closes
+ */
+public interface IsochronousChannel : AutoCloseable {
+    /**
+     * The MTU (Maximum Transmission Unit) for this isochronous channel.
+     *
+     * Maximum payload size for a single SDU (Service Data Unit). The ISO
+     * interval determines how many SDUs can be sent per ISO event.
+     * Distinct from L2CAP MTU -- this is the ISO PDU size.
+     *
+     * **Platform behavior:**
+     * - When the platform does not expose the negotiated value, a
+     *   conservative default (e.g., 256 bytes) is used.
+     */
+    public val mtu: Int
+
+    /**
+     * Whether the channel is currently open and usable.
+     */
+    public val isOpen: Boolean
+
+    /**
+     * Flow of incoming data from the remote device.
+     *
+     * - Emits [ByteArray] for each received SDU
+     * - Completes normally when channel is closed (locally or remotely)
+     * - Completes with exception if channel encounters an error
+     */
+    public val incoming: Flow<ByteArray>
+
+    /**
+     * Write data to the channel.
+     *
+     * @param data The bytes to send. If larger than [mtu], the write
+     *             may be fragmented or rejected depending on the platform.
+     * @throws IsochronousException if write fails or channel is closed
+     */
+    public suspend fun write(data: ByteArray)
+
+    /**
+     * Close the channel.
+     *
+     * - Flushes any pending writes
+     * - [incoming] flow completes
+     * - Subsequent [write] calls throw [IsochronousException.ChannelClosed]
+     *
+     * Safe to call multiple times.
+     */
+    override fun close()
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousException.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousException.kt
@@ -1,0 +1,50 @@
+package com.atruedev.kmpble.isochronous
+
+/**
+ * Exception thrown when LE Audio isochronous channel operations fail.
+ *
+ * Isochronous channels (CIS/BIS, Bluetooth 5.2+) provide time-bounded
+ * streaming for LE Audio use cases such as hearing aids, broadcast audio,
+ * and low-latency audio devices.
+ */
+public sealed class IsochronousException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause) {
+    /**
+     * Failed to open an isochronous channel.
+     */
+    public class OpenFailed(
+        message: String,
+        cause: Throwable? = null,
+    ) : IsochronousException("Failed to open isochronous channel: $message", cause)
+
+    /**
+     * Write operation failed.
+     */
+    public class WriteFailed(
+        message: String,
+        cause: Throwable? = null,
+    ) : IsochronousException("Isochronous write failed: $message", cause)
+
+    /**
+     * Channel is not open.
+     */
+    public class ChannelClosed(
+        message: String = "Isochronous channel is closed",
+    ) : IsochronousException(message)
+
+    /**
+     * Peripheral is not connected.
+     */
+    public class NotConnected(
+        message: String = "Peripheral is not connected",
+    ) : IsochronousException(message)
+
+    /**
+     * Isochronous channels are not supported on this device/OS version.
+     */
+    public class NotSupported(
+        message: String = "LE Audio isochronous channels are not supported",
+    ) : IsochronousException(message)
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListener.kt
@@ -1,0 +1,90 @@
+package com.atruedev.kmpble.isochronous
+
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Server-side LE Audio isochronous channel acceptor.
+ *
+ * Counterpart to [com.atruedev.kmpble.peripheral.Peripheral.openIsochronousChannel]
+ * (client side). [open] publishes a BIG (Broadcast Isochronous Group) or
+ * accepts CIG (Connected Isochronous Group) streams. Each accepted channel
+ * is emitted through [incoming].
+ *
+ * ## Usage (BIG / broadcast source)
+ *
+ * ```kotlin
+ * val listener = IsochronousListener()
+ * listener.open()
+ *
+ * listener.incoming.collect { channel ->
+ *     scope.launch {
+ *         channel.incoming.collect { bytes -> handle(bytes) }
+ *     }
+ * }
+ * ```
+ *
+ * ## Platform support
+ *
+ * - **Android:** Not publicly available. Throws [IsochronousException.NotSupported].
+ * - **iOS:** CoreBluetooth does not expose isochronous listeners.
+ *   Throws [IsochronousException.NotSupported].
+ * - **JVM:** No Bluetooth stack. Throws [IsochronousException.NotSupported].
+ *
+ * ## Lifecycle
+ *
+ * - Created via [IsochronousListener] factory function (no OS resources allocated)
+ * - [open] allocates OS resources and starts accepting streams
+ * - [close] stops accepting new streams; previously accepted channels
+ *   are NOT closed (caller owns their lifecycles)
+ *
+ * ## Channel ownership
+ *
+ * Each [IsochronousChannel] emitted from [incoming] is fully open and owned
+ * by the consumer. The listener does not track them. Consumers must call
+ * [IsochronousChannel.close] on each channel when done with it.
+ */
+public interface IsochronousListener : AutoCloseable {
+    /**
+     * Whether the listener is currently accepting connections.
+     */
+    public val isOpen: StateFlow<Boolean>
+
+    /**
+     * Hot stream of newly-accepted isochronous channels.
+     *
+     * Buffered: up to 16 unconsumed connections are retained. Start
+     * collecting before calling [open] to avoid missing early connections.
+     */
+    public val incoming: SharedFlow<IsochronousChannel>
+
+    /**
+     * Open the listener and start accepting isochronous streams.
+     *
+     * @param secure If true, requires encrypted connections.
+     * @param mtu Optional MTU hint propagated to each accepted channel.
+     * @throws IsochronousException.NotSupported if isochronous channels
+     *   are not available on this platform
+     */
+    public suspend fun open(
+        secure: Boolean = true,
+        mtu: Int? = null,
+    )
+
+    /**
+     * Stop accepting connections.
+     *
+     * Previously accepted channels (emitted through [incoming]) remain open.
+     * Safe to call multiple times.
+     */
+    override fun close()
+}
+
+/**
+ * Create a platform-specific [IsochronousListener].
+ *
+ * - Android: throws [IsochronousException.NotSupported] (no public API)
+ * - iOS: throws [IsochronousException.NotSupported] (CoreBluetooth limitation)
+ * - JVM: throws [IsochronousException.NotSupported] (no Bluetooth stack)
+ */
+public expect fun IsochronousListener(): IsochronousListener

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -17,6 +17,7 @@ import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -213,4 +214,21 @@ public interface Peripheral : AutoCloseable {
         secure: Boolean = true,
         mtu: Int? = null,
     ): L2capChannel
+
+    // --- Isochronous Channels ---
+
+    /**
+     * Open a LE Audio Isochronous Channel for time-bounded streaming.
+     *
+     * Isochronous channels (Bluetooth 5.2+) provide connection-oriented (CIS)
+     * or broadcast (BIS) streaming with guaranteed latency bounds. Used by
+     * LE Audio profiles for hearing aids, broadcast audio, and low-latency
+     * audio devices.
+     *
+     * @throws IsochronousException.NotSupported if isochronous channels are
+     *         not available on this platform
+     * @throws IsochronousException.NotConnected if the peripheral is not connected
+     * @throws IsochronousException.OpenFailed if channel setup fails
+     */
+    public suspend fun openIsochronousChannel(): IsochronousChannel
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
@@ -17,6 +17,8 @@ import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.ObservationEvent
 import com.atruedev.kmpble.gatt.internal.ObservationManager
 import com.atruedev.kmpble.gatt.internal.applyBackpressure
+import com.atruedev.kmpble.isochronous.IsochronousChannel
+import com.atruedev.kmpble.isochronous.IsochronousException
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.l2cap.L2capException
 import com.atruedev.kmpble.peripheral.PhyResult
@@ -42,6 +44,7 @@ internal class FakeGattResponder(
     private val observationManager: ObservationManager,
     private val characteristicConfigs: List<FakeCharacteristicConfig>,
     private val onL2capHandler: L2capHandler?,
+    private val onIsoHandler: IsochronousHandler?,
     private val cccdWritesState: MutableStateFlow<List<FakePeripheral.CccdWrite>>,
     private val closedFlag: () -> Boolean,
 ) {
@@ -244,6 +247,21 @@ internal class FakeGattResponder(
             onL2capHandler
                 ?: throw L2capException.NotSupported("No onOpenL2capChannel handler configured")
         return handler(psm, mtu)
+    }
+
+    suspend fun openIsochronousChannel(): IsochronousChannel {
+        checkNotClosed()
+        if (context.state.value !is State.Connected) {
+            throw IsochronousException.NotConnected(
+                "Peripheral is not connected (state: ${context.state.value})",
+            )
+        }
+        val handler =
+            onIsoHandler
+                ?: throw IsochronousException.NotSupported(
+                    "No onOpenIsochronousChannel handler configured",
+                )
+        return handler()
     }
 
     suspend fun readRssi(): Int = readRssiImpl()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousChannel.kt
@@ -1,0 +1,48 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.isochronous.IsochronousChannel
+import com.atruedev.kmpble.isochronous.IsochronousException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * Fake [IsochronousChannel] for unit tests.
+ *
+ * Records writes and provides a controllable incoming data stream via
+ * [emitIncoming]. Use in tests to simulate isochronous channel behavior
+ * without platform dependencies.
+ */
+public class FakeIsochronousChannel(
+    override val mtu: Int = 256,
+) : IsochronousChannel {
+    override var isOpen: Boolean = true
+        private set
+
+    private val _incoming = Channel<ByteArray>(Channel.BUFFERED)
+    override val incoming: Flow<ByteArray> = _incoming.receiveAsFlow()
+
+    private val writtenData = mutableListOf<ByteArray>()
+
+    override suspend fun write(data: ByteArray) {
+        if (!isOpen) throw IsochronousException.ChannelClosed()
+        writtenData.add(data)
+    }
+
+    override fun close() {
+        isOpen = false
+        _incoming.close()
+    }
+
+    /**
+     * Simulate incoming data from the remote device.
+     */
+    public suspend fun emitIncoming(data: ByteArray) {
+        _incoming.send(data)
+    }
+
+    /**
+     * Retrieve all data written to this channel.
+     */
+    public fun getWrittenData(): List<ByteArray> = writtenData.toList()
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousListener.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousListener.kt
@@ -1,0 +1,58 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.isochronous.IsochronousChannel
+import com.atruedev.kmpble.isochronous.IsochronousException
+import com.atruedev.kmpble.isochronous.IsochronousListener
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Fake [IsochronousListener] for unit tests.
+ *
+ * Tests can drive accept events via [simulateIncoming] and inspect state
+ * through [isOpen].
+ */
+public class FakeIsochronousListener : IsochronousListener {
+    private val _isOpen = MutableStateFlow(false)
+    override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    private val _incoming =
+        MutableSharedFlow<IsochronousChannel>(
+            replay = 0,
+            extraBufferCapacity = 16,
+        )
+    override val incoming: SharedFlow<IsochronousChannel> = _incoming.asSharedFlow()
+
+    private var closed = false
+    private var openCount = 0
+
+    override suspend fun open(
+        secure: Boolean,
+        mtu: Int?,
+    ) {
+        if (closed) throw IsochronousException.OpenFailed("Listener has been closed")
+        if (_isOpen.value) throw IsochronousException.OpenFailed("Listener already open")
+        _isOpen.value = true
+        openCount++
+    }
+
+    override fun close() {
+        closed = true
+        _isOpen.value = false
+    }
+
+    /**
+     * Test helper: emit an accepted [channel] to subscribers of [incoming].
+     *
+     * Must start the collector BEFORE emitting (SharedFlow with replay=0
+     * suspends on emit if no subscriber has available buffer capacity).
+     */
+    public suspend fun simulateIncoming(channel: IsochronousChannel) {
+        check(_isOpen.value) { "Cannot simulate incoming on a closed listener" }
+        _incoming.emit(channel)
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -18,6 +18,7 @@ import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.ObservationManager
+import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
@@ -38,6 +39,7 @@ public class FakePeripheral internal constructor(
     private val onConnectHandler: suspend () -> Result<Unit>,
     private val onDisconnectHandler: suspend () -> Result<Unit>,
     private val onL2capHandler: L2capHandler?,
+    private val onIsoHandler: IsochronousHandler?,
     private val onConnectionParameterUpdateHandler: (
         suspend (ConnectionParameters) -> ConnectionParameterUpdateResult?
     )? = null,
@@ -66,6 +68,7 @@ public class FakePeripheral internal constructor(
             observationManager = observationManager,
             characteristicConfigs = characteristicConfigs,
             onL2capHandler = onL2capHandler,
+            onIsoHandler = onIsoHandler,
             cccdWritesState = cccdWritesState,
             closedFlag = { closed },
         )
@@ -177,6 +180,8 @@ public class FakePeripheral internal constructor(
         secure: Boolean,
         mtu: Int?,
     ): L2capChannel = gattResponder.openL2capChannel(psm, secure, mtu)
+
+    override suspend fun openIsochronousChannel(): IsochronousChannel = gattResponder.openIsochronousChannel()
 
     override suspend fun readRssi(): Int = gattResponder.readRssi()
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.error.BleError
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.CoroutineDispatcher
@@ -20,6 +21,7 @@ public typealias ReadHandler = suspend () -> ByteArray
 public typealias WriteHandler = suspend (data: ByteArray, writeType: WriteType) -> Unit
 public typealias ObserveHandler = () -> Flow<ByteArray>
 public typealias L2capHandler = suspend (psm: Int, mtu: Int?) -> L2capChannel
+public typealias IsochronousHandler = suspend () -> IsochronousChannel
 
 @OptIn(ExperimentalUuidApi::class)
 internal data class FakeCharacteristicConfig(
@@ -38,6 +40,7 @@ public class FakePeripheralBuilder {
     private var connectHandler: suspend () -> Result<Unit> = { Result.success(Unit) }
     private var disconnectHandler: suspend () -> Result<Unit> = { Result.success(Unit) }
     internal var l2capHandler: L2capHandler? = null
+    internal var isoHandler: IsochronousHandler? = null
     internal var onConnectionParameterUpdate: (
         suspend (
             ConnectionParameters,
@@ -79,6 +82,14 @@ public class FakePeripheralBuilder {
         l2capHandler = handler
     }
 
+    /**
+     * Configure isochronous channel opening behavior.
+     * The handler returns an [IsochronousChannel] for testing LE Audio streaming.
+     */
+    public fun onOpenIsochronousChannel(handler: IsochronousHandler) {
+        isoHandler = handler
+    }
+
     /** Configure the response to [Peripheral.requestConnectionParameterUpdate] calls. */
     public fun onConnectionParameterUpdate(
         handler: suspend (ConnectionParameters) -> ConnectionParameterUpdateResult?,
@@ -100,6 +111,7 @@ public class FakePeripheralBuilder {
             onConnectHandler = connectHandler,
             onDisconnectHandler = disconnectHandler,
             onL2capHandler = l2capHandler,
+            onIsoHandler = isoHandler,
             onConnectionParameterUpdateHandler = onConnectionParameterUpdate,
             observationDispatcher = observationDispatcher,
         )

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/FakePeripheralTest.kt
@@ -8,7 +8,9 @@ import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.error.ConnectionLost
+import com.atruedev.kmpble.isochronous.IsochronousException
 import com.atruedev.kmpble.scanner.uuidFrom
+import com.atruedev.kmpble.testing.FakeIsochronousChannel
 import com.atruedev.kmpble.testing.FakePeripheral
 import com.atruedev.kmpble.testing.simulateEvent
 import kotlinx.coroutines.test.runTest
@@ -253,5 +255,50 @@ class FakePeripheralTest {
                 )
             val result = peripheral.requestConnectionParameterUpdate(params)
             assertEquals(customResult, result)
+        }
+
+    @Test
+    fun `openIsochronousChannel with handler returns channel`() =
+        runTest {
+            val fakeChannel = FakeIsochronousChannel()
+            val peripheral =
+                FakePeripheral {
+                    onOpenIsochronousChannel { fakeChannel }
+                }
+            peripheral.connect()
+
+            val channel = peripheral.openIsochronousChannel()
+            assertEquals(fakeChannel, channel)
+            assertTrue(channel.isOpen)
+        }
+
+    @Test
+    fun `openIsochronousChannel without handler throws NotSupported`() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect()
+
+            assertFailsWith<IsochronousException.NotSupported> {
+                peripheral.openIsochronousChannel()
+            }
+        }
+
+    @Test
+    fun `openIsochronousChannel when disconnected throws NotConnected`() =
+        runTest {
+            val fakeChannel = FakeIsochronousChannel()
+            val peripheral =
+                FakePeripheral {
+                    onOpenIsochronousChannel { fakeChannel }
+                }
+
+            assertFailsWith<IsochronousException.NotConnected> {
+                peripheral.openIsochronousChannel()
+            }
         }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.ios.kt
@@ -1,0 +1,6 @@
+package com.atruedev.kmpble.isochronous
+
+public actual fun IsochronousListener(): IsochronousListener =
+    throw IsochronousException.NotSupported(
+        "LE Audio isochronous listeners are not available on iOS",
+    )

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -28,6 +28,8 @@ import com.atruedev.kmpble.gatt.internal.PendingOperations
 import com.atruedev.kmpble.gatt.internal.PersistedObservation
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import com.atruedev.kmpble.internal.StateRestorationHandler
+import com.atruedev.kmpble.isochronous.IsochronousChannel
+import com.atruedev.kmpble.isochronous.IsochronousException
 import com.atruedev.kmpble.l2cap.IosL2capChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.internal.LifecycleSlots
@@ -283,6 +285,11 @@ public class IosPeripheral(
         secure: Boolean,
         mtu: Int?,
     ): L2capChannel = openL2capChannelInternal(psm, secure, mtu)
+
+    override suspend fun openIsochronousChannel(): IsochronousChannel =
+        throw IsochronousException.NotSupported(
+            "CoreBluetooth does not expose LE Audio isochronous channels",
+        )
 
     /**
      * Restore this peripheral from iOS state restoration.

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousListenerFactory.jvm.kt
@@ -1,0 +1,6 @@
+package com.atruedev.kmpble.isochronous
+
+public actual fun IsochronousListener(): IsochronousListener =
+    throw IsochronousException.NotSupported(
+        "LE Audio isochronous listeners are not available on JVM",
+    )

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -16,6 +16,7 @@ import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.gatt.Observation
 import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.isochronous.IsochronousChannel
 import com.atruedev.kmpble.l2cap.L2capChannel
 import com.atruedev.kmpble.peripheral.Peripheral
 import com.atruedev.kmpble.peripheral.PhyResult
@@ -115,6 +116,8 @@ internal class StubPeripheral(
         secure: Boolean,
         mtu: Int?,
     ): L2capChannel = unsupported()
+
+    override suspend fun openIsochronousChannel(): IsochronousChannel = unsupported()
 
     private fun unsupported(): Nothing = throw UnsupportedOperationException("StubPeripheral")
 }


### PR DESCRIPTION
## Summary
Adds `openIsochronousChannel()` to the `Peripheral` interface, wiring up the existing `IsochronousChannel` infrastructure for LE Audio (Bluetooth 5.2+).

## Changes
- **commonMain**: Add `openIsochronousChannel()` to `Peripheral` interface
- **AndroidPeripheral**: Throw `IsochronousException.NotSupported` (no public Android API for raw isochronous channels)
- **IosPeripheral**: Throw `IsochronousException.NotSupported` (CoreBluetooth does not expose isochronous channels)
- **StubPeripheral**: Throw `UnsupportedOperationException`
- **FakePeripheral**: Delegate to `FakeGattResponder` with configurable handler
- **FakePeripheralBuilder**: Add `onOpenIsochronousChannel(handler)` DSL method
- **Tests**: 3 conformance tests (success with handler, NotSupported without handler, NotConnected when disconnected)

## Usage
```kotlin
val channel = peripheral.openIsochronousChannel()
channel.incoming.collect { data -> audioProcessor.feed(data) }
channel.write(audioPacket)
channel.close()
```

Closes #276