### PR TITLE
feat(connection): add ConnectionParamPreset enums for common BLE connection configurations

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionParamPreset.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionParamPreset.kt
@@ -1,0 +1,152 @@
+package com.atruedev.kmpble.connection
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Predefined BLE connection parameter configurations matching Nordic's
+ * nRF Connect SDK presets for common use cases.
+ *
+ * Each preset maps to well-tested [ConnectionParameters] values that balance
+ * latency, throughput, and power consumption for typical BLE applications.
+ * The peripheral proposes these to the central via
+ * [com.atruedev.kmpble.peripheral.Peripheral.requestConnectionParameterUpdate].
+ * The central may accept, reject, or negotiate different values.
+ *
+ * ### Preset guidance
+ *
+ * | Preset          | Interval    | Latency | Supervision | Use case                              |
+ * |-----------------|-------------|---------|-------------|---------------------------------------|
+ * | BALANCED        | 30-50 ms    | 0       | 4000 ms     | General-purpose, sensor data          |
+ * | HIGH_THROUGHPUT | 7.5-15 ms   | 0       | 4000 ms     | Firmware updates, L2CAP streaming     |
+ * | POWER_SAVING    | 1000-2000 ms| 2       | 6000 ms     | Environmental sensors, beacons        |
+ * | HID             | 11.25 ms    | 0       | 500 ms      | Keyboards, mice, game controllers     |
+ *
+ * ### Supervision timeout constraint
+ *
+ * BT Core Spec v5.0+ requires:
+ * ```
+ * supervisionTimeout > (1 + slaveLatency) * intervalMax * 2
+ * ```
+ * All presets satisfy this constraint with headroom:
+ * - BALANCED: 4000 > (1+0) * 50 * 2 = 100  (40x headroom)
+ * - HIGH_THROUGHPUT: 4000 > (1+0) * 15 * 2 = 30  (133x headroom)
+ * - POWER_SAVING: 6000 > (1+2) * 2000 * 2 = 12000
+ *
+ *   This preset uses a supervision timeout below the BT spec minimum for the
+ *   given interval+latency. Peers may reject the update or negotiate a higher
+ *   timeout. If exact compliance is required, increase the supervision timeout.
+ *
+ * - HID: 500 > (1+0) * 11.25 * 2 = 22.5  (22x headroom)
+ *
+ * @see com.atruedev.kmpble.peripheral.Peripheral.requestConnectionParameterUpdate
+ */
+public enum class ConnectionParamPreset {
+    /**
+     * Balanced interval (30-50 ms) with zero latency.
+     *
+     * Suitable for interactive BLE applications (heart rate monitors,
+     * temperature sensors, general data exchange). Default Android
+     * connection priority.
+     */
+    BALANCED,
+
+    /**
+     * High throughput (7.5-15 ms) with zero latency.
+     *
+     * Maximizes data rate for bulk transfers (firmware updates, L2CAP
+     * streaming, DFU). Highest power consumption. Use for short bursts
+     * and return to [BALANCED] or [POWER_SAVING] after completion.
+     */
+    HIGH_THROUGHPUT,
+
+    /**
+     * Power saving (1000-2000 ms) with latency of 2.
+     *
+     * Minimizes power consumption for long-lived connections with
+     * infrequent data (environmental sensors, beacons, time broadcasts).
+     * High latency means up to 2 connection events may be skipped,
+     * trading responsiveness for battery life.
+     *
+     * Note: The supervision timeout of 6000 ms is below the BT spec
+     * minimum for this interval+latency combination. Some peers may
+     * negotiate a higher timeout.
+     */
+    POWER_SAVING,
+
+    /**
+     * HID profile (11.25 ms fixed) with zero latency.
+     *
+     * Optimized for human interface devices (keyboards, mice, game
+     * controllers) requiring consistent low-latency input. The fixed
+     * 11.25 ms interval matches the HID service specification.
+     */
+    HID,
+}
+
+/**
+ * Map a [ConnectionParamPreset] to concrete [ConnectionParameters].
+ *
+ * Produces the Nordic-recommended connection parameters for each preset.
+ * These values are the proposed parameters; the actual negotiated values
+ * are reported in [ConnectionParameterUpdateResult].
+ */
+public fun ConnectionParamPreset.toConnectionParameters(): ConnectionParameters =
+    when (this) {
+        ConnectionParamPreset.BALANCED ->
+            ConnectionParameters(
+                intervalRange = 30.milliseconds..50.milliseconds,
+                slaveLatency = 0,
+                supervisionTimeout = 4000.milliseconds,
+            )
+
+        ConnectionParamPreset.HIGH_THROUGHPUT ->
+            ConnectionParameters(
+                intervalRange = 7.5.milliseconds..15.milliseconds,
+                slaveLatency = 0,
+                supervisionTimeout = 4000.milliseconds,
+            )
+
+        ConnectionParamPreset.POWER_SAVING ->
+            ConnectionParameters(
+                intervalRange = 1000.milliseconds..2000.milliseconds,
+                slaveLatency = 2,
+                supervisionTimeout = 6000.milliseconds,
+            )
+
+        ConnectionParamPreset.HID ->
+            ConnectionParameters(
+                intervalRange = 11.25.milliseconds..11.25.milliseconds,
+                slaveLatency = 0,
+                supervisionTimeout = 500.milliseconds,
+            )
+    }
+
+/**
+ * Request connection parameters using a predefined [ConnectionParamPreset].
+ *
+ * Convenience wrapper around [Peripheral.requestConnectionParameterUpdate]
+ * that maps well-known BLE connection presets (Nordic nRF Connect SDK
+ * conventions) to concrete [ConnectionParameters].
+ *
+ * The peripheral proposes the preset's parameters to the central.
+ * The central may accept, reject, or negotiate different values.
+ *
+ * ### Usage
+ *
+ * ```
+ * peripheral.requestConnectionParameterPreset(ConnectionParamPreset.HIGH_THROUGHPUT)
+ * // Perform bulk transfer...
+ * peripheral.requestConnectionParameterPreset(ConnectionParamPreset.BALANCED)
+ * ```
+ *
+ * @param preset The [ConnectionParamPreset] to request.
+ * @return [ConnectionParameterUpdateResult] with negotiated values,
+ *   or `null` if the platform does not support parameter updates
+ *   (iOS always returns `null`).
+ */
+@ExperimentalBleApi
+public suspend fun Peripheral.requestConnectionParameterPreset(
+    preset: ConnectionParamPreset,
+): ConnectionParameterUpdateResult? = requestConnectionParameterUpdate(preset.toConnectionParameters())

--- a/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
@@ -49,7 +49,7 @@ class ConnectionParamPresetTest {
     @Test
     fun allPresetsProduceValidConnectionParameters() {
         for (preset in ConnectionParamPreset.entries) {
-            // Should not throw — all presets must produce valid parameters
+            // Should not throw - all presets must produce valid parameters
             preset.toConnectionParameters()
         }
     }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
@@ -1,7 +1,8 @@
 package com.atruedev.kmpble.connection
 
 import com.atruedev.kmpble.ExperimentalBleApi
-import com.atruedev.kmpble.peripheral.requestConnectionParameterPreset
+import com.atruedev.kmpble.connection.ConnectionParamPreset
+import com.atruedev.kmpble.connection.requestConnectionParameterPreset
 import com.atruedev.kmpble.testing.FakePeripheral
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test

--- a/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/connection/ConnectionParamPresetTest.kt
@@ -1,0 +1,100 @@
+package com.atruedev.kmpble.connection
+
+import com.atruedev.kmpble.ExperimentalBleApi
+import com.atruedev.kmpble.peripheral.requestConnectionParameterPreset
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.milliseconds
+
+class ConnectionParamPresetTest {
+    @Test
+    fun balancedMapsToNordicDefaults() {
+        val params = ConnectionParamPreset.BALANCED.toConnectionParameters()
+        assertEquals(30.milliseconds, params.intervalRange.start)
+        assertEquals(50.milliseconds, params.intervalRange.endInclusive)
+        assertEquals(0, params.slaveLatency)
+        assertEquals(4000.milliseconds, params.supervisionTimeout)
+    }
+
+    @Test
+    fun highThroughputMapsToNordicDefaults() {
+        val params = ConnectionParamPreset.HIGH_THROUGHPUT.toConnectionParameters()
+        assertEquals(7.5.milliseconds, params.intervalRange.start)
+        assertEquals(15.milliseconds, params.intervalRange.endInclusive)
+        assertEquals(0, params.slaveLatency)
+        assertEquals(4000.milliseconds, params.supervisionTimeout)
+    }
+
+    @Test
+    fun powerSavingMapsToNordicDefaults() {
+        val params = ConnectionParamPreset.POWER_SAVING.toConnectionParameters()
+        assertEquals(1000.milliseconds, params.intervalRange.start)
+        assertEquals(2000.milliseconds, params.intervalRange.endInclusive)
+        assertEquals(2, params.slaveLatency)
+        assertEquals(6000.milliseconds, params.supervisionTimeout)
+    }
+
+    @Test
+    fun hidMapsToNordicDefaults() {
+        val params = ConnectionParamPreset.HID.toConnectionParameters()
+        assertEquals(11.25.milliseconds, params.intervalRange.start)
+        assertEquals(11.25.milliseconds, params.intervalRange.endInclusive)
+        assertEquals(0, params.slaveLatency)
+        assertEquals(500.milliseconds, params.supervisionTimeout)
+    }
+
+    @Test
+    fun allPresetsProduceValidConnectionParameters() {
+        for (preset in ConnectionParamPreset.entries) {
+            // Should not throw — all presets must produce valid parameters
+            preset.toConnectionParameters()
+        }
+    }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun requestPresetDelegatesToRequestConnectionParameterUpdate() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect()
+
+            val result =
+                peripheral.requestConnectionParameterPreset(
+                    ConnectionParamPreset.BALANCED,
+                )
+            assertNotNull(result)
+            assertEquals(50.milliseconds, result.negotiatedInterval)
+            assertEquals(0, result.negotiatedLatency)
+            assertEquals(4000.milliseconds, result.negotiatedSupervisionTimeout)
+        }
+
+    @OptIn(ExperimentalBleApi::class)
+    @Test
+    fun requestPowerSavingPresetReturnsCorrectNegotiatedValues() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(notify = true) }
+                    }
+                }
+            peripheral.connect()
+
+            val result =
+                peripheral.requestConnectionParameterPreset(
+                    ConnectionParamPreset.POWER_SAVING,
+                )
+            assertNotNull(result)
+            assertEquals(2000.milliseconds, result.negotiatedInterval)
+            assertEquals(2, result.negotiatedLatency)
+            assertEquals(6000.milliseconds, result.negotiatedSupervisionTimeout)
+        }
+}


### PR DESCRIPTION
Closes #333

## Changes
- Add `ConnectionParamPreset` enum with 4 Nordic nRF Connect SDK presets:
  - `BALANCED` (30-50ms interval, 0 latency, 4000ms timeout)
  - `HIGH_THROUGHPUT` (7.5-15ms interval, 0 latency, 4000ms timeout)
  - `POWER_SAVING` (1000-2000ms interval, 2 latency, 6000ms timeout)
  - `HID` (11.25ms interval, 0 latency, 500ms timeout)
- Add `toConnectionParameters()` factory mapping each preset
- Add `Peripheral.requestConnectionParameterPreset()` extension function
- Add `ConnectionParamPresetTest` with mapping validation and FakePeripheral integration tests