### PR TITLE
fix(concurrency): use atomic for QuirkRegistry cached singleton

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/quirks/QuirkRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/quirks/QuirkRegistry.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.quirks
 
+import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 
@@ -95,7 +96,7 @@ public class QuirkRegistry internal constructor(
         private val lock = reentrantLock()
         private var userConfig: ((Builder) -> Unit)? = null
 
-        private var cached: QuirkRegistry? = null
+        private val cached = atomic<QuirkRegistry?>(null)
         private var initialized = false
 
         /**
@@ -116,13 +117,13 @@ public class QuirkRegistry internal constructor(
 
         /** Returns the singleton registry for the current device. */
         public fun getInstance(): QuirkRegistry {
-            val existing = cached
+            val existing = cached.value
             if (existing != null) return existing
             return lock.withLock {
                 initialized = true
-                cached ?: run {
+                cached.value ?: run {
                     val registry = buildRegistry(DeviceInfo.current(), userConfig)
-                    cached = registry
+                    cached.value = registry
                     registry
                 }
             }


### PR DESCRIPTION
Closes #405

## What
Replaces the plain `var cached: QuirkRegistry?` in `QuirkRegistry.getInstance()` with `atomic<QuirkRegistry?>(null)` from kotlinx.atomicfu.

## Why
The fast-path read `val existing = cached` (line 119) was an unsynchronized read of a plain `var`, creating a data race with the write `cached = registry` inside `lock.withLock` (line 125). On Kotlin/Native targets, the unsynchronized read may never observe the write from another thread, causing `getInstance()` to rebuild the registry unnecessarily or stall.

## Fix
- Changed `private var cached: QuirkRegistry? = null` to `private val cached = atomic<QuirkRegistry?>(null)`
- Updated all reads to `cached.value` (properly ordered atomic operations)
- Added `import kotlinx.atomicfu.atomic`