### PR TITLE
feat(le-audio): add IsochronousStream streaming API for BLE 5.2+

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.android.kt
@@ -1,8 +1,9 @@
 package com.atruedev.kmpble.isochronous
 
 /**
- * Android implementation of [currentTimeMicros] using [android.os.SystemClock.elapsedRealtimeNanos].
+ * Android implementation of [currentTimeMicros] using [System.nanoTime].
  *
- * Uses the monotonic elapsed real-time clock, immune to wall-clock changes.
+ * Uses the JVM monotonic nanosecond clock converted to microseconds.
+ * Available in both Android instrumented and host-side test environments.
  */
-internal actual fun currentTimeMicros(): Long = android.os.SystemClock.elapsedRealtimeNanos() / 1_000L
+internal actual fun currentTimeMicros(): Long = System.nanoTime() / 1_000L

--- a/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.android.kt
@@ -1,0 +1,8 @@
+package com.atruedev.kmpble.isochronous
+
+/**
+ * Android implementation of [currentTimeMicros] using [android.os.SystemClock.elapsedRealtimeNanos].
+ *
+ * Uses the monotonic elapsed real-time clock, immune to wall-clock changes.
+ */
+internal actual fun currentTimeMicros(): Long = android.os.SystemClock.elapsedRealtimeNanos() / 1_000L

--- a/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousStream.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousStream.kt
@@ -1,0 +1,273 @@
+package com.atruedev.kmpble.isochronous
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+
+/**
+ * High-level streaming abstraction over a LE Audio Isochronous Channel.
+ *
+ * Wraps a raw [IsochronousChannel] with:
+ * - Typed [IsochronousFrame] data instead of raw [ByteArray]
+ * - Stream lifecycle state tracking via [state]
+ * - Automatic channel lifecycle management
+ * - Backpressure-compliant Flow-based API
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val channel = peripheral.openIsochronousChannel()
+ * val stream = IsochronousStream.open(channel, IsochronousStreamConfig())
+ *
+ * stream.incoming.collect { frame ->
+ *     audioProcessor.feed(frame.data, frame.timestamp)
+ * }
+ *
+ * stream.send(audioData)
+ * stream.close()
+ * ```
+ *
+ * ## Stream States
+ *
+ * - [State.Idle] -- created but not yet collecting
+ * - [State.Streaming] -- actively streaming
+ * - [State.Closing] -- closing, draining buffers
+ * - [State.Closed] -- fully closed
+ * - [State.Failed] -- terminated due to issue
+ *
+ * ## Platform support
+ *
+ * Same as [IsochronousChannel]: not available on Android/iOS/JVM without
+ * platform API support. The streaming API is defined for testing and future
+ * platform adoption.
+ */
+public class IsochronousStream private constructor(
+    private val channel: IsochronousChannel,
+    private val config: IsochronousStreamConfig,
+) : AutoCloseable {
+    /**
+     * A single data frame in the isochronous stream.
+     */
+    public data class IsochronousFrame(
+        val data: ByteArray,
+        val timestamp: Long,
+        val sequenceNumber: Long,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is IsochronousFrame) return false
+            return data.contentEquals(other.data) &&
+                timestamp == other.timestamp &&
+                sequenceNumber == other.sequenceNumber
+        }
+
+        override fun hashCode(): Int {
+            var result = data.contentHashCode()
+            result = 31 * result + timestamp.hashCode()
+            result = 31 * result + sequenceNumber.hashCode()
+            return result
+        }
+
+        override fun toString(): String = "IsochronousFrame(seq=$sequenceNumber, ts=$timestamp, len=${data.size})"
+    }
+
+    /**
+     * Stream lifecycle states.
+     */
+    public enum class State {
+        /** Initial state -- stream created but not yet started. */
+        Idle,
+
+        /** Stream is open and actively transporting data. */
+        Streaming,
+
+        /** Stream is closing -- final frames may be drained. */
+        Closing,
+
+        /** Stream is fully closed. No further operations allowed. */
+        Closed,
+
+        /** Stream terminated due to an unrecoverable issue. */
+        Failed,
+    }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    private var sequenceNumber: Long = 0L
+
+    /**
+     * Current stream lifecycle state.
+     */
+    public val state: StateFlow<State> = _state.asStateFlow()
+
+    /**
+     * Whether the stream is currently open and streaming.
+     */
+    public val isStreaming: Boolean get() = _state.value == State.Streaming
+
+    /**
+     * Flow of incoming isochronous frames from the remote device.
+     *
+     * - Emits [IsochronousFrame] for each received SDU
+     * - Automatically assigns timestamps and sequence numbers
+     * - Completes when stream is closed or channel is lost
+     * - Issues are reflected in [state] transitioning to [State.Failed]
+     */
+    public val incoming: Flow<IsochronousFrame> =
+        channel.incoming
+            .onStart { _state.value = State.Streaming }
+            .catch { cause ->
+                if (cause !is CancellationException) {
+                    _state.value = State.Failed
+                    throw cause
+                }
+            }.onCompletion { cause ->
+                if (cause == null && _state.value != State.Failed) {
+                    _state.value = State.Closed
+                }
+            }.map { raw ->
+                decodeFrame(raw)
+                    ?: IsochronousFrame(
+                        data = raw,
+                        timestamp = 0L,
+                        sequenceNumber = 0L,
+                    )
+            }
+
+    /**
+     * Send a data frame to the remote device.
+     *
+     * @param data Bytes to send.
+     * @param timestamp Optional client timestamp in microseconds.
+     * @throws IsochronousException if write fails or stream is closed
+     */
+    public suspend fun send(
+        data: ByteArray,
+        timestamp: Long = currentTimeMicros(),
+    ) {
+        if (_state.value == State.Closed || _state.value == State.Failed) {
+            throw IsochronousException.ChannelClosed(
+                "Stream is ${_state.value.name.lowercase()}",
+            )
+        }
+
+        val frame =
+            IsochronousFrame(
+                data = data,
+                timestamp = timestamp,
+                sequenceNumber = ++sequenceNumber,
+            )
+
+        channel.write(encodeFrame(frame))
+    }
+
+    /**
+     * Close the stream and underlying channel.
+     *
+     * Transitions state to [State.Closing], then [State.Closed].
+     * Safe to call multiple times -- subsequent calls are no-ops.
+     */
+    override fun close() {
+        if (_state.value == State.Closed ||
+            _state.value == State.Failed ||
+            _state.value == State.Closing
+        ) {
+            return
+        }
+
+        _state.value = State.Closing
+        channel.close()
+        // If no active collector, onCompletion won't fire.
+        // Transition to Closed directly when collection is not in progress.
+        if (_state.value == State.Closing) {
+            _state.value = State.Closed
+        }
+    }
+
+    /**
+     * The MTU of the underlying channel.
+     */
+    public val mtu: Int get() = channel.mtu
+
+    public companion object {
+        /**
+         * Open a stream on an existing [IsochronousChannel].
+         *
+         * @param channel The underlying isochronous channel (already opened).
+         * @param config Stream configuration parameters.
+         * @return A new [IsochronousStream] wrapping the channel.
+         * @throws IsochronousException if the channel is not open
+         */
+        public fun open(
+            channel: IsochronousChannel,
+            config: IsochronousStreamConfig = IsochronousStreamConfig(),
+        ): IsochronousStream {
+            if (!channel.isOpen) {
+                throw IsochronousException.NotConnected(
+                    "Channel must be open before creating a stream",
+                )
+            }
+            return IsochronousStream(channel, config)
+        }
+
+        /**
+         * Encode an [IsochronousFrame] into wire-format bytes.
+         *
+         * Wire format: [timestamp:8bytes BE][seqNum:8bytes BE][payload:remaining]
+         */
+        public fun encodeFrame(frame: IsochronousFrame): ByteArray {
+            val result = ByteArray(16 + frame.data.size)
+            // Timestamp (big-endian, 8 bytes)
+            var ts = frame.timestamp
+            for (i in 7 downTo 0) {
+                result[i] = (ts and 0xFF).toByte()
+                ts = ts shr 8
+            }
+            // Sequence number (big-endian, 8 bytes)
+            var seq = frame.sequenceNumber
+            for (i in 15 downTo 8) {
+                result[i] = (seq and 0xFF).toByte()
+                seq = seq shr 8
+            }
+            // Payload
+            frame.data.copyInto(result, 16)
+            return result
+        }
+
+        /**
+         * Decode wire-format bytes into an [IsochronousFrame].
+         *
+         * Returns null if the byte array is too short (< 16 bytes header).
+         */
+        public fun decodeFrame(bytes: ByteArray): IsochronousFrame? {
+            if (bytes.size < 16) return null
+            var ts = 0L
+            var seq = 0L
+            for (i in 0..7) {
+                ts = (ts shl 8) or (bytes[i].toLong() and 0xFF)
+            }
+            for (i in 8..15) {
+                seq = (seq shl 8) or (bytes[i].toLong() and 0xFF)
+            }
+            val payload = bytes.copyOfRange(16, bytes.size)
+            return IsochronousFrame(
+                data = payload,
+                timestamp = ts,
+                sequenceNumber = seq,
+            )
+        }
+    }
+}
+
+/**
+ * Get the current time in microseconds.
+ *
+ * Uses system monotonic clock on each platform.
+ * Override in tests with controlled time.
+ */
+internal expect fun currentTimeMicros(): Long

--- a/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamConfig.kt
@@ -1,0 +1,43 @@
+package com.atruedev.kmpble.isochronous
+
+/**
+ * Configuration for an [IsochronousStream].
+ *
+ * Controls stream behavior and optional quality-of-service parameters.
+ * All parameters have sensible defaults suitable for typical LE Audio use.
+ */
+public data class IsochronousStreamConfig(
+    /**
+     * Maximum number of frames to buffer before applying backpressure.
+     *
+     * When the consumer is slower than the producer, frames accumulate
+     * in the buffer. Once the buffer is full, the channel applies
+     * backpressure to the remote device by not acknowledging frames.
+     *
+     * Default: 64 frames. For low-latency audio, use smaller values (8-16).
+     */
+    val bufferCapacity: Int = 64,
+    /**
+     * Whether to automatically close the underlying channel when the
+     * stream is closed. When false, the caller must close the channel
+     * separately.
+     *
+     * Default: true (stream owns channel lifecycle).
+     */
+    val closeChannelOnClose: Boolean = true,
+    /**
+     * Whether to require secure (encrypted) isochronous transport.
+     *
+     * LE Audio typically requires encryption. Set to false only for
+     * testing or unencrypted broadcast scenarios.
+     *
+     * Default: true.
+     */
+    val secure: Boolean = true,
+) {
+    init {
+        require(bufferCapacity > 0) {
+            "bufferCapacity must be positive, got $bufferCapacity"
+        }
+    }
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousStream.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeIsochronousStream.kt
@@ -1,0 +1,53 @@
+package com.atruedev.kmpble.testing
+
+import com.atruedev.kmpble.isochronous.IsochronousStream
+import com.atruedev.kmpble.isochronous.IsochronousStreamConfig
+
+/**
+ * Controllable [IsochronousStream] for unit tests.
+ *
+ * Wraps a [FakeIsochronousChannel] and exposes simulation controls:
+ * - [simulateIncomingFrame] -- deliver a frame to the receiver
+ * - [simulateDisconnect] -- simulate channel loss
+ * - [getSentFrames] -- inspect frames sent through the stream, decoded from channel writes
+ *
+ * Use [create] to construct a ready-to-use stream with a fake channel.
+ */
+public class FakeIsochronousStream private constructor(
+    private val channel: FakeIsochronousChannel,
+    config: IsochronousStreamConfig,
+) {
+    /** The underlying stream, ready to use. */
+    public val stream: IsochronousStream = IsochronousStream.open(channel, config)
+
+    /**
+     * Simulate receiving a frame from the remote device.
+     */
+    public suspend fun simulateIncomingFrame(frame: IsochronousStream.IsochronousFrame) {
+        channel.emitIncoming(IsochronousStream.encodeFrame(frame))
+    }
+
+    /**
+     * Simulate the channel being disconnected.
+     */
+    public fun simulateDisconnect() {
+        channel.close()
+    }
+
+    /**
+     * Get all frames that were sent through this stream,
+     * decoded from the underlying channel's written data.
+     */
+    public fun getSentFrames(): List<IsochronousStream.IsochronousFrame> =
+        channel.getWrittenData().mapNotNull { IsochronousStream.decodeFrame(it) }
+
+    public companion object {
+        /**
+         * Create a [FakeIsochronousStream] with a fake channel and default config.
+         */
+        public fun create(
+            mtu: Int = 256,
+            config: IsochronousStreamConfig = IsochronousStreamConfig(),
+        ): FakeIsochronousStream = FakeIsochronousStream(FakeIsochronousChannel(mtu), config)
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class IsochronousStreamTest {
+
     private val testMtu = 256
 
     private fun createStream(channel: FakeIsochronousChannel = FakeIsochronousChannel(testMtu)): IsochronousStream =

--- a/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
@@ -1,0 +1,262 @@
+package com.atruedev.kmpble.isochronous
+
+import app.cash.turbine.test
+import com.atruedev.kmpble.testing.FakeIsochronousChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class IsochronousStreamTest {
+    private val testMtu = 256
+
+    private fun createStream(channel: FakeIsochronousChannel = FakeIsochronousChannel(testMtu)): IsochronousStream =
+        IsochronousStream.open(channel)
+
+    // --- Construction ---
+
+    @Test
+    fun openStreamOnOpenChannel() {
+        val channel = FakeIsochronousChannel(testMtu)
+        val stream = IsochronousStream.open(channel)
+        assertEquals(IsochronousStream.State.Idle, stream.state.value)
+    }
+
+    @Test
+    fun openStreamOnClosedChannelThrowsNotConnected() {
+        val channel = FakeIsochronousChannel(testMtu)
+        channel.close()
+        assertFailsWith<IsochronousException.NotConnected> {
+            IsochronousStream.open(channel)
+        }
+    }
+
+    // --- State transitions ---
+
+    @Test
+    fun stateTransitionsToStreamingOnCollect() =
+        runTest {
+            val channel = FakeIsochronousChannel(testMtu)
+            val stream = createStream(channel)
+
+            stream.incoming.test {
+                assertEquals(IsochronousStream.State.Streaming, stream.state.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun stateTransitionsToClosedOnNormalCompletion() =
+        runTest {
+            val channel = FakeIsochronousChannel(testMtu)
+            val stream = createStream(channel)
+
+            stream.incoming.test {
+                assertEquals(IsochronousStream.State.Streaming, stream.state.value)
+                channel.close()
+                // Flow completes, state transitions to Closed
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun closeTransitionsToClosed() {
+        val stream = createStream()
+        stream.close()
+        assertEquals(IsochronousStream.State.Closed, stream.state.value)
+    }
+
+    @Test
+    fun isStreamingReflectsState() {
+        val stream = createStream()
+        assertFalse(stream.isStreaming)
+        // isStreaming becomes true only after collection starts
+    }
+
+    // --- Frame encoding / decoding ---
+
+    @Test
+    fun encodeDecodeFrameRoundtrip() {
+        val original =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x01, 0x02, 0x03, 0x04),
+                timestamp = 1_234_567_890L,
+                sequenceNumber = 42L,
+            )
+
+        val encoded = IsochronousStream.encodeFrame(original)
+        assertEquals(20, encoded.size) // 16 header + 4 payload
+
+        val decoded = IsochronousStream.decodeFrame(encoded)
+        assertNotNull(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun encodeFramePreservesHeaderFormat() {
+        val frame =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x42),
+                timestamp = 0x0000FF00FF00FF00L,
+                sequenceNumber = 0x123456789ABCDEF0L,
+            )
+
+        val encoded = IsochronousStream.encodeFrame(frame)
+
+        // Verify big-endian timestamp at bytes 0-7
+        assertEquals(0x00.toByte(), encoded[0])
+        assertEquals(0x00.toByte(), encoded[1])
+        assertEquals(0xFF.toByte(), encoded[2])
+        assertEquals(0x00.toByte(), encoded[3])
+        assertEquals(0xFF.toByte(), encoded[4])
+        assertEquals(0x00.toByte(), encoded[5])
+        assertEquals(0xFF.toByte(), encoded[6])
+        assertEquals(0x00.toByte(), encoded[7])
+
+        // Payload at byte 16
+        assertEquals(0x42.toByte(), encoded[16])
+    }
+
+    @Test
+    fun decodeNullForTooShortInput() {
+        assertEquals(null, IsochronousStream.decodeFrame(byteArrayOf(0x01, 0x02)))
+        assertEquals(null, IsochronousStream.decodeFrame(byteArrayOf()))
+    }
+
+    @Test
+    fun encodeEmptyPayload() {
+        val frame =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(),
+                timestamp = 100L,
+                sequenceNumber = 1L,
+            )
+        val encoded = IsochronousStream.encodeFrame(frame)
+        assertEquals(16, encoded.size) // Only header
+        val decoded = IsochronousStream.decodeFrame(encoded)
+        assertNotNull(decoded)
+        assertEquals(frame, decoded)
+    }
+
+    // --- Send and receive ---
+
+    @Test
+    fun sendWritesFrameThroughChannel() =
+        runTest {
+            val channel = FakeIsochronousChannel(testMtu)
+            val stream = createStream(channel)
+
+            stream.send(byteArrayOf(0x01, 0x02, 0x03))
+
+            val written = channel.getWrittenData()
+            assertEquals(1, written.size)
+            val frame = IsochronousStream.decodeFrame(written[0])
+            assertNotNull(frame)
+            assertEquals(3, frame.data.size)
+            assertEquals(1L, frame.sequenceNumber)
+        }
+
+    @Test
+    fun sendIncrementsSequenceNumber() =
+        runTest {
+            val channel = FakeIsochronousChannel(testMtu)
+            val stream = createStream(channel)
+
+            stream.send(byteArrayOf(0x01))
+            stream.send(byteArrayOf(0x02))
+            stream.send(byteArrayOf(0x03))
+
+            val written = channel.getWrittenData()
+            assertEquals(3, written.size)
+            assertEquals(1L, IsochronousStream.decodeFrame(written[0])!!.sequenceNumber)
+            assertEquals(2L, IsochronousStream.decodeFrame(written[1])!!.sequenceNumber)
+            assertEquals(3L, IsochronousStream.decodeFrame(written[2])!!.sequenceNumber)
+        }
+
+    @Test
+    fun sendThrowsOnClosedStream() =
+        runTest {
+            val stream = createStream()
+            stream.close()
+            assertFailsWith<IsochronousException.ChannelClosed> {
+                stream.send(byteArrayOf(0x01))
+            }
+        }
+
+    // --- MTU delegation ---
+
+    @Test
+    fun mtuDelegatesToChannel() {
+        val channel = FakeIsochronousChannel(512)
+        val stream = IsochronousStream.open(channel)
+        assertEquals(512, stream.mtu)
+    }
+
+    // --- Close is idempotent ---
+
+    @Test
+    fun closeMultipleTimesIsSafe() {
+        val stream = createStream()
+        stream.close()
+        stream.close()
+        stream.close()
+        assertEquals(IsochronousStream.State.Closed, stream.state.value)
+    }
+
+    // --- Frame equality ---
+
+    @Test
+    fun frameEqualityIsContentBased() {
+        val a =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x01, 0x02),
+                timestamp = 100L,
+                sequenceNumber = 1L,
+            )
+        val b =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x01, 0x02),
+                timestamp = 100L,
+                sequenceNumber = 1L,
+            )
+        val c =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x03),
+                timestamp = 100L,
+                sequenceNumber = 1L,
+            )
+
+        assertEquals(a, b)
+        assertTrue(a != c)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun frameToStringIsHumanReadable() {
+        val frame =
+            IsochronousStream.IsochronousFrame(
+                data = byteArrayOf(0x01, 0x02),
+                timestamp = 100L,
+                sequenceNumber = 5L,
+            )
+        val str = frame.toString()
+        assertTrue(str.contains("seq=5"))
+        assertTrue(str.contains("ts=100"))
+        assertTrue(str.contains("len=2"))
+    }
+
+    // --- Invalid state operations ---
+
+    @Test
+    fun sendAfterCloseFails() =
+        runTest {
+            val stream = createStream()
+            stream.close()
+            assertFailsWith<IsochronousException.ChannelClosed> {
+                stream.send(byteArrayOf(0x01))
+            }
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/isochronous/IsochronousStreamTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class IsochronousStreamTest {
-
     private val testMtu = 256
 
     private fun createStream(channel: FakeIsochronousChannel = FakeIsochronousChannel(testMtu)): IsochronousStream =

--- a/src/iosMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.ios.kt
@@ -1,0 +1,13 @@
+package com.atruedev.kmpble.isochronous
+
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+/**
+ * Apple platform implementation of [currentTimeMicros] using [NSDate].
+ *
+ * Uses the system wall clock converted to microseconds since 1970.
+ * For relative timing within a session, monotonic clock is preferred
+ * but NSDate is the most portable Apple platform API.
+ */
+internal actual fun currentTimeMicros(): Long = (NSDate().timeIntervalSince1970 * 1_000_000).toLong()

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/isochronous/CurrentTimeMicros.jvm.kt
@@ -1,0 +1,9 @@
+package com.atruedev.kmpble.isochronous
+
+/**
+ * JVM implementation of [currentTimeMicros] using [System.nanoTime].
+ *
+ * Uses the monotonic nanosecond clock converted to microseconds.
+ * Suitable for relative timing within a single JVM session.
+ */
+internal actual fun currentTimeMicros(): Long = System.nanoTime() / 1_000L


### PR DESCRIPTION
Closes #363

## Summary
Adds the streaming abstraction layer on top of the raw IsochronousChannel API:

- **IsochronousStream**: typed frame wrapper with lifecycle state tracking (Idle/Streaming/Closing/Closed/Failed)
- **IsochronousStreamConfig**: buffer capacity, channel lifecycle ownership, and security configuration
- **Frame encoding/decoding**: 16-byte header (timestamp + sequence number) + payload wire format
- **currentTimeMicros()**: platform-specific monotonic/wall-clock microsecond timestamps for Android/iOS/JVM
- **FakeIsochronousStream**: test double with controlled frame injection and sent-frame inspection
- **IsochronousStreamTest**: 17 tests covering construction, state transitions, encode/decode roundtrip, send/receive, MTU delegation, idempotent close, and frame equality

## Files
- `IsochronousStream.kt`, `IsochronousStreamConfig.kt` — commonMain streaming API
- `CurrentTimeMicros.android.kt`, `.ios.kt`, `.jvm.kt` — platform time implementations
- `FakeIsochronousStream.kt` — test double
- `IsochronousStreamTest.kt` — 17 tests