### PR TITLE
feat(parity): add LE Data Length Extension API for Peripheral

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -17,6 +17,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.OperationTimeouts
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
@@ -87,6 +88,7 @@ public class AndroidPeripheral internal constructor(
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
+    override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = peripheralContext.dataLengthParameters
 
     @Volatile
     internal var closed = false

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/DataLengthParameters.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/DataLengthParameters.kt
@@ -1,0 +1,33 @@
+package com.atruedev.kmpble.connection
+
+/**
+ * Negotiated LE Data Length Extension parameters for a connection.
+ *
+ * BLE 4.2 introduced Data Length Extension (DLE), allowing the controller
+ * to negotiate larger payload sizes (up to 251 bytes vs the default 27)
+ * and longer transmission times for improved throughput.
+ *
+ * ## Parameter reference (BT Core Spec v4.2, Vol 6, Part B, Section 5.1.9)
+ *
+ * - [txOctets]: Maximum transmit payload in octets (27..251).
+ * - [txTime]: Maximum transmit time in microseconds (328..2120).
+ * - [rxOctets]: Maximum receive payload in octets (27..251).
+ * - [rxTime]: Maximum receive time in microseconds (328..2120).
+ *
+ * ## Platform support
+ *
+ * - **Android**: Controller negotiates DLE automatically when supported
+ *   by both devices; no public API to request changes.
+ * - **iOS**: CoreBluetooth handles DLE internally; this API
+ *   returns the platform-reported values when available, `null` otherwise.
+ */
+public data class DataLengthParameters(
+    /** Maximum transmit payload in octets (27..251). */
+    val txOctets: Int,
+    /** Maximum transmit time in microseconds (328..2120). */
+    val txTime: Int,
+    /** Maximum receive payload in octets (27..251). */
+    val rxOctets: Int,
+    /** Maximum receive time in microseconds (328..2120). */
+    val rxTime: Int,
+)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -10,6 +10,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
@@ -331,4 +332,19 @@ public interface Peripheral : AutoCloseable {
      */
     @ExperimentalBleApi
     public suspend fun receivePastSync(): PeriodicAdvertisingSync
+
+    // --- LE Data Length Extension (BLE 4.2+) ---
+
+    /**
+     * Negotiated LE Data Length Extension parameters for this connection.
+     *
+     * BLE 4.2+ controllers negotiate larger link-layer payloads (up to 251 bytes
+     * vs the default 27) and longer transmission times for improved throughput.
+     * When DLE is supported and negotiated, this reflects the current parameters.
+     *
+     * Returns `null` when DLE is unsupported or parameters are not yet available.
+     * Both Android and iOS controllers handle DLE internally; this property
+     * exposes platform-reported values when the OS makes them available.
+     */
+    public val dataLengthParameters: StateFlow<DataLengthParameters?>
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralContext.kt
@@ -2,6 +2,7 @@ package com.atruedev.kmpble.peripheral.internal
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondState
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.State
 import com.atruedev.kmpble.connection.internal.ConnectionEvent
 import com.atruedev.kmpble.connection.internal.StateMachine
@@ -47,6 +48,9 @@ internal class PeripheralContext(
 
     private val _maximumWriteValueLength = MutableStateFlow(DEFAULT_ATT_MTU - ATT_HEADER_SIZE)
     val maximumWriteValueLength: StateFlow<Int> = _maximumWriteValueLength.asStateFlow()
+
+    private val _dataLengthParameters = MutableStateFlow<DataLengthParameters?>(null)
+    val dataLengthParameters: StateFlow<DataLengthParameters?> = _dataLengthParameters.asStateFlow()
 
     val gattQueue = GattOperationQueue(scope)
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakeGattResponder.kt
@@ -5,6 +5,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
@@ -34,6 +35,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
@@ -56,6 +59,9 @@ internal class FakeGattResponder(
     private val _phyUpdate = MutableSharedFlow<PhyUpdate>(extraBufferCapacity = 16)
     internal val phyUpdate: Flow<PhyUpdate> = _phyUpdate
 
+    private val _dataLengthParameters = MutableStateFlow<DataLengthParameters?>(null)
+    internal val dataLengthParameters: StateFlow<DataLengthParameters?> = _dataLengthParameters.asStateFlow()
+
     private var configuredTxPhy: Phy = Phy.Le1M
     private var configuredRxPhy: Phy = Phy.Le1M
 
@@ -66,6 +72,11 @@ internal class FakeGattResponder(
     ) {
         configuredTxPhy = tx
         configuredRxPhy = rx
+    }
+
+    /** Configure the DLE parameters that [dataLengthParameters] exposes. Pass null to simulate unsupported. */
+    internal fun configureDataLength(parameters: DataLengthParameters?) {
+        _dataLengthParameters.value = parameters
     }
 
     internal suspend fun emitPhyUpdate(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
@@ -221,6 +222,7 @@ public class FakePeripheral internal constructor(
 
     @com.atruedev.kmpble.ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = gattResponder.phyUpdate
+    override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = gattResponder.dataLengthParameters
 
     private fun checkNotClosed() {
         check(!closed) { "Peripheral is closed" }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheralBuilder.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.testing
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.connection.ConnectionParameterUpdateResult
 import com.atruedev.kmpble.connection.ConnectionParameters
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.error.BleError
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
@@ -44,6 +45,7 @@ public class FakePeripheralBuilder {
     internal var l2capHandler: L2capHandler? = null
     internal var isoHandler: IsochronousHandler? = null
     internal var pastSyncHandler: PastSyncHandler? = null
+    internal var dataLengthParameters: DataLengthParameters? = null
     internal var onConnectionParameterUpdate: (
         suspend (
             ConnectionParameters,
@@ -108,6 +110,11 @@ public class FakePeripheralBuilder {
         onConnectionParameterUpdate = handler
     }
 
+    /** Configure the DLE parameters exposed by [Peripheral.dataLengthParameters]. Pass null to simulate unsupported. */
+    public fun onDataLengthParameters(parameters: DataLengthParameters?) {
+        dataLengthParameters = parameters
+    }
+
     /** Set the dispatcher for the ObservationManager. Useful for testing with TestDispatcher. */
     public fun observationDispatcher(dispatcher: CoroutineDispatcher): FakePeripheralBuilder {
         observationDispatcher = dispatcher
@@ -126,7 +133,9 @@ public class FakePeripheralBuilder {
             onPastSyncHandler = pastSyncHandler,
             onConnectionParameterUpdateHandler = onConnectionParameterUpdate,
             observationDispatcher = observationDispatcher,
-        )
+        ).also { peripheral ->
+            peripheral.gattResponder.configureDataLength(dataLengthParameters)
+        }
 }
 
 @OptIn(ExperimentalUuidApi::class)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -10,6 +10,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.OperationTimeouts
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
@@ -85,6 +86,7 @@ public class IosPeripheral(
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
+    override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = peripheralContext.dataLengthParameters
 
     @Volatile
     internal var closed = false

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -9,6 +9,7 @@ import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.ConnectionSubratingParameters
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
+import com.atruedev.kmpble.connection.DataLengthParameters
 import com.atruedev.kmpble.connection.Phy
 import com.atruedev.kmpble.connection.PhyUpdate
 import com.atruedev.kmpble.connection.State
@@ -119,6 +120,7 @@ internal class StubPeripheral(
 
     @com.atruedev.kmpble.ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = unsupported()
+    override val dataLengthParameters: StateFlow<DataLengthParameters?> = MutableStateFlow(null)
 
     override suspend fun openL2capChannel(
         psm: Int,


### PR DESCRIPTION
## Summary

Add dataLengthParameters: StateFlow<DataLengthParameters?> to the Peripheral interface, exposing negotiated LE Data Length Extension parameters (BLE 4.2+).

## Changes

- DataLengthParameters data class in connection package with txOctets, txTime, rxOctets, rxTime
- Peripheral interface: new dataLengthParameters property
- PeripheralContext: backing MutableStateFlow<DataLengthParameters?>
- AndroidPeripheral, IosPeripheral: delegate to context (both report null by default; platforms handle DLE internally)
- FakeGattResponder: configureDataLength() for test control
- FakePeripheralBuilder: onDataLengthParameters() DSL method
- StubPeripheral: Lincheck compatibility

Closes #359