### PR TITLE
feat(dfu): expose public OTA DFU transport API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,9 +41,9 @@
 - [x] #276: feat(le-audio): add LE Audio Isochronous Channels API (PR #393) [enhancement, priority]
 - [x] #363: feat(le-audio): add LE Audio Isochronous Channels streaming API for Bluetooth 5.2+ (PR #416) [enhancement]
 - [x] #338: feat(parity): add Periodic Advertising Sync Transfer (PAST) support (Bluetooth 5.1+) (PR #413) [enhancement]
-- [~] #368: feat(parity): add BLE Direction Finding (AoA/AoD) API for Bluetooth 5.1+ [enhancement]
+- [x] #368: feat(parity): add BLE Direction Finding (AoA/AoD) API for Bluetooth 5.1+ (PR #427) [enhancement]
 - [x] #318: feat(connection): add LE Connection Subrating support (Bluetooth 5.3) [enhancement]
-- [ ] #359: feat(parity): add LE Data Length Extension API for BLE 4.2+ throughput optimization [enhancement]
+- [x] #359: feat(parity): add LE Data Length Extension API for BLE 4.2+ throughput optimization (PR #426) [enhancement]
 - [ ] #332: feat(dfu): design and expose public OTA DFU transport API [enhancement]
 
 ## Testing

--- a/kmp-ble-dfu/MODULE.md
+++ b/kmp-ble-dfu/MODULE.md
@@ -2,7 +2,13 @@
 
 Device Firmware Update (DFU) and Over-The-Air (OTA) update support for kmp-ble.
 Start with [DfuController][com.atruedev.kmpble.dfu.DfuController] to perform firmware updates over BLE.
-Supports Nordic Secure DFU v2, L2CAP-based OTA, observable progress tracking, and resumable transfers across Android and iOS.
+Supports Nordic Secure DFU v2, MCUboot SMP, Espressif ESP OTA, L2CAP-based OTA, observable progress tracking, and resumable transfers across Android and iOS.
+
+Use [DfuTransport][com.atruedev.kmpble.dfu.transport.DfuTransport] directly for custom DFU flows, or use the companion factory methods:
+- `DfuTransport.gatt(peripheral)` for Nordic DFU over GATT
+- `DfuTransport.l2cap(peripheral, channel)` for high-throughput L2CAP
+- `DfuTransport.smp(peripheral)` for MCUboot SMP
+- `DfuTransport.espOta(peripheral)` for Espressif ESP OTA
 
 # Package com.atruedev.kmpble.dfu
 
@@ -26,6 +32,12 @@ Nordic Secure DFU v2 implementation.
 
 BLE transport layer for DFU data transfer. [DfuTransport][com.atruedev.kmpble.dfu.transport.DfuTransport]
 abstracts the link between GATT characteristic writes and L2CAP channel writes.
+
+Built-in transport classes are public and constructable directly:
+- [GattDfuTransport][com.atruedev.kmpble.dfu.transport.GattDfuTransport] - standard Nordic DFU over GATT
+- [L2capDfuTransport][com.atruedev.kmpble.dfu.transport.L2capDfuTransport] - high-throughput L2CAP with GATT commands
+- [SmpTransport][com.atruedev.kmpble.dfu.transport.SmpTransport] - MCUboot SMP with fragment reassembly
+- [EspOtaTransport][com.atruedev.kmpble.dfu.transport.EspOtaTransport] - Espressif ESP-IDF OTA
 
 # Package com.atruedev.kmpble.dfu.testing
 

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransport.kt
@@ -1,5 +1,10 @@
 package com.atruedev.kmpble.dfu.transport
 
+import com.atruedev.kmpble.dfu.DfuTransportConfig
+import com.atruedev.kmpble.l2cap.L2capChannel
+import com.atruedev.kmpble.peripheral.Peripheral
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -46,4 +51,54 @@ public interface DfuTransport : AutoCloseable {
      * the L2CAP transport closes the underlying channel.
      */
     override fun close()
+
+    public companion object {
+        /**
+         * Create a GATT-based DFU transport using the DFU Control Point and
+         * DFU Packet characteristics on the standard Nordic DFU service.
+         *
+         * @param peripheral a connected peripheral with the DFU service discovered
+         * @param commandTimeout how long to wait for command responses
+         * @throws com.atruedev.kmpble.dfu.DfuError.CharacteristicNotFound if DFU characteristics are missing
+         */
+        public fun gatt(peripheral: Peripheral, commandTimeout: Duration = 10.seconds): DfuTransport =
+            GattDfuTransport(peripheral, commandTimeout)
+
+        /**
+         * Create an L2CAP-based DFU transport for high-throughput firmware transfer.
+         *
+         * Commands are still sent via GATT; data goes over the L2CAP channel.
+         *
+         * @param peripheral a connected peripheral with the DFU service discovered
+         * @param channel an open L2CAP CoC channel for data transfer
+         * @param commandTimeout how long to wait for command responses
+         * @throws com.atruedev.kmpble.dfu.DfuError.CharacteristicNotFound if DFU characteristics are missing
+         */
+        public fun l2cap(peripheral: Peripheral, channel: L2capChannel, commandTimeout: Duration = 10.seconds): DfuTransport =
+            L2capDfuTransport(peripheral, channel, commandTimeout)
+
+        /**
+         * Create an SMP-based DFU transport for MCUboot devices.
+         *
+         * @param peripheral a connected peripheral with the SMP service discovered
+         * @param commandTimeout how long to wait for command responses
+         * @throws com.atruedev.kmpble.dfu.DfuError.ServiceNotFound if the SMP service is missing
+         */
+        public fun smp(peripheral: Peripheral, commandTimeout: Duration = 10.seconds): DfuTransport =
+            SmpTransport(peripheral, commandTimeout)
+
+        /**
+         * Create an ESP OTA transport for Espressif ESP-IDF devices.
+         *
+         * @param peripheral a connected peripheral with the OTA service discovered
+         * @param config ESP OTA configuration with optional custom UUIDs
+         * @param commandTimeout how long to wait for command responses
+         * @throws com.atruedev.kmpble.dfu.DfuError.CharacteristicNotFound if OTA characteristics are missing
+         */
+        public fun espOta(
+            peripheral: Peripheral,
+            config: DfuTransportConfig.EspOta = DfuTransportConfig.EspOta(),
+            commandTimeout: Duration = 10.seconds,
+        ): DfuTransport = EspOtaTransport(peripheral, config, commandTimeout)
+    }
 }

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransportExt.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransportExt.kt
@@ -11,7 +11,7 @@ import com.atruedev.kmpble.dfu.DfuError
  * because the link dropped mid-transmission ([DfuError.TransferFailed]).
  * Both are treated as successful reset signals.
  */
-internal suspend fun DfuTransport.sendCommandExpectingDisconnect(data: ByteArray) {
+public suspend fun DfuTransport.sendCommandExpectingDisconnect(data: ByteArray) {
     try {
         sendCommand(data)
     } catch (_: DfuError.Timeout) {

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransportUtil.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/DfuTransportUtil.kt
@@ -11,21 +11,21 @@ import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 
-internal fun resolveControlPoint(peripheral: Peripheral): Characteristic =
+public fun resolveControlPoint(peripheral: Peripheral): Characteristic =
     peripheral.findCharacteristic(DfuUuids.DFU_SERVICE, DfuUuids.DFU_CONTROL_POINT)
         ?: throw DfuError.CharacteristicNotFound("DFU Control Point")
 
-internal fun resolveDataPacket(peripheral: Peripheral): Characteristic =
+public fun resolveDataPacket(peripheral: Peripheral): Characteristic =
     peripheral.findCharacteristic(DfuUuids.DFU_SERVICE, DfuUuids.DFU_PACKET)
         ?: throw DfuError.CharacteristicNotFound("DFU Packet")
 
-internal fun controlPointNotifications(
+public fun controlPointNotifications(
     peripheral: Peripheral,
     controlPoint: Characteristic,
 ): Flow<ByteArray> =
     peripheral.observeValues(controlPoint, BackpressureStrategy.Unbounded)
 
-internal suspend fun sendCommandViaGatt(
+public suspend fun sendCommandViaGatt(
     peripheral: Peripheral,
     controlPoint: Characteristic,
     notifications: Flow<ByteArray>,

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/EspOtaTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/EspOtaTransport.kt
@@ -22,7 +22,7 @@ import kotlin.uuid.ExperimentalUuidApi
  * deliver command responses.
  */
 @OptIn(ExperimentalUuidApi::class)
-internal class EspOtaTransport(
+public class EspOtaTransport(
     private val peripheral: Peripheral,
     config: DfuTransportConfig.EspOta,
     private val commandTimeout: Duration,

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/GattDfuTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/GattDfuTransport.kt
@@ -5,7 +5,7 @@ import com.atruedev.kmpble.peripheral.Peripheral
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
-internal class GattDfuTransport(
+public class GattDfuTransport(
     private val peripheral: Peripheral,
     private val commandTimeout: Duration,
 ) : DfuTransport {

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/L2capDfuTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/L2capDfuTransport.kt
@@ -5,7 +5,7 @@ import com.atruedev.kmpble.peripheral.Peripheral
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
-internal class L2capDfuTransport(
+public class L2capDfuTransport(
     private val peripheral: Peripheral,
     private val channel: L2capChannel,
     private val commandTimeout: Duration,

--- a/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/SmpTransport.kt
+++ b/kmp-ble-dfu/src/commonMain/kotlin/com/atruedev/kmpble/dfu/transport/SmpTransport.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration
  * the MTU. This transport reassembles fragmented responses based on the SMP
  * header length field before returning to the caller.
  */
-internal class SmpTransport(
+public class SmpTransport(
     private val peripheral: Peripheral,
     private val commandTimeout: Duration,
 ) : DfuTransport {
@@ -56,7 +56,7 @@ internal class SmpTransport(
     // No-op: notification lifecycle is scoped to sendCommand's coroutineScope
     override fun close() {}
 
-    companion object {
+    private companion object {
         private const val SMP_HEADER_SIZE = 8
         private const val SMP_LENGTH_OFFSET = 2
 


### PR DESCRIPTION
Closes #332

Makes all DfuTransport implementations public so consumers can construct them directly for custom DFU flows:
- `GattDfuTransport` - standard Nordic DFU over GATT
- `L2capDfuTransport` - high-throughput L2CAP with GATT commands
- `SmpTransport` - MCUboot SMP with fragment reassembly
- `EspOtaTransport` - Espressif ESP-IDF OTA

Adds `DfuTransport` companion factory methods for convenience:
- `DfuTransport.gatt(peripheral)`
- `DfuTransport.l2cap(peripheral, channel)`
- `DfuTransport.smp(peripheral)`
- `DfuTransport.espOta(peripheral)`

Also makes utility functions (`DfuTransportUtil`) and `sendCommandExpectingDisconnect` extension public. Updates MODULE.md.