### PR TITLE
test(monitoring): add PowerMonitor and LePowerController edge case tests

### DIFF
--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
@@ -5,6 +5,7 @@ import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.ConnectionParameterUpdateResult
 import com.atruedev.kmpble.connection.ConnectionParameters
 import com.atruedev.kmpble.testing.FakePeripheralBuilder
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -303,6 +304,207 @@ class LePowerControllerTest {
             // After stop, requestPeerPowerChange still works - it's stateless
             val response = controller.requestPeerPowerChange(-4)
             assertTrue(response.accepted)
+        }
+    }
+
+    // -- Edge cases --
+
+    @Test
+    fun `boundary threshold minus5 uses balanced params`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-5)
+            // -5 < -4 so falls into balanced range
+            assertNotNull(capturedParams)
+            assertEquals(2, capturedParams!!.slaveLatency)
+            assertEquals(2000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun `boundary threshold minus13 uses power saving params`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-13)
+            // -13 < -12 so falls into low power range
+            assertNotNull(capturedParams)
+            assertEquals(4, capturedParams!!.slaveLatency)
+            assertEquals(4000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun `boundary threshold minus21 uses max saving params`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            var capturedParams: ConnectionParameters? = null
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { params ->
+                            capturedParams = params
+                            defaultResult
+                        }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            controller.requestPeerPowerChange(-21)
+            // -21 < -20 so falls into max saving range
+            assertNotNull(capturedParams)
+            assertEquals(7, capturedParams!!.slaveLatency)
+            assertEquals(6000.milliseconds, capturedParams!!.supervisionTimeout)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun `start stop start cycle restores monitoring`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { defaultResult }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            val first = controller.requestPeerPowerChange(-4)
+            assertTrue(first.accepted)
+
+            controller.stop()
+            controller.start()
+
+            val second = controller.requestPeerPowerChange(-10)
+            assertTrue(second.accepted)
+            assertEquals(-10, second.targetDbm)
+
+            controller.stop()
+        }
+    }
+
+    @Test
+    fun `stop without start is safe no op`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val controller = LePowerController(peripheral, CoroutineScope(dispatcher))
+
+        // Stop before start should not throw
+        controller.stop()
+    }
+
+    @Test
+    fun `request without start still works`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .apply {
+                        service("180d") {
+                            characteristic("2a37") { properties(notify = true) }
+                        }
+                        onConnectionParameterUpdate { defaultResult }
+                    }.build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            // requestPeerPowerChange is stateless - works without start
+            val response = controller.requestPeerPowerChange(-10)
+            assertTrue(response.accepted)
+            assertEquals(-10, response.targetDbm)
+        }
+    }
+
+    @Test
+    fun `request when not connected still works with default`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+
+            val controller = LePowerController(peripheral, backgroundScope)
+            controller.start()
+            scheduler.runCurrent()
+
+            // No connection established
+            // FakePeripheral.requestConnectionParameterUpdate returns default response
+            val response = controller.requestPeerPowerChange(-4)
+            assertNotNull(response)
         }
     }
 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/PowerMonitorTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/PowerMonitorTest.kt
@@ -166,4 +166,168 @@ class PowerMonitorTest {
         monitor.recordRssi(-55)
         assertEquals(0, monitor.pathLoss.value!!.pathLoss)
     }
+
+    // -- Edge cases --
+
+    @Test
+    fun `start stop start cycle restores monitoring`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            monitor.recordRssi(-50)
+            assertNotNull(monitor.pathLoss.value)
+
+            monitor.stop()
+            peripheral.disconnect()
+            scheduler.runCurrent()
+            // Reading persists after stop, even though collection stopped
+            assertNotNull(monitor.pathLoss.value)
+
+            // Restart
+            monitor.start()
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            monitor.recordRssi(-60)
+            assertEquals(60, monitor.pathLoss.value!!.pathLoss)
+
+            // Disconnect after restart clears reading
+            peripheral.disconnect()
+            scheduler.runCurrent()
+            assertNull(monitor.pathLoss.value)
+        }
+    }
+
+    @Test
+    fun `stop without start is safe no op`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher))
+
+        // Stop before start should not throw
+        monitor.stop()
+        assertNull(monitor.pathLoss.value)
+    }
+
+    @Test
+    fun `record before start still works`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher))
+
+        // Record before start - stateless operation, should work
+        monitor.recordRssi(-70)
+        assertNotNull(monitor.pathLoss.value)
+        assertEquals(70, monitor.pathLoss.value!!.pathLoss)
+    }
+
+    @Test
+    fun `extreme rssi max positive produces negative path loss`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher), txPower = 0)
+
+        // BLE RSSI max is typically near 0 (strong signal)
+        monitor.recordRssi(0)
+        val reading = monitor.pathLoss.value
+        assertNotNull(reading)
+        assertEquals(0, reading.pathLoss)
+        assertEquals(0, reading.rssi)
+        assertEquals(0, reading.txPower)
+    }
+
+    @Test
+    fun `extreme rssi max negative produces large path loss`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val peripheral =
+            FakePeripheralBuilder()
+                .observationDispatcher(dispatcher)
+                .build()
+        val monitor = PowerMonitor(peripheral, CoroutineScope(dispatcher), txPower = 0)
+
+        // BLE typical minimum is around -127 (extreme weak signal)
+        monitor.recordRssi(-127)
+        val reading = monitor.pathLoss.value
+        assertNotNull(reading)
+        assertEquals(127, reading.pathLoss)
+        assertEquals(-127, reading.rssi)
+        assertEquals(0, reading.txPower)
+    }
+
+    @Test
+    fun `multiple rapid rssi recordings last one wins`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+
+            // Rapid fire multiple readings
+            monitor.recordRssi(-40)
+            monitor.recordRssi(-50)
+            monitor.recordRssi(-60)
+
+            assertEquals(60, monitor.pathLoss.value!!.pathLoss)
+            assertEquals(-60, monitor.pathLoss.value!!.rssi)
+
+            peripheral.disconnect()
+            scheduler.runCurrent()
+        }
+    }
+
+    @Test
+    fun `close permanently stops collection`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        runTest(scheduler) {
+            val peripheral =
+                FakePeripheralBuilder()
+                    .observationDispatcher(dispatcher)
+                    .build()
+            val monitor = PowerMonitor(peripheral, backgroundScope)
+            monitor.start()
+
+            peripheral.connect(ConnectionOptions())
+            scheduler.runCurrent()
+            monitor.recordRssi(-45)
+            assertNotNull(monitor.pathLoss.value)
+
+            // Close the peripheral entirely
+            peripheral.close()
+            scheduler.runCurrent()
+
+            // Reading from the monitor still accessible (stateless record)
+            // but collection is stopped -- new disconnect should not cause issues
+            monitor.recordRssi(-75)
+            assertEquals(75, monitor.pathLoss.value!!.pathLoss)
+        }
+    }
 }


### PR DESCRIPTION
Closes #305

Adds edge case integration tests for PowerMonitor and LePowerController.

**PowerMonitor (7 tests):**
- start/stop/start cycle restores disconnect clearing
- stop without start is safe no-op
- record before start still works (stateless)
- extreme RSSI max positive (0 dBm)
- extreme RSSI max negative (-127 dBm)
- multiple rapid recordings (last one wins)
- close permanently stops collection

**LePowerController (7 tests):**
- boundary threshold -5 uses balanced params (between high and balanced)
- boundary threshold -13 uses power saving params (between balanced and low)
- boundary threshold -21 uses max saving params (between low and max)
- start/stop/start cycle restores monitoring
- stop without start is safe no-op
- request without start still works (stateless)
- request when not connected still works with default