### PR TITLE
fix(connection): add deprecated timeout constructor shim to ConnectionOptions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -174,6 +174,45 @@ AndroidGattCache no longer uses `synchronized`. If your code held a reference to
 the cache internals, the thread-safety mechanism has changed. Public API is
 unchanged.
 
+### 7. ConnectionOptions.timeout Replaced by timeouts: OperationTimeouts
+
+The single `timeout` parameter has been replaced by per-operation
+`OperationTimeouts` for fine-grained control over connect, service discovery,
+read, write, MTU, and L2CAP operation deadlines.
+
+A deprecated secondary constructor accepts the legacy `timeout` parameter and
+maps it to `timeouts.connect`, so existing call sites still compile with a
+warning. Migrate at your own pace.
+
+**Before (0.8.x):**
+
+```kotlin
+val options = ConnectionOptions(
+    timeout = 30.seconds,
+    mtuRequest = 512,
+)
+```
+
+**After (0.9.0):**
+
+```kotlin
+import com.atruedev.kmpble.connection.OperationTimeouts
+
+val options = ConnectionOptions(
+    timeouts = OperationTimeouts(
+        connect = 30.seconds,
+        serviceDiscovery = 15.seconds,
+        read = 5.seconds,
+        write = 5.seconds,
+    ),
+    mtuRequest = 512,
+)
+```
+
+All `OperationTimeouts` fields have sensible defaults (30s connect, 15s
+discovery, 5s read/write, 10s MTU/L2CAP). Omit any you do not need to
+customize.
+
 ## New Features
 
 ### PHY Selection for Scanning

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
@@ -61,6 +61,53 @@ public data class ConnectionOptions(
     }
 
     /**
+     * Backward-compatible constructor that maps the legacy [timeout] parameter
+     * to [timeouts.connect].
+     *
+     * @deprecated Use [timeouts] = [OperationTimeouts]`(connect = timeout)` instead.
+     */
+    @Deprecated(
+        message = "Use timeouts = OperationTimeouts(connect = timeout) instead",
+        replaceWith =
+            ReplaceWith(
+                "ConnectionOptions(" +
+                    "autoConnect = autoConnect, " +
+                    "timeouts = OperationTimeouts(connect = timeout), " +
+                    "transportType = transportType, " +
+                    "phyMask = phyMask, " +
+                    "mtuRequest = mtuRequest, " +
+                    "bondingPreference = bondingPreference, " +
+                    "reconnectionStrategy = reconnectionStrategy, " +
+                    "gattOperationTimeout = gattOperationTimeout, " +
+                    "pairingHandler = pairingHandler" +
+                    ")",
+            ),
+        level = DeprecationLevel.WARNING,
+    )
+    public constructor(
+        autoConnect: Boolean = false,
+        timeout: Duration = 30.seconds,
+        transportType: TransportType = TransportType.Auto,
+        phyMask: PhyMask = PhyMask.LE_1M,
+        mtuRequest: Int? = null,
+        bondingPreference: BondingPreference = BondingPreference.IfRequired,
+        reconnectionStrategy: ReconnectionStrategy = ReconnectionStrategy.None,
+        gattOperationTimeout: Duration = 10.seconds,
+        pairingHandler: PairingHandler? = null,
+    ) : this(
+        autoConnect = autoConnect,
+        timeouts = OperationTimeouts(connect = timeout),
+        transportType = transportType,
+        phyMask = phyMask,
+        mtuRequest = mtuRequest,
+        bondingPreference = bondingPreference,
+        reconnectionStrategy = reconnectionStrategy,
+        gattOperationTimeout = gattOperationTimeout,
+        pairingHandler = pairingHandler,
+        gattRetryPolicy = RetryPolicy.NONE,
+    )
+
+    /**
      * Validate this configuration and return a list of advisory warnings.
      *
      * Warnings highlight common misconfigurations that are technically


### PR DESCRIPTION
## Summary

v0.9.0 replaced `ConnectionOptions.timeout` with per-operation `timeouts: OperationTimeouts`, which is a good improvement but unnecessarily breaks all existing call sites that use `ConnectionOptions(timeout = ...)`.

## What this does

Adds a **deprecated secondary constructor** that accepts the legacy `timeout` parameter and maps it to `timeouts.connect`. Consumers on v0.8.x can upgrade to v0.9.0 **without compile errors** -- they get a deprecation warning with an auto-applicable `ReplaceWith` hint to migrate at their own pace.

Also adds section 7 to `MIGRATION.md` documenting the migration path.

## Before / After

```kotlin
// v0.8.x -- still compiles on v0.9.0 (with deprecation warning)
ConnectionOptions(timeout = 30.seconds)

// v0.9.0 -- IDE auto-suggests this migration
ConnectionOptions(timeouts = OperationTimeouts(connect = 30.seconds))
```