### PR TITLE
fix(ci): update Package.swift via PR instead of direct push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,36 +67,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Package.swift
+      - name: Upload Package.swift checksum artifact
         run: |
           VERSION=${{ github.ref_name }}
           CHECKSUM=$(swift package compute-checksum build/XCFrameworks/release/KmpBle.xcframework.zip)
-          git fetch origin main
-          git checkout main
-          cat > Package.swift << SWIFT
-          // swift-tools-version:5.9
-          import PackageDescription
+          echo "VERSION=$VERSION" > package-checksum.txt
+          echo "CHECKSUM=$CHECKSUM" >> package-checksum.txt
 
-          let package = Package(
-              name: "KmpBle",
-              platforms: [.iOS(.v15)],
-              products: [
-                  .library(name: "KmpBle", targets: ["KmpBle"]),
-              ],
-              targets: [
-                  .binaryTarget(
-                      name: "KmpBle",
-                      url: "https://github.com/gary-quinn/kmp-ble/releases/download/${VERSION}/KmpBle.xcframework.zip",
-                      checksum: "${CHECKSUM}"
-                  ),
-              ]
-          )
-          SWIFT
-          git config user.email "gary@atruedev.com"
-          git config user.name "Gary Quinn"
-          git add Package.swift
-          git diff --cached --quiet || git commit -m "update Package.swift for ${VERSION}"
-          git push origin main
+      - uses: actions/upload-artifact@eaeb399d4867acaad5ec458c095db6bc2c22c9e3 # v7.0.1
+        with:
+          name: package-checksum
+          path: package-checksum.txt
 
   deploy-api-docs:
     needs: publish
@@ -136,6 +117,40 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Download Package.swift checksum
+        uses: actions/download-artifact@5eb6532fd2b9a88089ae413748ffc7c2e85a3258 # v6.0.0
+        with:
+          name: package-checksum
+
+      - name: Read checksum
+        id: pkg
+        run: |
+          cat package-checksum.txt >> $GITHUB_OUTPUT
+
+      - name: Update Package.swift
+        run: |
+          VERSION="${{ steps.pkg.outputs.VERSION }}"
+          CHECKSUM="${{ steps.pkg.outputs.CHECKSUM }}"
+          cat > Package.swift << SWIFT
+          // swift-tools-version:5.9
+          import PackageDescription
+
+          let package = Package(
+              name: "KmpBle",
+              platforms: [.iOS(.v15)],
+              products: [
+                  .library(name: "KmpBle", targets: ["KmpBle"]),
+              ],
+              targets: [
+                  .binaryTarget(
+                      name: "KmpBle",
+                      url: "https://github.com/gary-quinn/kmp-ble/releases/download/${VERSION}/KmpBle.xcframework.zip",
+                      checksum: "${CHECKSUM}"
+                  ),
+              ]
+          )
+          SWIFT
 
       - name: Get release metadata
         id: meta
@@ -216,6 +231,7 @@ jobs:
             - `README.md` - dependency version
             - `CHANGELOG.md` - auto-generated entries from merged PRs
             - `llms.txt` - dependency version
+            - `Package.swift` - XCFramework checksum
 
             Release: ${{ needs.publish.outputs.release_url }}
           branch: update-docs-${{ needs.publish.outputs.version }}


### PR DESCRIPTION
## Problem

Every release fails at the "Update Package.swift" step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The publish workflow was computing the XCFramework checksum then trying to `git push origin main` directly, but `main` requires PRs.

## Fix

Move the `Package.swift` update into the `update-docs` job, which already has the PR creation + auto-merge flow using `AUTO_MERGE_PAT` that bypasses branch protection:

1. **publish job**: Uploads `VERSION` + `CHECKSUM` as a workflow artifact instead of pushing
2. **update-docs job**: Downloads the artifact, regenerates `Package.swift`, then includes it in the existing docs-update PR

No new permissions or secrets needed -- reuses the existing `create-pull-request` + `gh pr merge` flow.