### PR TITLE
docs: update README and llms.txt for v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Kotlin Multiplatform BLE library for Android and iOS.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("com.atruedev:kmp-ble:0.8.5")
+            implementation("com.atruedev:kmp-ble:0.9.0")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.5")
-            implementation("com.atruedev:kmp-ble-dfu:0.8.5")
-            implementation("com.atruedev:kmp-ble-codec:0.8.5")
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")
+            implementation("com.atruedev:kmp-ble-profiles:0.9.0")
+            implementation("com.atruedev:kmp-ble-dfu:0.9.0")
+            implementation("com.atruedev:kmp-ble-codec:0.9.0")
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.9.0")
         }
     }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -16,14 +16,14 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Core - scan, connect, GATT client/server, advertise, L2CAP
-            implementation("com.atruedev:kmp-ble:0.8.5")
+            implementation("com.atruedev:kmp-ble:0.9.0")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.5")  // type-safe GATT profiles
-            implementation("com.atruedev:kmp-ble-dfu:0.8.5")       // Nordic DFU firmware updates
-            implementation("com.atruedev:kmp-ble-codec:0.8.5")     // typed read/write codec
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")  // CBOR via kotlinx-serialization
-            implementation("com.atruedev:kmp-ble-quirks:0.8.5")    // OEM device workarounds
+            implementation("com.atruedev:kmp-ble-profiles:0.9.0")  // type-safe GATT profiles
+            implementation("com.atruedev:kmp-ble-dfu:0.9.0")       // Nordic DFU firmware updates
+            implementation("com.atruedev:kmp-ble-codec:0.9.0")     // typed read/write codec
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.9.0")  // CBOR via kotlinx-serialization
+            implementation("com.atruedev:kmp-ble-quirks:0.9.0")    // OEM device workarounds
         }
     }
 }


### PR DESCRIPTION
Bump all dependency version strings from `0.8.5` to `0.9.0`.

**Files:**
- `README.md` - Gradle dependency versions
- `llms.txt` - Gradle dependency versions