### PR TITLE
test(peripheral): add platform smoke tests for dataLengthParameters (#428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Kotlin Multiplatform BLE library for Android and iOS.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("com.atruedev:kmp-ble:0.8.5")
+            implementation("com.atruedev:kmp-ble:0.9.0")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.5")
-            implementation("com.atruedev:kmp-ble-dfu:0.8.5")
-            implementation("com.atruedev:kmp-ble-codec:0.8.5")
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")
+            implementation("com.atruedev:kmp-ble-profiles:0.9.0")
+            implementation("com.atruedev:kmp-ble-dfu:0.9.0")
+            implementation("com.atruedev:kmp-ble-codec:0.9.0")
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.9.0")
         }
     }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -16,14 +16,14 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Core - scan, connect, GATT client/server, advertise, L2CAP
-            implementation("com.atruedev:kmp-ble:0.8.5")
+            implementation("com.atruedev:kmp-ble:0.9.0")
 
             // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.8.5")  // type-safe GATT profiles
-            implementation("com.atruedev:kmp-ble-dfu:0.8.5")       // Nordic DFU firmware updates
-            implementation("com.atruedev:kmp-ble-codec:0.8.5")     // typed read/write codec
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.8.5")  // CBOR via kotlinx-serialization
-            implementation("com.atruedev:kmp-ble-quirks:0.8.5")    // OEM device workarounds
+            implementation("com.atruedev:kmp-ble-profiles:0.9.0")  // type-safe GATT profiles
+            implementation("com.atruedev:kmp-ble-dfu:0.9.0")       // Nordic DFU firmware updates
+            implementation("com.atruedev:kmp-ble-codec:0.9.0")     // typed read/write codec
+            implementation("com.atruedev:kmp-ble-codec-serialization:0.9.0")  // CBOR via kotlinx-serialization
+            implementation("com.atruedev:kmp-ble-quirks:0.9.0")    // OEM device workarounds
         }
     }
 }

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralDataLengthSmokeTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralDataLengthSmokeTest.kt
@@ -1,0 +1,51 @@
+package com.atruedev.kmpble.peripheral
+
+import android.content.Context
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowBluetoothDevice
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Smoke test that verifies AndroidPeripheral exposes [Peripheral.dataLengthParameters]
+ * through the same flow instance as its internal PeripheralContext.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AndroidPeripheralDataLengthSmokeTest {
+    private lateinit var appContext: Context
+    private lateinit var shadowDevice: ShadowBluetoothDevice
+
+    @Before
+    fun setup() {
+        appContext = RuntimeEnvironment.getApplication()
+        shadowDevice = ShadowBluetoothDevice.newInstance("00:11:22:33:44:55")
+    }
+
+    @Test
+    fun androidPeripheral_exposes_dataLengthParameters_as_StateFlow() {
+        val peripheral = AndroidPeripheral(shadowDevice.device, appContext)
+        val flow = peripheral.dataLengthParameters
+
+        assertNotNull(flow, "AndroidPeripheral.dataLengthParameters must not be null")
+        assertEquals(null, flow.value, "Default data length parameters should be null")
+        peripheral.close()
+    }
+
+    @Test
+    fun androidPeripheral_dataLengthParameters_backed_by_PeripheralContext() {
+        val peripheral = AndroidPeripheral(shadowDevice.device, appContext)
+        val contextFlow = peripheral.peripheralContext.dataLengthParameters
+        val peripheralFlow = peripheral.dataLengthParameters
+
+        assertTrue(
+            contextFlow === peripheralFlow,
+            "AndroidPeripheral.dataLengthParameters must be the same flow instance as PeripheralContext.dataLengthParameters",
+        )
+        peripheral.close()
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralDataLengthSmokeTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralDataLengthSmokeTest.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.peripheral
 
+import android.bluetooth.BluetoothDevice
 import android.content.Context
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -18,17 +19,17 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 class AndroidPeripheralDataLengthSmokeTest {
     private lateinit var appContext: Context
-    private lateinit var shadowDevice: ShadowBluetoothDevice
+    private lateinit var bluetoothDevice: BluetoothDevice
 
     @Before
     fun setup() {
         appContext = RuntimeEnvironment.getApplication()
-        shadowDevice = ShadowBluetoothDevice.newInstance("00:11:22:33:44:55")
+        bluetoothDevice = ShadowBluetoothDevice.newInstance("00:11:22:33:44:55")
     }
 
     @Test
     fun androidPeripheral_exposes_dataLengthParameters_as_StateFlow() {
-        val peripheral = AndroidPeripheral(shadowDevice.device, appContext)
+        val peripheral = AndroidPeripheral(bluetoothDevice, appContext)
         val flow = peripheral.dataLengthParameters
 
         assertNotNull(flow, "AndroidPeripheral.dataLengthParameters must not be null")
@@ -38,7 +39,7 @@ class AndroidPeripheralDataLengthSmokeTest {
 
     @Test
     fun androidPeripheral_dataLengthParameters_backed_by_PeripheralContext() {
-        val peripheral = AndroidPeripheral(shadowDevice.device, appContext)
+        val peripheral = AndroidPeripheral(bluetoothDevice, appContext)
         val contextFlow = peripheral.peripheralContext.dataLengthParameters
         val peripheralFlow = peripheral.dataLengthParameters
 

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/peripheral/PeripheralContextDataLengthSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/peripheral/PeripheralContextDataLengthSmokeTest.kt
@@ -1,0 +1,59 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.DataLengthParameters
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Smoke test that verifies FakePeripheral (the common testing double used
+ * to simulate both Android and iOS behavior) correctly exposes
+ * Peripheral.dataLengthParameters through the same flow instance that
+ * PeripheralContext owns.
+ *
+ * Both AndroidPeripheral and IosPeripheral follow the same pattern:
+ * delegating to PeripheralContext.dataLengthParameters.
+ */
+class PeripheralContextDataLengthSmokeTest {
+    @Test
+    fun `PeripheralContext owns dataLengthParameters flow`() =
+        runTest {
+            val peripheral = FakePeripheral { }
+            val context = peripheral.peripheralContext
+            val flow = peripheral.dataLengthParameters
+
+            assertNotNull(flow, "Peripheral.dataLengthParameters must not be null")
+            assertEquals(null, flow.value, "Default data length parameters should be null")
+            assertTrue(
+                context.dataLengthParameters === flow,
+                "PeripheralContext.dataLengthParameters must be the same flow instance",
+            )
+            peripheral.close()
+        }
+
+    @Test
+    fun dataLengthParameters_flow_type_is_StateFlow() =
+        runTest {
+            val peripheral = FakePeripheral { }
+            assertTrue(
+                peripheral.dataLengthParameters is StateFlow<DataLengthParameters?>,
+                "dataLengthParameters must be a StateFlow<DataLengthParameters?>",
+            )
+            peripheral.close()
+        }
+
+    @Test
+    fun dataLengthParameters_reflects_context_update() =
+        runTest {
+            val expected = DataLengthParameters(251, 2120, 251, 2120)
+            val peripheral = FakePeripheral { onDataLengthParameters(expected) }
+
+            assertEquals(expected, peripheral.dataLengthParameters.value)
+            assertEquals(expected, peripheral.peripheralContext.dataLengthParameters.value)
+            peripheral.close()
+        }
+}


### PR DESCRIPTION
Closes #428