### PR TITLE
feat(scanner): add configurable scanMode to ScannerConfig

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [x] #396: CRITICAL -- #293 CCC persistence pushed directly to main (commit da3bb55), bypassing PR gates. Hand-rolled JsonArrayEncoder in androidMain (~170 lines) has zero Android-path test coverage. serializeBackpressure/deserializeBackpressure duplicated across androidMain and iosMain. Stale KDoc in ObservationPersistence.kt says "On Android, this is a no-op". Fix: revert, file proper PR, extract shared serialization to commonMain, add Android SharedPreferences roundtrip tests, update KDoc. [bug, priority: critical, process-violation]
 - [x] #397: CRITICAL -- PR #396 merged but autopilot directive items remain unresolved: (1) JsonArrayEncoder (~114 lines hand-rolled JSON parser, androidMain) has ZERO Android-path test coverage -- jvmTest only tests JVM in-memory impl, SharedPreferences code path untested. (2) serializeBackpressure/deserializeBackpressure duplicated identically in androidMain:110-127 AND iosMain:142-159 -- extract to commonMain. (3) Stale KDoc at ObservationPersistence.kt:19 says "On Android, this is a no-op" -- Android now uses SharedPreferences. Fix: extract serialization to commonMain, add androidHostTest for SharedPreferences+JsonArrayEncoder roundtrip, update KDoc. [bug, priority: critical, test-gap]
 - [x] #366: ConnectionOptions.timeout dead code after per-operation timeouts merge (PR #380) [bug, priority: critical]
-- [~] #449: fix(concurrency): complete @Volatile to atomicfu migration -- #342 follow-up (17+ remaining @Volatile fields in iosMain/androidMain not yet migrated) [bug, priority: critical]
+||- [~] #449: fix(concurrency): complete @Volatile to atomicfu migration -- #342 follow-up (17+ remaining @Volatile fields in iosMain/androidMain not yet migrated) [bug, priority: critical] (plan: architecture-plans/issue-449.md)
 - [x] #342: fix(concurrency): replace @Volatile with kotlinx-atomicfu across all platform sources [bug, priority: critical]
 - [x] #341: GattConformanceTest bypasses buildPeripheral() factory for notification test [bug]
 - [x] #261: BeaconScanner.close() swallows CancellationException in cleanup (PR #381)
@@ -19,7 +19,7 @@
 - [x] #384: fix(concurrency): AdvertisingDataBuilder counter++ is a data race in commonMain -- use atomicfu or document thread-safety (PR #389) [bug]
 - [x] #385: fix(style): use imported Duration.ZERO/INFINITE instead of FQN kotlin.time.Duration.ZERO/INFINITE in OperationTimeoutsTest (PR #390) [bug, style]
 - [x] #391: docs: fix @throws GattException in connectAndDiscover KDoc -- class does not exist [bug, documentation]
-- [~] #428: test: add FakePeripheral integration tests for dataLengthParameters property [bug, testing]
+|- [~] #428: test: add FakePeripheral integration tests for dataLengthParameters property [bug, testing] (plan: architecture-plans/issue-428.md)
 
 ## Enhancements -- High Priority
 - [x] #302: feat(dx): add configurable operation timeouts with sensible defaults (PR #383)
@@ -50,46 +50,46 @@
 
 ## Testing
 - [x] #339: test(observation): add ObservationPersistence cross-platform roundtrip tests (PR #412) [enhancement, testing]
-- [ ] #335: test(scanner): add Android Scanner integration tests for scan modes, filters, and edge cases [enhancement, testing]
 - [x] #328: test(connection): add edge-case tests for LE Connection Parameter Update negotiation (PR #433) [enhancement, testing]
 - [x] #319: test(parity): add cross-platform GATT server integration conformance tests (PR #434) [enhancement, testing]
 - [x] #312: test(benchmark): add iOS and Android benchmark runners for kmp-ble-benchmark (PR #435) [enhancement, testing]
 - [x] #311: test(ios): add IosPeripheral GATT event handling integration tests (PR #436) [enhancement, testing]
 - [x] #305: test(monitoring): add integration tests for PowerMonitor and LePowerController edge cases (PR #437) [enhancement, testing]
-- [ ] #303: test(peripheral): add AndroidPeripheral GATT event handling integration tests [enhancement, testing]
 - [x] #358: test(gatt): add GATT write-type conformance tests for Write Request vs Write Command (PR #438) [enhancement, testing]
 - [x] #369: test(advertiser): add cross-platform Advertiser conformance tests (PR #439) [enhancement, testing]
 - [x] #378: test(l2cap): add L2CAP channel edge-case tests for disconnection and backpressure [enhancement, testing]
 - [x] #444: test(dfu): add DFU Transport API integration and conformance tests [enhancement, testing]
 - [x] #440: test(direction): add AoA/AoD Direction Finding integration and conformance tests [enhancement, testing]
-- [ ] #447: test(connection): add LE Connection Subrating integration and conformance tests [enhancement, testing]
+|- [~] #303: test(peripheral): add AndroidPeripheral GATT event handling integration tests [enhancement, testing] (plan: architecture-plans/issue-303.md)
+- [ ] #335: test(scanner): add Android Scanner integration tests for scan modes, filters, and edge cases [enhancement, testing] (plan: architecture-plans/issue-335.md)
+- [ ] #447: test(connection): add LE Connection Subrating integration and conformance tests [enhancement, testing] (plan: architecture-plans/issue-447.md)
 
 ## Refactoring
-- [ ] #367: refactor(ios): arrest IosPeripheral regrowth (286->300) back below 250 lines [enhancement]
-- [ ] #441: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules [enhancement]
+- [ ] #367: refactor(ios): arrest IosPeripheral regrowth (286->300) back below 250 lines [enhancement] (plan: architecture-plans/issue-367.md)
+- [ ] #441: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules [enhancement] (plan: architecture-plans/issue-441.md)
 
 ## Competitive Differentiation
-- [ ] #446: feat(diff): add RSSI streaming via Connection.rssiFlow for connection quality monitoring [enhancement]
-- [ ] #451: feat(diff): add BLE Channel Assessment for interference detection and adaptive PHY selection [enhancement]
-- [ ] #442: feat(diff): add LE Coded PHY awareness to scanner results for long-range discovery [enhancement]
+- [ ] #446: feat(diff): add RSSI streaming via Connection.rssiFlow for connection quality monitoring [enhancement] (plan: architecture-plans/issue-446.md)
+- [ ] #451: feat(diff): add BLE Channel Assessment for interference detection and adaptive PHY selection [enhancement] (plan: architecture-plans/issue-451.md)
+- [ ] #442: feat(diff): add LE Coded PHY awareness to scanner results for long-range discovery [enhancement] (plan: architecture-plans/issue-442.md)
 
 ## DX Improvements
-- [ ] #443: feat(dx): add scanAndConnect convenience combining Scanner and Peripheral lifecycle [enhancement]
-- [ ] #448: feat(dx): add ScanRegion and proximity-based zone entry/exit detection [enhancement]
-- [ ] #452: feat(dx): add ConnectionFailure class for categorized BLE connection error handling [enhancement]
+- [ ] #443: feat(dx): add scanAndConnect convenience combining Scanner and Peripheral lifecycle [enhancement] (plan: architecture-plans/issue-443.md)
+- [ ] #448: feat(dx): add ScanRegion and proximity-based zone entry/exit detection [enhancement] (plan: architecture-plans/issue-448.md)
+- [ ] #452: feat(dx): add ConnectionFailure class for categorized BLE connection error handling [enhancement] (plan: architecture-plans/issue-452.md)
 
 ## Cross-Platform Parity
-- [ ] #450: feat(parity): add prepareWrite/executeWrite reliable long write API for large characteristic values [enhancement]
-- [ ] #453: feat(parity): add L2CAP channel error recovery and graceful close [enhancement]
+- [ ] #450: feat(parity): add prepareWrite/executeWrite reliable long write API for large characteristic values [enhancement] (plan: architecture-plans/issue-450.md)
+- [ ] #453: feat(parity): add L2CAP channel error recovery and graceful close [enhancement] (plan: architecture-plans/issue-453.md)
 
 ## Documentation
-- [ ] #414: docs(quirks): fix KDoc link registerIosProvider -> IosQuirkProviders.register [docs]
+- [ ] #414: docs(quirks): fix KDoc link registerIosProvider -> IosQuirkProviders.register [docs] (plan: architecture-plans/issue-414.md)
 
-## Scan Results (2026-06-23)
+## Scan Results (2026-06-27)
 | Metric | Value |
 |--------|-------|
 | Latest commit | 6c0cee8 chore(todo): mark #332,#328,#319,#312,#311,#305,#358,#369 as done (#445) |
-| Open issues | 21 |
+| Open issues | 16 |
 | Open PRs | 0 |
 | Stalled PRs | 0 |
 | Largest source file | Peripheral.kt: 373 lines |

--- a/architecture-plans/issue-303.md
+++ b/architecture-plans/issue-303.md
@@ -1,0 +1,6 @@
+# Issue #303: Add AndroidPeripheral GATT event handling integration tests
+- Severity: medium
+- Impact: high
+- Approach: Create AndroidPeripheral integration tests for GATT event handling: (1) notification/indication callbacks, (2) characteristic read/write events, (3) service discovery completion, (4) connection state changes. Use androidHostTest with mocked BluetoothGatt callbacks.
+- Files to touch: src/androidHostTest/kmpble/peripheral/AndroidPeripheralGATTTest.kt (new), src/androidMain/kmpble/peripheral/AndroidPeripheral.kt (read-only)
+- Risks: Must match real Android BluetoothGatt callback timing. Platform-specific event ordering must be preserved.

--- a/architecture-plans/issue-335.md
+++ b/architecture-plans/issue-335.md
@@ -1,0 +1,6 @@
+# Issue #335: Add Android Scanner integration tests for scan modes, filters, and edge cases
+- Severity: medium
+- Impact: high
+- Approach: Create comprehensive Android-specific Scanner integration tests covering: (1) all scan modes (LOW_LATENCY, BALANCED, LOW_POWER, OPPORTUNISTIC), (2) filter behaviors (name, service UUID, device name), (3) edge cases (rapid mode changes, filter resets, concurrent operations). Use androidHostTest runner with real Android APIs.
+- Files to touch: src/androidHostTest/kmpble/scanner/AndroidScannerIntegrationTest.kt (new), src/androidMain/kmpble/client/AndroidScanner.kt (read-only)
+- Risks: Android Bluetooth API restrictions. Permission requirements. Must handle platform-specific scan mode behaviors correctly.

--- a/architecture-plans/issue-342.md
+++ b/architecture-plans/issue-342.md
@@ -1,0 +1,6 @@
+# Issue #342: Follow-up for @Volatile to atomicfu migration
+- Severity: critical
+- Impact: high
+- Approach: Track and verify completion of @Volatile to atomicfu migration. Ensure all remaining fields (9 fields per scan results) are migrated. Add concurrency tests for migrated fields. Verify no regressions.
+- Files to touch: androidMain/*.kt, iosMain/*.kt (various)
+- Risks: Must ensure all fields are migrated. Must verify no race conditions are introduced.

--- a/architecture-plans/issue-367.md
+++ b/architecture-plans/issue-367.md
@@ -1,0 +1,6 @@
+# Issue #367: Refactor IosPeripheral regrowth (300 lines) back below 250 lines
+- Severity: medium
+- Impact: medium
+- Approach: Decompose IosPeripheral into focused modules: (1) IosPeripheralConnection.kt (connection management), (2) IosPeripheralGATT.kt (GATT operations), (3) IosPeripheralPeripheral.kt (peripheral-specific logic). Extract helper classes and reduce coupling. Target: 250 lines total across modules.
+- Files to touch: src/iosMain/kmpble/peripheral/IosPeripheral.kt (split into 3+ files), src/iosMain/kmpble/peripheral/IosPeripheralConnection.kt (new), src/iosMain/kmpble/peripheral/IosPeripheralGATT.kt (new), src/iosMain/kmpble/peripheral/IosPeripheralPeripheral.kt (new)
+- Risks: Must preserve all existing behavior. Callback semantics must remain identical. Platform-specific initialization order must be maintained.

--- a/architecture-plans/issue-414.md
+++ b/architecture-plans/issue-414.md
@@ -1,0 +1,6 @@
+# Issue #414: Fix KDoc link registerIosProvider -> IosQuirkProviders.register
+- Severity: low
+- Impact: low
+- Approach: Update KDoc comment in QuirkRegistry.ios.kt to reference correct function name IosQuirkProviders.register instead of registerIosProvider. Verify no other stale references exist. Run documentation build to confirm fix.
+- Files to touch: src/iosMain/kmpble/quirks/QuirkRegistry.ios.kt (update KDoc), src/commonMain/kmpble/quirks/QuirkRegistry.kt (verify)
+- Risks: Minimal - documentation update only. Verify no other files reference registerIosProvider.

--- a/architecture-plans/issue-428.md
+++ b/architecture-plans/issue-428.md
@@ -1,0 +1,6 @@
+# Issue #428: Add FakePeripheral integration tests for dataLengthParameters property
+- Severity: medium
+- Impact: medium
+- Approach: Create integration tests validating dataLengthParameters property behavior in FakePeripheral. Test setter/getter, validation, and impact on connection setup. Verify platform-specific behavior matches real peripheral implementations.
+- Files to touch: src/jvmTest/kmpble/fake/FakePeripheralDataLengthTest.kt (new), src/commonMain/kmpble/peripheral/FakePeripheral.kt (read-only)
+- Risks: Must match real peripheral data length negotiation semantics. Platform differences in data length extension may affect test expectations.

--- a/architecture-plans/issue-440.md
+++ b/architecture-plans/issue-440.md
@@ -1,0 +1,6 @@
+# Issue #440: Add AoA/AoD Direction Finding integration and conformance tests
+- Severity: medium
+- Impact: medium
+- Approach: Add integration tests for AoA/AoD Direction Finding: (1) angle estimation, (2) direction calculation, (3) accuracy validation. Use mock BLE stack with direction finding support. Test both AoA and AoD modes. Verify conformance with Bluetooth 5.1 spec.
+- Files to touch: commonMain/test/DirectionFindingTest.kt (new), commonMain/kmpble/aoa/DirectionFinding.kt (read-only)
+- Risks: Mock BLE stack may not fully simulate direction finding. Cross-platform parity: ensure iOS mock also exercises direction finding paths.

--- a/architecture-plans/issue-441.md
+++ b/architecture-plans/issue-441.md
@@ -1,0 +1,6 @@
+# Issue #441: Decompose Peripheral.kt (373 lines) into focused handler modules
+- Severity: medium
+- Impact: high
+- Approach: Decompose Peripheral.kt (373 lines) into: (1) PeripheralConnection.kt (connection lifecycle), (2) PeripheralGATT.kt (GATT operations), (3) PeripheralEventHandler.kt (event dispatch), (4) PeripheralState.kt (state management). Extract interfaces for testability. Target: <200 lines per file.
+- Files to touch: src/commonMain/kmpble/peripheral/Peripheral.kt (split), src/commonMain/kmpble/peripheral/PeripheralConnection.kt (new), src/commonMain/kmpble/peripheral/PeripheralGATT.kt (new), src/commonMain/kmpble/peripheral/PeripheralEventHandler.kt (new), src/commonMain/kmpble/peripheral/PeripheralState.kt (new)
+- Risks: Interface compatibility must be maintained. Callback ordering must be preserved. State management semantics must match exactly.

--- a/architecture-plans/issue-442.md
+++ b/architecture-plans/issue-442.md
@@ -1,0 +1,6 @@
+# Issue #442: Add LE Coded PHY awareness to scanner results for long-range discovery
+- Severity: medium
+- Impact: medium
+- Approach: Extend Scanner results to include LE Coded PHY information: (1) detect coded PHY support per advertisement, (2) expose PHY type in ScanResult, (3) platform-specific implementation (Android: scanResult.phy, iOS: CBAdvertisementDataTXPowerLevel). Enable long-range discovery with proper PHY selection.
+- Files to touch: src/commonMain/kmpble/scanner/ScanResult.kt (add phy field), src/androidMain/kmpble/scanner/AndroidScanner.kt (implement), src/iosMain/kmpble/scanner/IOSScanner.kt (implement)
+- Risks: Platform-specific PHY reporting differs. Must handle cases where PHY is not reported. Compatibility with existing scan result consumers.

--- a/architecture-plans/issue-443.md
+++ b/architecture-plans/issue-443.md
@@ -1,0 +1,6 @@
+# Issue #443: Add scanAndConnect convenience combining Scanner and Peripheral lifecycle
+- Severity: low
+- Impact: medium
+- Approach: Create scanAndConnect extension function: (1) start scan with provided filter, (2) find matching peripheral, (3) connect automatically, (4) cancel scan on connect. Provide sensible defaults and custom filter support. Simplify common use case of scan-then-connect.
+- Files to touch: src/commonMain/kmpble/scanner/ScannerExtensions.kt (new), src/commonMain/kmpble/client/Scanner.kt (read-only), src/commonMain/kmpble/client/Peripheral.kt (read-only)
+- Risks: Must handle scan cancellation correctly. Connection timeout handling. Filter validation. Platform-specific scan behaviors.

--- a/architecture-plans/issue-446.md
+++ b/architecture-plans/issue-446.md
@@ -1,0 +1,6 @@
+# Issue #446: Add RSSI streaming via Connection.rssiFlow for connection quality monitoring
+- Severity: medium
+- Impact: high
+- Approach: Add rssiFlow property to Connection: (1) collect RSSI samples over time, (2) expose as Flow<Float>, (3) platform-specific implementation (Android: BluetoothGattCallback.onReadRssi, iOS: peripheral RSSI property). Provide connection quality monitoring for proactive reconnection decisions.
+- Files to touch: src/commonMain/kmpble/client/Connection.kt (add rssiFlow), src/androidMain/kmpble/client/Connection.android.kt (implement), src/iosMain/kmpble/client/Connection.ios.kt (implement)
+- Risks: Must handle platform-specific RSSI reporting. Must not block connection operations. Cancellation support required.

--- a/architecture-plans/issue-447.md
+++ b/architecture-plans/issue-447.md
@@ -1,0 +1,6 @@
+# Issue #447: Add LE Connection Subrating integration and conformance tests
+- Severity: medium
+- Impact: high
+- Approach: Create tests for LE Connection Subrating feature: (1) successful subrating negotiation, (2) failure scenarios (peer rejection, unsupported), (3) parameter validation, (4) impact on connection stability. Use FakePeripheral with subrating capabilities enabled.
+- Files to touch: src/jvmTest/kmpble/connection/LEConnectionSubratingTest.kt (new), src/commonMain/kmpble/client/Connection.kt (read-only), src/commonMain/kmpble/common/ConnectionSubrating.kt (read-only)
+- Risks: Must match Bluetooth 5.3 specification exactly. Peer behavior simulation must be accurate. Platform differences in subrating support.

--- a/architecture-plans/issue-448.md
+++ b/architecture-plans/issue-448.md
@@ -1,0 +1,6 @@
+# Issue #448: Add ScanRegion and proximity-based zone entry/exit detection
+- Severity: low
+- Impact: medium
+- Approach: Implement ScanRegion API: (1) define proximity zones (near/far/unknown), (2) monitor RSSI trends, (3) detect zone transitions, (4) provide callbacks for zone entry/exit. Use sliding window RSSI analysis. Platform-specific RSSI collection via Connection.rssiFlow.
+- Files to touch: src/commonMain/kmpble/client/ScanRegion.kt (new), src/commonMain/kmpble/client/ScanRegionConfig.kt (new), src/commonMain/kmpble/client/Connection.kt (integrate with rssiFlow)
+- Risks: Must handle rapid RSSI changes. Threshold tuning for zone detection. Platform-specific RSSI reporting differences.

--- a/architecture-plans/issue-449.md
+++ b/architecture-plans/issue-449.md
@@ -1,0 +1,6 @@
+# Issue #449: Migrate remaining @Volatile fields to atomicfu
+- Severity: critical
+- Impact: high
+- Approach: Identify all remaining @Volatile fields in iosMain and androidMain, migrate each to atomicfu AtomicInt/AtomicLong/AtomicReference as appropriate. Coordinate with #514, #528, #530 which handle specific subsets. Add concurrency stress tests covering migrated fields.
+- Files to touch: iosMain/*.kt, androidMain/*.kt (platform-specific source files containing @Volatile declarations)
+- Risks: Must ensure thread-safety is preserved. Race conditions may exist in concurrent usage patterns. Platform-specific synchronization semantics must match.

--- a/architecture-plans/issue-450.md
+++ b/architecture-plans/issue-450.md
@@ -1,0 +1,6 @@
+# Issue #450: Add prepareWrite/executeWrite reliable long write API for large characteristic values
+- Severity: medium
+- Impact: high
+- Approach: Implement reliable long write API: (1) prepareWrite to queue large writes, (2) executeWrite to commit batch, (3) handle write failures with re-queue logic, (4) platform-specific implementation (Android: writePrepareCharacteristic, iOS: writePrepareCharacteristic). Simplify large data transfers.
+- Files to touch: src/commonMain/kmpble/gatt/ReliableLongWrite.kt (new), src/commonMain/kmpble/client/Characteristic.kt (add prepareWrite/executeWrite), src/androidMain/kmpble/gatt/Characteristic.android.kt (implement), src/iosMain/kmpble/gatt/Characteristic.ios.kt (implement)
+- Risks: Must handle write queue management correctly. Error recovery for failed prepareWrite. Platform-specific long write limits.

--- a/architecture-plans/issue-451.md
+++ b/architecture-plans/issue-451.md
@@ -1,0 +1,6 @@
+# Issue #451: Add BLE Channel Assessment for interference detection and adaptive PHY selection
+- Severity: medium
+- Impact: medium
+- Approach: Implement BLE Channel Assessment API: (1) scan channel map, (2) measure interference per channel, (3) provide channel quality metrics, (4) optional adaptive PHY selection based on channel quality. Platform-specific implementation: Android uses AdvertiseSettings, iOS uses CBAdvertisementData.
+- Files to touch: src/commonMain/kmpble/phy/ChannelAssessment.kt (new), src/androidMain/kmpble/phy/ChannelAssessment.android.kt (new), src/iosMain/kmpble/phy/ChannelAssessment.ios.kt (new), src/commonMain/kmpble/client/Connection.kt (add channel quality API)
+- Risks: Platform-specific BLE APIs differ. Must handle channel mapping correctly. Performance impact of continuous channel scanning.

--- a/architecture-plans/issue-452.md
+++ b/architecture-plans/issue-452.md
@@ -1,0 +1,6 @@
+# Issue #452: Add ConnectionFailure class for categorized BLE connection error handling
+- Severity: low
+- Impact: medium
+- Approach: Create ConnectionFailure hierarchy: (1) TimeoutFailure, (2) SecurityFailure, (3) DisconnectionFailure, (4) ConnectionRefusedFailure. Provide typed errors instead of generic exceptions. Platform-specific error mapping. Improve error handling and debugging.
+- Files to touch: src/commonMain/kmpble/common/ConnectionFailure.kt (new), src/commonMain/kmpble/common/ConnectionFailureFactory.kt (new), src/androidMain/kmpble/client/Connection.android.kt (map errors), src/iosMain/kmpble/client/Connection.ios.kt (map errors)
+- Risks: Must match platform-specific error semantics. Backward compatibility with existing error handling. Error mapping accuracy.

--- a/architecture-plans/issue-453.md
+++ b/architecture-plans/issue-453.md
@@ -1,0 +1,6 @@
+# Issue #453: Add L2CAP channel error recovery and graceful close
+- Severity: medium
+- Impact: high
+- Approach: Implement L2CAP channel error recovery: (1) detect channel errors (disconnection, timeout), (2) provide graceful close with cleanup, (3) reconnection support, (4) error callbacks for application handling. Platform-specific L2CAP error handling.
+- Files to touch: src/commonMain/kmpble/l2cap/L2CAPChannel.kt (add error recovery), src/androidMain/kmpble/l2cap/L2CAPChannel.android.kt (implement), src/iosMain/kmpble/l2cap/L2CAPChannel.ios.kt (implement)
+- Risks: Must handle platform-specific L2CAP error semantics. Connection state management. Cleanup order must be correct.

--- a/architecture-plans/issue-454.md
+++ b/architecture-plans/issue-454.md
@@ -1,0 +1,6 @@
+# Issue #454: refactor(android): decompose AndroidGattBridge (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #501, #521, #481, #472, and #463. Consolidate into single PR. Decompose AndroidGattBridge into: (1) AndroidGattBridgeConnection.kt, (2) AndroidGattBridgeGatt.kt, (3) AndroidGattBridgeCallback.kt. Isolate @Volatile fields in callback channel to dedicated class with atomic operations.
+- Files to touch: androidMain/gatt/AndroidGattBridge.kt, androidMain/gatt/AndroidGattBridgeConnection.kt (new), androidMain/gatt/AndroidGattBridgeGatt.kt (new), androidMain/gatt/AndroidGattBridgeCallback.kt (new)
+- Risks: Must preserve all existing callback semantics. Callback channel migration must be thoroughly tested.

--- a/architecture-plans/issue-455.md
+++ b/architecture-plans/issue-455.md
@@ -1,0 +1,6 @@
+# Issue #455: refactor(ios): decompose IosPeripheral (286 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #367, #482, #473, and #464. Consolidate into single PR. Decompose IosPeripheral into: (1) IosPeripheralConnection.kt, (2) IosPeripheralGatt.kt, (3) IosPeripheralAdvertising.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: iosMain/kmpble/client/IosPeripheral.kt, iosMain/kmpble/client/IosPeripheralConnection.kt (new), iosMain/kmpble/client/IosPeripheralGatt.kt (new), iosMain/kmpble/client/IosPeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing peripheral behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-456.md
+++ b/architecture-plans/issue-456.md
@@ -1,0 +1,6 @@
+# Issue #456: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #441, #483, #474, and #465. Consolidate into single PR. Decompose Peripheral.kt into: (1) PeripheralConnectHandler.kt, (2) PeripheralDiscoverHandler.kt, (3) PeripheralOperationHandler.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: commonMain/kmpble/client/Peripheral.kt, commonMain/kmpble/client/PeripheralConnectHandler.kt (new), commonMain/kmpble/client/PeripheralDiscoverHandler.kt (new), commonMain/kmpble/client/PeripheralOperationHandler.kt (new), commonMain/kmpble/client/PeripheralCallbackAdapter.kt (new)
+- Risks: High refactoring risk due to file size and cross-platform abstraction layer. Must verify no expect/actual contract changes.

--- a/architecture-plans/issue-457.md
+++ b/architecture-plans/issue-457.md
@@ -1,0 +1,6 @@
+# Issue #457: refactor(common): decompose ConnectionOptions (231 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #511, #484, #475, and #466. Consolidate into single PR. Decompose ConnectionOptions into: (1) ConnectionOptionsTimeout.kt, (2) ConnectionOptionsSecurity.kt, (3) ConnectionOptionsRetry.kt. Extract builder DSL for each config group.
+- Files to touch: commonMain/kmpble/client/ConnectionOptions.kt, commonMain/kmpble/client/ConnectionOptionsTimeout.kt (new), commonMain/kmpble/client/ConnectionOptionsSecurity.kt (new), commonMain/kmpble/client/ConnectionOptionsRetry.kt (new)
+- Risks: API break if public API changes. Must maintain backward compatibility.

--- a/architecture-plans/issue-458.md
+++ b/architecture-plans/issue-458.md
@@ -1,0 +1,6 @@
+# Issue #458: refactor(common): decompose IsochronousStream (282 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #516, #490, #488, #476, and #467. Consolidate into single PR. Decompose IsochronousStream into: (1) IsochronousStreamConfig.kt, (2) IsochronousStreamPlayback.kt, (3) IsochronousStreamMetadata.kt.
+- Files to touch: commonMain/leaudio/IsochronousStream.kt, commonMain/leaudio/IsochronousStreamConfig.kt (new), commonMain/leaudio/IsochronousStreamPlayback.kt (new), commonMain/leaudio/IsochronousStreamMetadata.kt (new)
+- Risks: Must preserve all existing stream behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-459.md
+++ b/architecture-plans/issue-459.md
@@ -1,0 +1,6 @@
+# Issue #459: refactor(android): decompose AndroidExtendedAdvertiser (260 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #487, #477, and #468. Consolidate into single PR. Decompose AndroidExtendedAdvertiser into: (1) AndroidExtendedAdvertiserConfig.kt, (2) AndroidExtendedAdvertiserAdvertising.kt, (3) AndroidExtendedAdvertiserControl.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/advertising/AndroidExtendedAdvertiser.kt, androidMain/advertising/AndroidExtendedAdvertiserConfig.kt (new), androidMain/advertising/AndroidExtendedAdvertiserAdvertising.kt (new), androidMain/advertising/AndroidExtendedAdvertiserControl.kt (new)
+- Risks: Must preserve all existing advertiser behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-460.md
+++ b/architecture-plans/issue-460.md
@@ -1,0 +1,6 @@
+# Issue #460: refactor(common): decompose L2CAPChannel (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #494, #478, and #469. Consolidate into single PR. Decompose L2CAPChannel into: (1) L2CAPChannelConnection.kt, (2) L2CAPChannelData.kt, (3) L2CAPChannelError.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: commonMain/l2cap/L2CAPChannel.kt, commonMain/l2cap/L2CAPChannelConnection.kt (new), commonMain/l2cap/L2CAPChannelData.kt (new), commonMain/l2cap/L2CAPChannelError.kt (new)
+- Risks: Must preserve all existing channel behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-461.md
+++ b/architecture-plans/issue-461.md
@@ -1,0 +1,6 @@
+# Issue #461: refactor(android): decompose AndroidGattServer (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #485, #479, and #470. Consolidate into single PR. Decompose AndroidGattServer into: (1) AndroidGattServerConnection.kt, (2) AndroidGattServerCharacteristic.kt, (3) AndroidGattServerDescriptor.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/server/AndroidGattServer.kt, androidMain/server/AndroidGattServerConnection.kt (new), androidMain/server/AndroidGattServerCharacteristic.kt (new), androidMain/server/AndroidGattServerDescriptor.kt (new)
+- Risks: Must preserve all existing server behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-462.md
+++ b/architecture-plans/issue-462.md
@@ -1,0 +1,6 @@
+# Issue #462: refactor(common): decompose FakeGattResponder (365 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #495, #480, and #471. Consolidate into single PR. Decompose FakeGattResponder into: (1) FakeGattResponderCharacteristic.kt, (2) FakeGattResponderDescriptor.kt, (3) FakeGattResponderService.kt. Extract test helper methods to dedicated classes.
+- Files to touch: commonMain/test/FakeGattResponder.kt, commonMain/test/FakeGattResponderCharacteristic.kt (new), commonMain/test/FakeGattResponderDescriptor.kt (new), commonMain/test/FakeGattResponderService.kt (new)
+- Risks: Must preserve all existing test behavior. Decomposition must not break existing tests.

--- a/architecture-plans/issue-463.md
+++ b/architecture-plans/issue-463.md
@@ -1,0 +1,6 @@
+# Issue #463: refactor(android): decompose AndroidGattBridge (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #501, #521, #481, and #472. Consolidate into single PR. Decompose AndroidGattBridge into: (1) AndroidGattBridgeConnection.kt, (2) AndroidGattBridgeGatt.kt, (3) AndroidGattBridgeCallback.kt. Isolate @Volatile fields in callback channel to dedicated class with atomic operations.
+- Files to touch: androidMain/gatt/AndroidGattBridge.kt, androidMain/gatt/AndroidGattBridgeConnection.kt (new), androidMain/gatt/AndroidGattBridgeGatt.kt (new), androidMain/gatt/AndroidGattBridgeCallback.kt (new)
+- Risks: Must preserve all existing callback semantics. Callback channel migration must be thoroughly tested.

--- a/architecture-plans/issue-464.md
+++ b/architecture-plans/issue-464.md
@@ -1,0 +1,6 @@
+# Issue #464: refactor(ios): decompose IosPeripheral (286 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #367, #482, and #473. Consolidate into single PR. Decompose IosPeripheral into: (1) IosPeripheralConnection.kt, (2) IosPeripheralGatt.kt, (3) IosPeripheralAdvertising.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: iosMain/kmpble/client/IosPeripheral.kt, iosMain/kmpble/client/IosPeripheralConnection.kt (new), iosMain/kmpble/client/IosPeripheralGatt.kt (new), iosMain/kmpble/client/IosPeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing peripheral behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-465.md
+++ b/architecture-plans/issue-465.md
@@ -1,0 +1,6 @@
+# Issue #465: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #441, #483, and #474. Consolidate into single PR. Decompose Peripheral.kt into: (1) PeripheralConnectHandler.kt, (2) PeripheralDiscoverHandler.kt, (3) PeripheralOperationHandler.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: commonMain/kmpble/client/Peripheral.kt, commonMain/kmpble/client/PeripheralConnectHandler.kt (new), commonMain/kmpble/client/PeripheralDiscoverHandler.kt (new), commonMain/kmpble/client/PeripheralOperationHandler.kt (new), commonMain/kmpble/client/PeripheralCallbackAdapter.kt (new)
+- Risks: High refactoring risk due to file size and cross-platform abstraction layer. Must verify no expect/actual contract changes.

--- a/architecture-plans/issue-466.md
+++ b/architecture-plans/issue-466.md
@@ -1,0 +1,6 @@
+# Issue #466: refactor(common): decompose ConnectionOptions (231 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #511, #484, and #475. Consolidate into single PR. Decompose ConnectionOptions into: (1) ConnectionOptionsTimeout.kt, (2) ConnectionOptionsSecurity.kt, (3) ConnectionOptionsRetry.kt. Extract builder DSL for each config group.
+- Files to touch: commonMain/kmpble/client/ConnectionOptions.kt, commonMain/kmpble/client/ConnectionOptionsTimeout.kt (new), commonMain/kmpble/client/ConnectionOptionsSecurity.kt (new), commonMain/kmpble/client/ConnectionOptionsRetry.kt (new)
+- Risks: API break if public API changes. Must maintain backward compatibility.

--- a/architecture-plans/issue-467.md
+++ b/architecture-plans/issue-467.md
@@ -1,0 +1,6 @@
+# Issue #467: refactor(common): decompose IsochronousStream (282 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #516, #490, #488, and #476. Consolidate into single PR. Decompose IsochronousStream into: (1) IsochronousStreamConfig.kt, (2) IsochronousStreamPlayback.kt, (3) IsochronousStreamMetadata.kt.
+- Files to touch: commonMain/leaudio/IsochronousStream.kt, commonMain/leaudio/IsochronousStreamConfig.kt (new), commonMain/leaudio/IsochronousStreamPlayback.kt (new), commonMain/leaudio/IsochronousStreamMetadata.kt (new)
+- Risks: Must preserve all existing stream behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-468.md
+++ b/architecture-plans/issue-468.md
@@ -1,0 +1,6 @@
+# Issue #468: refactor(android): decompose AndroidExtendedAdvertiser (260 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #487 and #477. Consolidate into single PR. Decompose AndroidExtendedAdvertiser into: (1) AndroidExtendedAdvertiserConfig.kt, (2) AndroidExtendedAdvertiserAdvertising.kt, (3) AndroidExtendedAdvertiserControl.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/advertising/AndroidExtendedAdvertiser.kt, androidMain/advertising/AndroidExtendedAdvertiserConfig.kt (new), androidMain/advertising/AndroidExtendedAdvertiserAdvertising.kt (new), androidMain/advertising/AndroidExtendedAdvertiserControl.kt (new)
+- Risks: Must preserve all existing advertiser behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-469.md
+++ b/architecture-plans/issue-469.md
@@ -1,0 +1,6 @@
+# Issue #469: refactor(common): decompose L2CAPChannel (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #494 and #478. Consolidate into single PR. Decompose L2CAPChannel into: (1) L2CAPChannelConnection.kt, (2) L2CAPChannelData.kt, (3) L2CAPChannelError.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: commonMain/l2cap/L2CAPChannel.kt, commonMain/l2cap/L2CAPChannelConnection.kt (new), commonMain/l2cap/L2CAPChannelData.kt (new), commonMain/l2cap/L2CAPChannelError.kt (new)
+- Risks: Must preserve all existing channel behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-470.md
+++ b/architecture-plans/issue-470.md
@@ -1,0 +1,6 @@
+# Issue #470: refactor(android): decompose AndroidGattServer (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #485 and #479. Consolidate into single PR. Decompose AndroidGattServer into: (1) AndroidGattServerConnection.kt, (2) AndroidGattServerCharacteristic.kt, (3) AndroidGattServerDescriptor.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/server/AndroidGattServer.kt, androidMain/server/AndroidGattServerConnection.kt (new), androidMain/server/AndroidGattServerCharacteristic.kt (new), androidMain/server/AndroidGattServerDescriptor.kt (new)
+- Risks: Must preserve all existing server behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-471.md
+++ b/architecture-plans/issue-471.md
@@ -1,0 +1,6 @@
+# Issue #471: refactor(common): decompose FakeGattResponder (365 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #495 and #480. Consolidate into single PR. Decompose FakeGattResponder into: (1) FakeGattResponderCharacteristic.kt, (2) FakeGattResponderDescriptor.kt, (3) FakeGattResponderService.kt. Extract test helper methods to dedicated classes.
+- Files to touch: commonMain/test/FakeGattResponder.kt, commonMain/test/FakeGattResponderCharacteristic.kt (new), commonMain/test/FakeGattResponderDescriptor.kt (new), commonMain/test/FakeGattResponderService.kt (new)
+- Risks: Must preserve all existing test behavior. Decomposition must not break existing tests.

--- a/architecture-plans/issue-472.md
+++ b/architecture-plans/issue-472.md
@@ -1,0 +1,6 @@
+# Issue #472: refactor(android): decompose AndroidGattBridge (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #501, #521, and #481. Consolidate into single PR. Decompose AndroidGattBridge into: (1) AndroidGattBridgeConnection.kt, (2) AndroidGattBridgeGatt.kt, (3) AndroidGattBridgeCallback.kt. Isolate @Volatile fields in callback channel to dedicated class with atomic operations.
+- Files to touch: androidMain/gatt/AndroidGattBridge.kt, androidMain/gatt/AndroidGattBridgeConnection.kt (new), androidMain/gatt/AndroidGattBridgeGatt.kt (new), androidMain/gatt/AndroidGattBridgeCallback.kt (new)
+- Risks: Must preserve all existing callback semantics. Callback channel migration must be thoroughly tested.

--- a/architecture-plans/issue-473.md
+++ b/architecture-plans/issue-473.md
@@ -1,0 +1,6 @@
+# Issue #473: refactor(ios): decompose IosPeripheral (286 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #367 and #482. Consolidate into single PR. Decompose IosPeripheral into: (1) IosPeripheralConnection.kt, (2) IosPeripheralGatt.kt, (3) IosPeripheralAdvertising.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: iosMain/kmpble/client/IosPeripheral.kt, iosMain/kmpble/client/IosPeripheralConnection.kt (new), iosMain/kmpble/client/IosPeripheralGatt.kt (new), iosMain/kmpble/client/IosPeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing peripheral behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-474.md
+++ b/architecture-plans/issue-474.md
@@ -1,0 +1,6 @@
+# Issue #474: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #441 and #483. Consolidate into single PR. Decompose Peripheral.kt into: (1) PeripheralConnectHandler.kt, (2) PeripheralDiscoverHandler.kt, (3) PeripheralOperationHandler.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: commonMain/kmpble/client/Peripheral.kt, commonMain/kmpble/client/PeripheralConnectHandler.kt (new), commonMain/kmpble/client/PeripheralDiscoverHandler.kt (new), commonMain/kmpble/client/PeripheralOperationHandler.kt (new), commonMain/kmpble/client/PeripheralCallbackAdapter.kt (new)
+- Risks: High refactoring risk due to file size and cross-platform abstraction layer. Must verify no expect/actual contract changes.

--- a/architecture-plans/issue-475.md
+++ b/architecture-plans/issue-475.md
@@ -1,0 +1,6 @@
+# Issue #475: refactor(common): decompose ConnectionOptions (231 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #511 and #484. Consolidate into single PR. Decompose ConnectionOptions into: (1) ConnectionOptionsTimeout.kt, (2) ConnectionOptionsSecurity.kt, (3) ConnectionOptionsRetry.kt. Extract builder DSL for each config group.
+- Files to touch: commonMain/kmpble/client/ConnectionOptions.kt, commonMain/kmpble/client/ConnectionOptionsTimeout.kt (new), commonMain/kmpble/client/ConnectionOptionsSecurity.kt (new), commonMain/kmpble/client/ConnectionOptionsRetry.kt (new)
+- Risks: API break if public API changes. Must maintain backward compatibility.

--- a/architecture-plans/issue-476.md
+++ b/architecture-plans/issue-476.md
@@ -1,0 +1,6 @@
+# Issue #476: refactor(common): decompose IsochronousStream (282 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #516, #490, and #488. Consolidate into single PR. Decompose IsochronousStream into: (1) IsochronousStreamConfig.kt, (2) IsochronousStreamPlayback.kt, (3) IsochronousStreamMetadata.kt.
+- Files to touch: commonMain/leaudio/IsochronousStream.kt, commonMain/leaudio/IsochronousStreamConfig.kt (new), commonMain/leaudio/IsochronousStreamPlayback.kt (new), commonMain/leaudio/IsochronousStreamMetadata.kt (new)
+- Risks: Must preserve all existing stream behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-477.md
+++ b/architecture-plans/issue-477.md
@@ -1,0 +1,6 @@
+# Issue #477: refactor(android): decompose AndroidExtendedAdvertiser (260 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #487. Consolidate into single PR. Decompose AndroidExtendedAdvertiser into: (1) AndroidExtendedAdvertiserConfig.kt, (2) AndroidExtendedAdvertiserAdvertising.kt, (3) AndroidExtendedAdvertiserControl.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/advertising/AndroidExtendedAdvertiser.kt, androidMain/advertising/AndroidExtendedAdvertiserConfig.kt (new), androidMain/advertising/AndroidExtendedAdvertiserAdvertising.kt (new), androidMain/advertising/AndroidExtendedAdvertiserControl.kt (new)
+- Risks: Must preserve all existing advertiser behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-478.md
+++ b/architecture-plans/issue-478.md
@@ -1,0 +1,6 @@
+# Issue #478: refactor(common): decompose L2CAPChannel (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #494. Consolidate into single PR. Decompose L2CAPChannel into: (1) L2CAPChannelConnection.kt, (2) L2CAPChannelData.kt, (3) L2CAPChannelError.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: commonMain/l2cap/L2CAPChannel.kt, commonMain/l2cap/L2CAPChannelConnection.kt (new), commonMain/l2cap/L2CAPChannelData.kt (new), commonMain/l2cap/L2CAPChannelError.kt (new)
+- Risks: Must preserve all existing channel behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-479.md
+++ b/architecture-plans/issue-479.md
@@ -1,0 +1,6 @@
+# Issue #479: refactor(android): decompose AndroidGattServer (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #485. Consolidate into single PR. Decompose AndroidGattServer into: (1) AndroidGattServerConnection.kt, (2) AndroidGattServerCharacteristic.kt, (3) AndroidGattServerDescriptor.kt. Isolate @Volatile fields to dedicated class with atomic operations.
+- Files to touch: androidMain/server/AndroidGattServer.kt, androidMain/server/AndroidGattServerConnection.kt (new), androidMain/server/AndroidGattServerCharacteristic.kt (new), androidMain/server/AndroidGattServerDescriptor.kt (new)
+- Risks: Must preserve all existing server behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-480.md
+++ b/architecture-plans/issue-480.md
@@ -1,0 +1,6 @@
+# Issue #480: refactor(common): decompose FakeGattResponder (365 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #495. Consolidate into single PR. Decompose FakeGattResponder into: (1) FakeGattResponderCharacteristic.kt, (2) FakeGattResponderDescriptor.kt, (3) FakeGattResponderService.kt. Extract test helper methods to dedicated classes.
+- Files to touch: commonMain/test/FakeGattResponder.kt, commonMain/test/FakeGattResponderCharacteristic.kt (new), commonMain/test/FakeGattResponderDescriptor.kt (new), commonMain/test/FakeGattResponderService.kt (new)
+- Risks: Must preserve all existing test behavior. Decomposition must not break existing tests.

--- a/architecture-plans/issue-481.md
+++ b/architecture-plans/issue-481.md
@@ -1,0 +1,6 @@
+# Issue #481: refactor(android): decompose AndroidGattBridge (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #501 and #521. Consolidate into single PR. Decompose AndroidGattBridge into: (1) AndroidGattBridgeConnection.kt, (2) AndroidGattBridgeGatt.kt, (3) AndroidGattBridgeCallback.kt. Isolate @Volatile fields in callback channel to dedicated class with atomic operations.
+- Files to touch: androidMain/gatt/AndroidGattBridge.kt, androidMain/gatt/AndroidGattBridgeConnection.kt (new), androidMain/gatt/AndroidGattBridgeGatt.kt (new), androidMain/gatt/AndroidGattBridgeCallback.kt (new)
+- Risks: Must preserve all existing callback semantics. Callback channel migration must be thoroughly tested.

--- a/architecture-plans/issue-482.md
+++ b/architecture-plans/issue-482.md
@@ -1,0 +1,6 @@
+# Issue #482: refactor(ios): decompose IosPeripheral (286 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #367. Consolidate into single PR. Decompose IosPeripheral into: (1) IosPeripheralConnection.kt, (2) IosPeripheralGatt.kt, (3) IosPeripheralAdvertising.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: iosMain/kmpble/client/IosPeripheral.kt, iosMain/kmpble/client/IosPeripheralConnection.kt (new), iosMain/kmpble/client/IosPeripheralGatt.kt (new), iosMain/kmpble/client/IosPeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing peripheral behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-483.md
+++ b/architecture-plans/issue-483.md
@@ -1,0 +1,6 @@
+# Issue #483: refactor(common): decompose Peripheral.kt (373 lines) into focused handler modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #441. Consolidate into single PR. Decompose Peripheral.kt into: (1) PeripheralConnectHandler.kt, (2) PeripheralDiscoverHandler.kt, (3) PeripheralOperationHandler.kt. Extract platform-specific callback routing to dedicated adapter classes.
+- Files to touch: commonMain/kmpble/client/Peripheral.kt, commonMain/kmpble/client/PeripheralConnectHandler.kt (new), commonMain/kmpble/client/PeripheralDiscoverHandler.kt (new), commonMain/kmpble/client/PeripheralOperationHandler.kt (new), commonMain/kmpble/client/PeripheralCallbackAdapter.kt (new)
+- Risks: High refactoring risk due to file size and cross-platform abstraction layer. Must verify no expect/actual contract changes.

--- a/architecture-plans/issue-484.md
+++ b/architecture-plans/issue-484.md
@@ -1,0 +1,6 @@
+# Issue #484: refactor(common): decompose ConnectionOptions (231 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #511. Consolidate into single PR. Decompose ConnectionOptions into: (1) ConnectionOptionsTimeout.kt, (2) ConnectionOptionsSecurity.kt, (3) ConnectionOptionsRetry.kt. Extract builder DSL for each config group.
+- Files to touch: commonMain/kmpble/client/ConnectionOptions.kt, commonMain/kmpble/client/ConnectionOptionsTimeout.kt (new), commonMain/kmpble/client/ConnectionOptionsSecurity.kt (new), commonMain/kmpble/client/ConnectionOptionsRetry.kt (new)
+- Risks: API break if public API changes. Must maintain backward compatibility.

--- a/architecture-plans/issue-485.md
+++ b/architecture-plans/issue-485.md
@@ -1,0 +1,6 @@
+# Issue #485: refactor(android): decompose AndroidGattServer (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose AndroidGattServer into: (1) AndroidGattServerConnection.kt, (2) AndroidGattServerCharacteristic.kt, (3) AndroidGattServerDescriptor.kt. Isolate @Volatile fields to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: androidMain/server/AndroidGattServer.kt, androidMain/server/AndroidGattServerConnection.kt (new), androidMain/server/AndroidGattServerCharacteristic.kt (new), androidMain/server/AndroidGattServerDescriptor.kt (new)
+- Risks: Must preserve all existing server behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-486.md
+++ b/architecture-plans/issue-486.md
@@ -1,0 +1,6 @@
+# Issue #486: refactor(common): decompose FakePeripheral (373 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose FakePeripheral into: (1) FakePeripheralConnection.kt, (2) FakePeripheralGatt.kt, (3) FakePeripheralAdvertising.kt. Isolate test helper methods to dedicated classes. Maintain test API.
+- Files to touch: commonMain/test/FakePeripheral.kt, commonMain/test/FakePeripheralConnection.kt (new), commonMain/test/FakePeripheralGatt.kt (new), commonMain/test/FakePeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing test behavior. Decomposition must not break existing tests.

--- a/architecture-plans/issue-487.md
+++ b/architecture-plans/issue-487.md
@@ -1,0 +1,6 @@
+# Issue #487: refactor(android): decompose AndroidExtendedAdvertiser (260 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose AndroidExtendedAdvertiser into: (1) AndroidExtendedAdvertiserConfig.kt, (2) AndroidExtendedAdvertiserAdvertising.kt, (3) AndroidExtendedAdvertiserControl.kt. Isolate @Volatile fields to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: androidMain/advertising/AndroidExtendedAdvertiser.kt, androidMain/advertising/AndroidExtendedAdvertiserConfig.kt (new), androidMain/advertising/AndroidExtendedAdvertiserAdvertising.kt (new), androidMain/advertising/AndroidExtendedAdvertiserControl.kt (new)
+- Risks: Must preserve all existing advertiser behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-488.md
+++ b/architecture-plans/issue-488.md
@@ -1,0 +1,6 @@
+# Issue #488: refactor(common): decompose IsochronousStream (282 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Duplicate of #516 and #490. Consolidate into single PR. Decompose IsochronousStream into: (1) IsochronousStreamConfig.kt, (2) IsochronousStreamPlayback.kt, (3) IsochronousStreamMetadata.kt.
+- Files to touch: commonMain/leaudio/IsochronousStream.kt, commonMain/leaudio/IsochronousStreamConfig.kt (new), commonMain/leaudio/IsochronousStreamPlayback.kt (new), commonMain/leaudio/IsochronousStreamMetadata.kt (new)
+- Risks: Same as #516 and #490.

--- a/architecture-plans/issue-489.md
+++ b/architecture-plans/issue-489.md
@@ -1,0 +1,6 @@
+# Issue #489: refactor(android): decompose AndroidPeripheral (277 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose AndroidPeripheral into: (1) AndroidPeripheralConnection.kt, (2) AndroidPeripheralGatt.kt, (3) AndroidPeripheralAdvertising.kt. Isolate @Volatile fields to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: androidMain/client/AndroidPeripheral.kt, androidMain/client/AndroidPeripheralConnection.kt (new), androidMain/client/AndroidPeripheralGatt.kt (new), androidMain/client/AndroidPeripheralAdvertising.kt (new)
+- Risks: Must preserve all existing peripheral behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-494.md
+++ b/architecture-plans/issue-494.md
@@ -1,0 +1,6 @@
+# Issue #494: refactor(common): decompose L2CAPChannel (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose L2CAPChannel into: (1) L2CAPChannelConnection.kt, (2) L2CAPChannelData.kt, (3) L2CAPChannelError.kt. Isolate @Volatile fields to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: commonMain/l2cap/L2CAPChannel.kt, commonMain/l2cap/L2CAPChannelConnection.kt (new), commonMain/l2cap/L2CAPChannelData.kt (new), commonMain/l2cap/L2CAPChannelError.kt (new)
+- Risks: Must preserve all existing channel behavior. Decomposition must not introduce circular dependencies.

--- a/architecture-plans/issue-500.md
+++ b/architecture-plans/issue-500.md
@@ -1,0 +1,6 @@
+# Issue #500: refactor(android): decompose AndroidGattServerState (236 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose AndroidGattServerState into: (1) AndroidGattServerStateConnection.kt, (2) AndroidGattServerStateCharacteristic.kt, (3) AndroidGattServerStateDescriptor.kt. Isolate @Volatile fields to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: androidMain/server/AndroidGattServerState.kt, androidMain/server/AndroidGattServerStateConnection.kt (new), androidMain/server/AndroidGattServerStateCharacteristic.kt (new), androidMain/server/AndroidGattServerStateDescriptor.kt (new)
+- Risks: Must preserve all existing state machine behavior. State transitions must be tested.

--- a/architecture-plans/issue-501.md
+++ b/architecture-plans/issue-501.md
@@ -1,0 +1,6 @@
+# Issue #501: refactor(android): decompose AndroidGattBridge (287 lines) into focused modules
+- Severity: medium
+- Impact: low
+- Approach: Decompose AndroidGattBridge into: (1) AndroidGattBridgeConnection.kt, (2) AndroidGattBridgeGatt.kt, (3) AndroidGattBridgeCallback.kt. Isolate @Volatile fields in callback channel to dedicated class with atomic operations. Add concurrency tests.
+- Files to touch: androidMain/gatt/AndroidGattBridge.kt, androidMain/gatt/AndroidGattBridgeConnection.kt (new), androidMain/gatt/AndroidGattBridgeGatt.kt (new), androidMain/gatt/AndroidGattBridgeCallback.kt (new)
+- Risks: Must preserve all existing callback semantics. Callback channel migration must be thoroughly tested.

--- a/architecture-plans/issue-513.md
+++ b/architecture-plans/issue-513.md
@@ -1,0 +1,6 @@
+# Issue #513: Add iOS support for scan response data reading in Scanner API
+- Severity: medium
+- Impact: medium
+- Approach: Add iOS-specific implementation for scan response data reading. Platform-specific: iOS uses CBScanResponseDataKey. Verify parity with Android implementation. Add tests for iOS scan response data retrieval.
+- Files to touch: iosMain/kmpble/client/Scanner.ios.kt, commonMain/kmpble/client/ScanResult.kt (read-only)
+- Risks: iOS Bluetooth API restrictions -- may require specific iOS version. Must verify parity with Android implementation.

--- a/architecture-plans/issue-515.md
+++ b/architecture-plans/issue-515.md
@@ -1,0 +1,6 @@
+# Issue #515: Add connection quality history and RSSI trend analysis for proactive reconnection
+- Severity: medium
+- Impact: high
+- Approach: Add connection quality monitoring: (1) collect RSSI samples over time, (2) compute trend (improving/degrading/stable), (3) expose quality history as Flow. Platform-specific: Android/iOS provide RSSI readings differently. Use sliding window for trend analysis. Provide reconnection recommendation based on trend.
+- Files to touch: commonMain/kmpble/client/ConnectionQuality.kt (new), commonMain/kmpble/client/ConnectionQualityHistory.kt (new), iosMain/kmpble/client/ConnectionQuality.ios.kt, androidMain/kmpble/client/ConnectionQuality.android.kt
+- Risks: Must handle rapid RSSI changes. Must not block the main connection loop. Must provide cancellation support. Must handle platform-specific RSSI reporting differences.

--- a/architecture-plans/issue-517.md
+++ b/architecture-plans/issue-517.md
@@ -1,0 +1,6 @@
+# Issue #517: Add observation persistence cancellation and recovery tests
+- Severity: medium
+- Impact: medium
+- Approach: Add tests for observation persistence: (1) cancellation during write, (2) recovery after failure, (3) state consistency. Use Android instrumented tests with mock SharedPreferences. Test edge cases: partial writes, corruption.
+- Files to touch: androidMain/test/ObservationPersistenceCancellationTest.kt (new), androidMain/persistence/ObservationPersistence.android.kt (read-only)
+- Risks: Instrumented tests require Android environment. Must handle SharedPreferences lifecycle carefully. Must test cancellation scenarios.

--- a/architecture-plans/issue-518.md
+++ b/architecture-plans/issue-518.md
@@ -1,0 +1,6 @@
+# Issue #518: Add PHY read/write API for Bluetooth 5.x physical layer control
+- Severity: medium
+- Impact: medium
+- Approach: Add PHY control API: (1) read current PHY, (2) write/select PHY, (3) query PHY capabilities. Platform-specific: Android uses BluetoothGatt.setPHY/getPHY; iOS uses CBPeripheral writeValue for PHY control. Handle platform capability checks gracefully.
+- Files to touch: commonMain/kmpble/phy/PHY.kt (new), commonMain/kmpble/phy/PHYControl.kt (new), iosMain/kmpble/phy/PHYControl.ios.kt, androidMain/kmpble/phy/PHYControl.android.kt
+- Risks: PHY control is Bluetooth 5.0+ only -- not all chips support it. Must handle platform capability checks gracefully.

--- a/architecture-plans/issue-519.md
+++ b/architecture-plans/issue-519.md
@@ -1,0 +1,6 @@
+# Issue #519: Add ObservationPersistence SharedPreferences Android roundtrip tests
+- Severity: medium
+- Impact: medium
+- Approach: Add Android-specific tests for ObservationPersistence: (1) write CCC state to SharedPreferences, (2) read back after process restart, (3) verify state persistence across app lifecycle. Use Android instrumented tests with mock SharedPreferences. Test edge cases: empty state, corrupted data.
+- Files to touch: androidMain/test/ObservationPersistenceAndroidTest.kt (new), androidMain/persistence/ObservationPersistence.android.kt (read-only)
+- Risks: Instrumented tests require Android environment. Must handle SharedPreferences lifecycle carefully. Must test both success and failure paths.

--- a/architecture-plans/issue-520.md
+++ b/architecture-plans/issue-520.md
@@ -1,0 +1,6 @@
+# Issue #520: Add GATT notification batching for high-frequency sensor data
+- Severity: medium
+- Impact: high
+- Approach: Add GATT notification batching: (1) batch multiple notifications before dispatching, (2) configurable batch size and timeout, (3) emit batched updates. Platform-specific: Android/iOS handle notification batching differently. Use coroutine-based batching with configurable window.
+- Files to touch: commonMain/kmpble/gatt/NotificationBatcher.kt (new), commonMain/kmpble/client/Peripheral.kt (add batching support), iosMain/kmpble/gatt/NotificationBatcher.ios.kt, androidMain/kmpble/gatt/NotificationBatcher.android.kt
+- Risks: Must handle rapid notification rates. Must not block the main GATT callback loop. Must provide cancellation support. Must handle platform-specific notification timing.

--- a/architecture-plans/issue-522.md
+++ b/architecture-plans/issue-522.md
@@ -1,0 +1,6 @@
+# Issue #522: Add Connection.reconnect() convenience for single-tap reconnection
+- Severity: medium
+- Impact: high
+- Approach: Add `Connection.reconnect()` suspend function: (1) disconnect current connection, (2) reconnect with same parameters, (3) return new Connection. Handle timeout and failure. Reuse existing connect/disconnect APIs. Provide reconnection status flow.
+- Files to touch: commonMain/kmpble/client/Connection.kt (add reconnect method), commonMain/kmpble/client/Reconnect.kt (new, internal)
+- Risks: Must handle reconnection timing. Must not leak connection resources. Must handle platform-specific reconnection behavior.

--- a/architecture-plans/issue-523.md
+++ b/architecture-plans/issue-523.md
@@ -1,0 +1,6 @@
+# Issue #523: Add PHY layer metrics collection for connection quality monitoring
+- Severity: medium
+- Impact: medium
+- Approach: Add PHY metrics collection: (1) collect PHY-specific metrics (RSSI, SNR, etc.), (2) expose as Flow<PHYMetrics>, (3) compute quality score. Platform-specific: Android/iOS provide PHY metrics differently. Use coroutine-based collection with configurable interval.
+- Files to touch: commonMain/kmpble/phy/PHYMetrics.kt (new), commonMain/kmpble/phy/PHYMetricsCollector.kt (new), iosMain/kmpble/phy/PHYMetricsCollector.ios.kt, androidMain/kmpble/phy/PHYMetricsCollector.android.kt
+- Risks: Must handle platform-specific PHY metric availability. Must not block the main connection loop. Must provide cancellation support.

--- a/architecture-plans/issue-524.md
+++ b/architecture-plans/issue-524.md
@@ -1,0 +1,6 @@
+# Issue #524: Add AndroidGattBridge callback channel concurrency tests
+- Severity: medium
+- Impact: medium
+- Approach: Add concurrency tests for AndroidGattBridge callback channel: (1) concurrent callback dispatch, (2) callback ordering, (3) callback cancellation. Use coroutine-based concurrency testing. Verify no race conditions. Test with high-frequency callback scenarios.
+- Files to touch: androidMain/test/AndroidGattBridgeConcurrencyTest.kt (new), androidMain/gatt/AndroidGattBridge.kt (read-only)
+- Risks: Must handle platform-specific callback timing. Must verify no race conditions. Must test with high-frequency scenarios.

--- a/architecture-plans/issue-526.md
+++ b/architecture-plans/issue-526.md
@@ -1,0 +1,6 @@
+# Issue #526: Implement iOS scan response data reading to match Android functionality
+- Severity: medium
+- Impact: medium
+- Approach: Implement iOS-specific scan response data reading: (1) read scan response data from peripheral, (2) parse data according to Bluetooth spec, (3) expose as ScanResult property. Platform-specific: iOS uses CBScanResponseDataKey. Verify parity with Android implementation.
+- Files to touch: iosMain/kmpble/client/Scanner.ios.kt, commonMain/kmpble/client/ScanResult.kt (read-only)
+- Risks: iOS Bluetooth API restrictions -- may require specific iOS version. Must verify parity with Android implementation.

--- a/architecture-plans/issue-527.md
+++ b/architecture-plans/issue-527.md
@@ -1,0 +1,6 @@
+# Issue #527: Add stress tests for ObservationPersistence SharedPreferences writes
+- Severity: medium
+- Impact: medium
+- Approach: Add stress tests for ObservationPersistence: (1) high-frequency write operations, (2) concurrent read/write, (3) persistence under pressure. Use Android instrumented tests with mock SharedPreferences. Verify no data loss or corruption under load.
+- Files to touch: androidMain/test/ObservationPersistenceStressTest.kt (new), androidMain/persistence/ObservationPersistence.android.kt (read-only)
+- Risks: Instrumented tests require Android environment. Must handle SharedPreferences lifecycle carefully. Must test under high load conditions.

--- a/architecture-plans/issue-531.md
+++ b/architecture-plans/issue-531.md
@@ -1,0 +1,6 @@
+# Issue #531: Add AndroidGattBridge concurrency stress tests
+- Severity: medium
+- Impact: medium
+- Approach: Add concurrency stress tests for AndroidGattBridge: (1) high-frequency callback dispatch, (2) concurrent connection operations, (3) stress testing under load. Use coroutine-based concurrency testing. Verify no race conditions or deadlocks.
+- Files to touch: androidMain/test/AndroidGattBridgeStressTest.kt (new), androidMain/gatt/AndroidGattBridge.kt (read-only)
+- Risks: Must handle platform-specific callback timing. Must verify no race conditions or deadlocks. Must test under high load conditions.

--- a/architecture-plans/issue-532.md
+++ b/architecture-plans/issue-532.md
@@ -1,0 +1,6 @@
+# Issue #532: Add iOS scan response data API to match Android Scanner
+- Severity: medium
+- Impact: medium
+- Approach: Add iOS-specific scan response data API: (1) query scan response data from peripheral, (2) parse data according to Bluetooth spec, (3) expose as Scanner property. Platform-specific: iOS uses CBScanResponseDataKey. Verify parity with Android implementation.
+- Files to touch: iosMain/kmpble/client/Scanner.ios.kt, commonMain/kmpble/client/Scanner.kt (read-only)
+- Risks: iOS Bluetooth API restrictions -- may require specific iOS version. Must verify parity with Android implementation.

--- a/architecture-plans/issue-533.md
+++ b/architecture-plans/issue-533.md
@@ -1,0 +1,6 @@
+# Issue #533: Add PHY layer metrics collection benchmarks
+- Severity: medium
+- Impact: medium
+- Approach: Add benchmarks for PHY layer metrics collection: (1) collection overhead, (2) memory usage, (3) CPU impact. Use Android benchmarks. Verify no performance regression. Compare with baseline.
+- Files to touch: androidMain/benchmark/PHYMetricsBenchmark.kt (new), commonMain/kmpble/phy/PHYMetrics.kt (read-only)
+- Risks: Must handle platform-specific benchmark requirements. Must verify no performance regression. Must compare with baseline.

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -192,4 +192,65 @@ class AndroidScannerTest {
         // Accept either success or Stub exception -- the instrumented CI will validate
         assertTrue(result.isSuccess || result.exceptionOrNull() is RuntimeException)
     }
+
+    // =========================================================================
+    // scanModeToAndroid -- maps ScanMode enum to Android constants
+    // =========================================================================
+
+    @Test
+    fun `scanModeToAndroid LowPower maps to SCAN_MODE_BALANCED`() {
+        assertEquals(
+            ScanSettings.SCAN_MODE_BALANCED,
+            AndroidScanner.scanModeToAndroid(ScanMode.LowPower),
+        )
+    }
+
+    @Test
+    fun `scanModeToAndroid Balanced maps to SCAN_MODE_BALANCED`() {
+        assertEquals(
+            ScanSettings.SCAN_MODE_BALANCED,
+            AndroidScanner.scanModeToAndroid(ScanMode.Balanced),
+        )
+    }
+
+    @Test
+    fun `scanModeToAndroid LowLatency maps to SCAN_MODE_LOW_LATENCY`() {
+        assertEquals(
+            ScanSettings.SCAN_MODE_LOW_LATENCY,
+            AndroidScanner.scanModeToAndroid(ScanMode.LowLatency),
+        )
+    }
+
+    @Test
+    fun `scanModeToAndroid covers all ScanMode values`() {
+        val results = ScanMode.entries.map { it to AndroidScanner.scanModeToAndroid(it) }
+        assertEquals(3, results.size)
+        assertTrue(results.all { it.second == ScanSettings.SCAN_MODE_BALANCED || it.second == ScanSettings.SCAN_MODE_LOW_LATENCY })
+    }
+
+    // =========================================================================
+    // ScannerConfig scanMode -- default and DSL
+    // =========================================================================
+
+    @Test
+    fun `ScannerConfig scanMode defaults to Balanced`() {
+        val config = ScannerConfig()
+        assertEquals(ScanMode.Balanced, config.scanMode)
+    }
+
+    @Test
+    fun `ScannerConfig DSL sets custom scanMode`() {
+        val config = ScannerConfig().apply {
+            scanMode = ScanMode.LowLatency
+        }
+        assertEquals(ScanMode.LowLatency, config.scanMode)
+    }
+
+    @Test
+    fun `ScannerConfig DSL sets LowPower scanMode`() {
+        val config = ScannerConfig().apply {
+            scanMode = ScanMode.LowPower
+        }
+        assertEquals(ScanMode.LowPower, config.scanMode)
+    }
 }

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.scanner
 
+import android.bluetooth.le.ScanSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -225,7 +225,12 @@ class AndroidScannerTest {
     fun `scanModeToAndroid covers all ScanMode values`() {
         val results = ScanMode.entries.map { it to AndroidScanner.scanModeToAndroid(it) }
         assertEquals(3, results.size)
-        assertTrue(results.all { it.second == ScanSettings.SCAN_MODE_BALANCED || it.second == ScanSettings.SCAN_MODE_LOW_LATENCY })
+        assertTrue(
+            results.all {
+                it.second == ScanSettings.SCAN_MODE_BALANCED ||
+                    it.second == ScanSettings.SCAN_MODE_LOW_LATENCY
+            },
+        )
     }
 
     // =========================================================================
@@ -240,17 +245,19 @@ class AndroidScannerTest {
 
     @Test
     fun `ScannerConfig DSL sets custom scanMode`() {
-        val config = ScannerConfig().apply {
-            scanMode = ScanMode.LowLatency
-        }
+        val config = ScannerConfig()
+            .apply {
+                scanMode = ScanMode.LowLatency
+            }
         assertEquals(ScanMode.LowLatency, config.scanMode)
     }
 
     @Test
     fun `ScannerConfig DSL sets LowPower scanMode`() {
-        val config = ScannerConfig().apply {
-            scanMode = ScanMode.LowPower
-        }
+        val config = ScannerConfig()
+            .apply {
+                scanMode = ScanMode.LowPower
+            }
         assertEquals(ScanMode.LowPower, config.scanMode)
     }
 }

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -245,19 +245,17 @@ class AndroidScannerTest {
 
     @Test
     fun `ScannerConfig DSL sets custom scanMode`() {
-        val config = ScannerConfig()
-            .apply {
-                scanMode = ScanMode.LowLatency
-            }
+        val config = ScannerConfig().apply {
+            scanMode = ScanMode.LowLatency
+        }
         assertEquals(ScanMode.LowLatency, config.scanMode)
     }
 
     @Test
     fun `ScannerConfig DSL sets LowPower scanMode`() {
-        val config = ScannerConfig()
-            .apply {
-                scanMode = ScanMode.LowPower
-            }
+        val config = ScannerConfig().apply {
+            scanMode = ScanMode.LowPower
+        }
         assertEquals(ScanMode.LowPower, config.scanMode)
     }
 }

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -245,17 +245,21 @@ class AndroidScannerTest {
 
     @Test
     fun `ScannerConfig DSL sets custom scanMode`() {
-        val config = ScannerConfig().apply {
-            scanMode = ScanMode.LowLatency
-        }
+        val config =
+            ScannerConfig()
+                .apply {
+                    scanMode = ScanMode.LowLatency
+                }
         assertEquals(ScanMode.LowLatency, config.scanMode)
     }
 
     @Test
     fun `ScannerConfig DSL sets LowPower scanMode`() {
-        val config = ScannerConfig().apply {
-            scanMode = ScanMode.LowPower
-        }
+        val config =
+            ScannerConfig()
+                .apply {
+                    scanMode = ScanMode.LowPower
+                }
         assertEquals(ScanMode.LowPower, config.scanMode)
     }
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.os.ParcelUuid
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -11,8 +11,6 @@ import android.content.Context
 import android.os.ParcelUuid
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
-import com.atruedev.kmpble.scanner.ScanPhy
-import com.atruedev.kmpble.scanner.internal.toScanEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -61,7 +59,7 @@ public class AndroidScanner(
             val settings =
                 ScanSettings
                     .Builder()
-                    .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                    .setScanMode(scanModeToAndroid(config.scanMode))
                     .setLegacy(config.legacyOnly)
                     .setPhy(scanPhyToAndroid(config.phy))
                     .build()
@@ -135,6 +133,13 @@ public class AndroidScanner(
                 ScanPhy.Le1M -> BluetoothDevice.PHY_LE_1M
                 ScanPhy.LeCoded -> BluetoothDevice.PHY_LE_CODED
                 ScanPhy.All -> ScanSettings.PHY_LE_ALL_SUPPORTED
+            }
+
+        internal fun scanModeToAndroid(mode: ScanMode): Int =
+            when (mode) {
+                ScanMode.LowPower -> ScanSettings.SCAN_MODE_BALANCED
+                ScanMode.Balanced -> ScanSettings.SCAN_MODE_BALANCED
+                ScanMode.LowLatency -> ScanSettings.SCAN_MODE_LOW_LATENCY
             }
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanMode.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanMode.kt
@@ -1,0 +1,23 @@
+package com.atruedev.kmpble.scanner
+
+/**
+ * Scan strategy controlling how aggressively the platform searches for devices.
+ *
+ * | ------- | -------------------------------------------------- |
+ * | Android | `ScanSettings.Builder.setScanMode(int)`            |
+ * | iOS     | No public equivalent; CoreBluetooth chooses        |
+ * |         | dynamically based on RSSI and connection intent.   |
+ */
+public enum class ScanMode {
+    /** Low power. OS decides scan intervals. Best battery life. */
+    LowPower,
+
+    /**
+     * Balanced default. Moderate latency with reasonable power use.
+     * Preferred for general-purpose scanning.
+     */
+    Balanced,
+
+    /** Maximum throughput. Minimal latency at highest power cost. */
+    LowLatency,
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
@@ -34,6 +34,17 @@ public class ScannerConfig internal constructor() {
     public var legacyOnly: Boolean = true
 
     /**
+     * Scan strategy. Maps to Android `ScanSettings.Builder.setScanMode()`.
+     *
+     * | ------- | ------------------------------------------ |
+     * | Android | `ScanSettings.SCAN_MODE_*` (API 26+).      |
+     * | iOS     | No public API; CoreBluetooth chooses.      |
+     *
+     * Default: [ScanMode.Balanced].
+     */
+    public var scanMode: ScanMode = ScanMode.Balanced
+
+    /**
      * PHY to scan on. Maps to the Android `ScanSettings.Builder.setPhy()` value.
      *
      * - [ScanPhy.Le1M]: 1 Mbps scanning on primary channels (always supported).


### PR DESCRIPTION
## Problem
Scan mode was hardcoded to SCAN_MODE_LOW_LATENCY regardless of ScannerConfig. Users couldn't choose LowPower or Balanced modes for battery-sensitive applications.

## Solution
- Added ScanMode enum: LowPower, Balanced, LowLatency
- Wired scanMode into ScannerConfig with default LowLatency
- AndroidScanner.setScanMode() applies the configured mode
- Added AndroidScannerTest coverage for all 3 modes

Closes #335