### PR TITLE
feat(dx): add Peripheral.reconnect() for single-tap reconnection (#522)

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -95,8 +95,8 @@ public class AndroidPeripheral internal constructor(
     private var _lastConnectionOptions: ConnectionOptions? = null
     override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
 
-    private val _closed = atomic(false)
-    internal val closed: Boolean get() = _closed.value
+    private val _closed = java.util.concurrent.atomic.AtomicBoolean(false)
+    internal val closed: Boolean get() = _closed.get()
 
     /**
      * Confined to [peripheralContext.dispatcher]. Read by [handleConnectionStateChanged]

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -92,8 +92,11 @@ public class AndroidPeripheral internal constructor(
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
     override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = peripheralContext.dataLengthParameters
 
-    @Volatile
-    internal var closed = false
+    private var _lastConnectionOptions: ConnectionOptions? = null
+    override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
+
+    private val _closed = atomic(false)
+    internal val closed: Boolean get() = _closed.value
 
     /**
      * Confined to [peripheralContext.dispatcher]. Read by [handleConnectionStateChanged]
@@ -134,6 +137,7 @@ public class AndroidPeripheral internal constructor(
 
     @OptIn(ExperimentalBleApi::class)
     override suspend fun connect(options: ConnectionOptions) {
+        _lastConnectionOptions = options
         connectInternal(options)
     }
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -169,8 +169,8 @@ public class AndroidPeripheral internal constructor(
 
     @OptIn(ExperimentalBleApi::class)
     override fun close() {
-        if (closed) return
-        closed = true
+        if (_closed.get()) return
+        _closed.set(true)
         reconnectionHandler.stop()
         pairingRequestHandler.closeSync()
         bondManager.stop()

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -95,7 +96,7 @@ public class AndroidPeripheral internal constructor(
     private var _lastConnectionOptions: ConnectionOptions? = null
     override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
 
-    private val _closed = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val _closed = AtomicBoolean(false)
     internal val closed: Boolean get() = _closed.get()
 
     /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -39,6 +39,15 @@ public interface Peripheral : AutoCloseable {
 
     public suspend fun disconnect()
 
+    /**
+     * The [ConnectionOptions] used for the most recent [connect] call,
+     * or `null` if [connect] has never been invoked on this peripheral.
+     *
+     * Used by [com.atruedev.kmpble.peripheral.reconnect] to re-establish
+     * a connection with the same configuration after disconnect.
+     */
+    public val lastConnectionOptions: ConnectionOptions?
+
     override fun close()
 
     public val state: StateFlow<State>

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
@@ -1,7 +1,7 @@
 package com.atruedev.kmpble.peripheral
 
 import com.atruedev.kmpble.connection.ConnectionOptions
-import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.peripheral.state.State
 import kotlin.uuid.ExperimentalUuidApi
 
 /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
@@ -1,0 +1,46 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.State
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * Reconnect to this peripheral using the last-used [ConnectionOptions].
+ *
+ * After a successful [connect] call, the peripheral caches the options
+ * used. [reconnect] retrieves those cached options, re-establishes the
+ * connection, and re-discovers GATT services (since GATT state is lost
+ * on disconnect).
+ *
+ * ```kotlin
+ * peripheral.connect(ConnectionOptions.Balanced)
+ * // ... work with the peripheral ...
+ * peripheral.disconnect()
+ * // ... later, reconnect with the same options ...
+ * peripheral.reconnect()
+ * ```
+ *
+ * Behavior:
+ * - Uses the [ConnectionOptions] from the most recent [connect] call.
+ * - Re-discovers GATT services after connecting (since GATT state is lost).
+ * - If [connect] was never called, throws [IllegalStateException].
+ *
+ * @throws IllegalStateException if [connect] was never called (no cached options)
+ *   or if the peripheral is already in [State.Connected.Ready].
+ * @throws com.atruedev.kmpble.error.BleException if reconnection fails.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public suspend fun Peripheral.reconnect() {
+    val lastOptions = lastConnectionOptions
+        ?: throw IllegalStateException(
+            "Cannot reconnect: connect() has not been called yet. " +
+                "Call connect(options) first, then use reconnect() after disconnect.",
+        )
+
+    check(state.value !is State.Connected.Ready) {
+        "Cannot reconnect: peripheral is already connected"
+    }
+
+    connect(lastOptions)
+    refreshServices()
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralReconnect.kt
@@ -31,11 +31,12 @@ import kotlin.uuid.ExperimentalUuidApi
  */
 @OptIn(ExperimentalUuidApi::class)
 public suspend fun Peripheral.reconnect() {
-    val lastOptions = lastConnectionOptions
-        ?: throw IllegalStateException(
-            "Cannot reconnect: connect() has not been called yet. " +
-                "Call connect(options) first, then use reconnect() after disconnect.",
-        )
+    val lastOptions =
+        lastConnectionOptions
+            ?: throw IllegalStateException(
+                "Cannot reconnect: connect() has not been called yet. " +
+                    "Call connect(options) first, then use reconnect() after disconnect.",
+            )
 
     check(state.value !is State.Connected.Ready) {
         "Cannot reconnect: peripheral is already connected"

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -62,6 +62,8 @@ public class FakePeripheral internal constructor(
     internal val peripheralContext: PeripheralContext get() = context
     internal val observationManager = ObservationManager(observationDispatcher)
     private var closed = false
+    private var _lastConnectionOptions: ConnectionOptions? = null
+    override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
     internal val cccdWritesState = MutableStateFlow<List<CccdWrite>>(emptyList())
 
     internal val connectionSimulator =
@@ -100,6 +102,7 @@ public class FakePeripheral internal constructor(
 
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
+        _lastConnectionOptions = options
         context.processEvent(ConnectionEvent.ConnectRequested)
         context.gattQueue.start()
 

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
@@ -1,0 +1,155 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.PhyMask
+import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.scanner.uuidFrom
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Peripheral.reconnect] extension function.
+ *
+ * Validates that reconnect() uses the last-used ConnectionOptions,
+ * re-discovers services, and handles edge cases correctly.
+ */
+class ReconnectTest {
+
+    @Test
+    fun reconnect_throwsWhenNoPreviousConnection() =
+        runTest {
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            assertFailsWith<IllegalStateException> {
+                peripheral.reconnect()
+            }
+        }
+
+    @Test
+    fun reconnect_connectsAfterDisconnect() =
+        runTest {
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            peripheral.connect()
+            peripheral.disconnect()
+            peripheral.reconnect()
+
+            assertIs<State.Connected.Ready>(peripheral.state.value)
+            peripheral.disconnect()
+        }
+
+    @Test
+    fun reconnect_rediscoverServicesAfterDisconnect() =
+        runTest {
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+                service("180f") {
+                    characteristic("2a19") { properties(read = true) }
+                }
+            }
+
+            peripheral.connect()
+            peripheral.disconnect()
+            peripheral.reconnect()
+
+            val services = peripheral.services.value
+            assertTrue(services?.isNotEmpty() == true)
+            assertEquals(2, services?.size)
+            peripheral.disconnect()
+        }
+
+    @Test
+    fun reconnect_usesDefaultOptionsWhenConnectHadDefaults() =
+        runTest {
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            peripheral.connect()
+            peripheral.disconnect()
+            peripheral.reconnect()
+
+            assertIs<State.Connected.Ready>(peripheral.state.value)
+            peripheral.disconnect()
+        }
+
+    @Test
+    fun reconnect_usesCustomOptionsFromPreviousConnect() =
+        runTest {
+            val options = ConnectionOptions(
+                autoConnect = false,
+                phyMask = PhyMask.LE_2M,
+                mtuRequest = 185,
+            )
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            peripheral.connect(options)
+            peripheral.disconnect()
+            peripheral.reconnect()
+
+            // If the peripheral accepted the connection, options were used
+            assertIs<State.Connected.Ready>(peripheral.state.value)
+            peripheral.disconnect()
+        }
+
+    @Test
+    fun reconnect_whileAlreadyConnected_throwsError() =
+        runTest {
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            peripheral.connect()
+
+            assertFailsWith<IllegalStateException> {
+                peripheral.reconnect()
+            }
+
+            peripheral.disconnect()
+        }
+
+    @Test
+    fun reconnect_maintainsConnectCallCount() =
+        runTest {
+            val connectAttempts = mutableListOf<Int>()
+
+            val peripheral = FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true) }
+                }
+            }
+
+            // First connect
+            peripheral.connect()
+            peripheral.disconnect()
+
+            // Reconnect should count as a new connect
+            peripheral.reconnect()
+
+            assertIs<State.Connected.Ready>(peripheral.state.value)
+            peripheral.disconnect()
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
@@ -2,7 +2,7 @@ package com.atruedev.kmpble.peripheral
 
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.PhyMask
-import com.atruedev.kmpble.connection.State
+import com.atruedev.kmpble.peripheral.state.State
 import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.testing.FakePeripheral
 import kotlinx.coroutines.test.runTest

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/ReconnectTest.kt
@@ -3,7 +3,6 @@ package com.atruedev.kmpble.peripheral
 import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.PhyMask
 import com.atruedev.kmpble.peripheral.state.State
-import com.atruedev.kmpble.scanner.uuidFrom
 import com.atruedev.kmpble.testing.FakePeripheral
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -19,15 +18,15 @@ import kotlin.test.assertTrue
  * re-discovers services, and handles edge cases correctly.
  */
 class ReconnectTest {
-
     @Test
     fun reconnect_throwsWhenNoPreviousConnection() =
         runTest {
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             assertFailsWith<IllegalStateException> {
                 peripheral.reconnect()
@@ -37,11 +36,12 @@ class ReconnectTest {
     @Test
     fun reconnect_connectsAfterDisconnect() =
         runTest {
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             peripheral.connect()
             peripheral.disconnect()
@@ -54,14 +54,15 @@ class ReconnectTest {
     @Test
     fun reconnect_rediscoverServicesAfterDisconnect() =
         runTest {
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
+                    service("180f") {
+                        characteristic("2a19") { properties(read = true) }
+                    }
                 }
-                service("180f") {
-                    characteristic("2a19") { properties(read = true) }
-                }
-            }
 
             peripheral.connect()
             peripheral.disconnect()
@@ -76,11 +77,12 @@ class ReconnectTest {
     @Test
     fun reconnect_usesDefaultOptionsWhenConnectHadDefaults() =
         runTest {
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             peripheral.connect()
             peripheral.disconnect()
@@ -93,16 +95,18 @@ class ReconnectTest {
     @Test
     fun reconnect_usesCustomOptionsFromPreviousConnect() =
         runTest {
-            val options = ConnectionOptions(
-                autoConnect = false,
-                phyMask = PhyMask.LE_2M,
-                mtuRequest = 185,
-            )
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val options =
+                ConnectionOptions(
+                    autoConnect = false,
+                    phyMask = PhyMask.LE_2M,
+                    mtuRequest = 185,
+                )
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             peripheral.connect(options)
             peripheral.disconnect()
@@ -116,11 +120,12 @@ class ReconnectTest {
     @Test
     fun reconnect_whileAlreadyConnected_throwsError() =
         runTest {
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             peripheral.connect()
 
@@ -136,11 +141,12 @@ class ReconnectTest {
         runTest {
             val connectAttempts = mutableListOf<Int>()
 
-            val peripheral = FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true) }
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") { properties(read = true) }
+                    }
                 }
-            }
 
             // First connect
             peripheral.connect()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -120,7 +120,7 @@ public class IosPeripheral(
         }
     }
 
-    override suspend fun connect(options: ConnectionOptions): Unit {
+    override suspend fun connect(options: ConnectionOptions) {
         _lastConnectionOptions = options
         connectInternal(options)
     }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -81,6 +81,9 @@ public class IosPeripheral(
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
+    internal var _lastConnectionOptions: ConnectionOptions? = null
+    override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
+
     override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = peripheralContext.dataLengthParameters
 
     internal val _closed = atomic(false)
@@ -117,7 +120,10 @@ public class IosPeripheral(
         }
     }
 
-    override suspend fun connect(options: ConnectionOptions): Unit = connectInternal(options)
+    override suspend fun connect(options: ConnectionOptions): Unit {
+        _lastConnectionOptions = options
+        connectInternal(options)
+    }
 
     override suspend fun disconnect(): Unit = disconnectInternal()
 

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -46,6 +46,7 @@ internal class StubPeripheral(
     override val services: StateFlow<List<DiscoveredService>?> = MutableStateFlow(null)
     override val maximumWriteValueLength: StateFlow<Int> = MutableStateFlow(20)
     override val mtu: StateFlow<Int> = MutableStateFlow(23)
+    override val lastConnectionOptions: ConnectionOptions? = null
 
     override suspend fun connect(options: ConnectionOptions) = unsupported()
 


### PR DESCRIPTION
Clean rebase of #522 - resolves merge conflicts.

- Add lastConnectionOptions property to Peripheral interface
- Add reconnect() extension that reuses last-used ConnectionOptions
- Auto re-discovers services after reconnection
- Throws IllegalStateException when connect() never called or already connected

Closes #522