### PR TITLE
fix(test): use Uuid.fromLongs instead of string manipulation for unique test UUIDs

### DIFF
--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceAndroidHostTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceAndroidHostTest.kt
@@ -516,11 +516,9 @@ class ObservationPersistenceAndroidHostTest {
         val observations =
             (1..100)
                 .map { index ->
-                    val suffix = index.toString(16).padStart(2, '0')
-                    val uniqueUuid =
-                        Uuid.parse("00002a37-0000-1000-8000-00805f9b34$suffix")
+                    val charUuid = Uuid.fromLongs(0, index.toLong())
                     PersistedObservation(
-                        ObservationKey(uniqueUuid, uniqueUuid),
+                        ObservationKey(serviceUuid, charUuid),
                         BackpressureStrategy.Latest,
                     )
                 }.toSet()


### PR DESCRIPTION
## Summary

Replace the fragile `Uuid.parse("...f9b34$suffix")` with `Uuid.fromLongs(0, index.toLong())` 
in `largeNumberOfObservationsRoundtripsCorrectly`. 

The string manipulation approach was:
- Fragile (depends on exact UUID format and hex padding)
- Obscured test intent (hard to see that each UUID is unique)
- Hard to maintain (off-by-one in hex padding could break silently)

`Uuid.fromLongs` generates unique UUIDs deterministically without string parsing.