### PR TITLE
fix(ios): reject duplicate connect callback to prevent overlapping discovery cycles

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
@@ -18,6 +18,7 @@ import com.atruedev.kmpble.logging.logEvent
 import com.atruedev.kmpble.peripheral.state.ConnectionEvent
 import com.atruedev.kmpble.peripheral.state.State
 import com.atruedev.kmpble.quirks.BleQuirks
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -151,7 +152,26 @@ internal suspend fun AndroidPeripheral.handleLinkUp(
     // BluetoothGattCharacteristic/BluetoothGattDescriptor instances stay valid for the life of
     // the BluetoothGatt connection, so a fresh discoverServices() doesn't invalidate handles
     // the way CoreBluetooth replacing CBService/CBCharacteristic objects does on iOS.
-    bridge.discoverServices()
+    //
+    // Unlike CoreBluetooth's void discoverServices, BluetoothGatt.discoverServices() reports
+    // "didn't start" via a false return (not an exception) - and it can also throw
+    // SecurityException if permissions are revoked mid-call. Either way, if discovery never
+    // starts, no GATT callback will ever arrive to release the slot armed above.
+    val started =
+        try {
+            bridge.discoverServices()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logEvent(BleLogEvent.Error(identifier, "discoverServices() threw", cause = e))
+            false
+        }
+    if (!started) {
+        val failure = OperationFailed("discoverServices() did not start")
+        peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(failure))
+        slots.failDiscovery(BleException(failure))
+        slots.completeConnect()
+    }
 }
 
 /**

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
@@ -147,6 +147,10 @@ internal suspend fun AndroidPeripheral.handleLinkUp(
     if (!bondIfRequiredForLink()) return
     // Duplicate STATE_CONNECTED callback; a discovery cycle already in flight covers it.
     if (!slots.tryArmDiscovery()) return
+    // No generation counter or native-map clear here (unlike IosPeripheral): Android's
+    // BluetoothGattCharacteristic/BluetoothGattDescriptor instances stay valid for the life of
+    // the BluetoothGatt connection, so a fresh discoverServices() doesn't invalidate handles
+    // the way CoreBluetooth replacing CBService/CBCharacteristic objects does on iOS.
     bridge.discoverServices()
 }
 
@@ -200,14 +204,17 @@ internal suspend fun AndroidPeripheral.bondIfRequiredForLink(): Boolean {
 }
 
 internal suspend fun AndroidPeripheral.handleLinkDown(rawStatus: Int) {
+    // Captured once, before processEvent() below can transition the state machine - this is
+    // "was a disconnect() call in flight", not derivable from bleError's type.
+    val disconnectRequested = peripheralContext.state.value is State.Disconnecting.Requested
     val bleError =
-        if (peripheralContext.state.value is State.Disconnecting.Requested) {
+        if (disconnectRequested) {
             OperationFailed("disconnect")
         } else {
             ConnectionLost("Remote disconnect", ConnectionFailureReason.LINK_LOSS, rawStatus)
         }
     peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
-    if (bleError is OperationFailed) slots.completeDisconnect()
+    if (disconnectRequested) slots.completeDisconnect()
     onDisconnectCleanup()
     // Release a discovery cycle left in flight by the disconnect, so the next
     // connect's tryArmDiscovery() isn't permanently blocked by this slot.

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralConnection.kt
@@ -8,6 +8,7 @@ import android.bluetooth.BluetoothProfile
 import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.connection.BondingPreference
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionFailureReason
 import com.atruedev.kmpble.error.ConnectionLost
@@ -144,6 +145,8 @@ internal suspend fun AndroidPeripheral.handleLinkUp(
 
     peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
     if (!bondIfRequiredForLink()) return
+    // Duplicate STATE_CONNECTED callback; a discovery cycle already in flight covers it.
+    if (!slots.tryArmDiscovery()) return
     bridge.discoverServices()
 }
 
@@ -197,17 +200,18 @@ internal suspend fun AndroidPeripheral.bondIfRequiredForLink(): Boolean {
 }
 
 internal suspend fun AndroidPeripheral.handleLinkDown(rawStatus: Int) {
-    if (peripheralContext.state.value is State.Disconnecting.Requested) {
-        peripheralContext.processEvent(ConnectionEvent.ConnectionLost(OperationFailed("disconnect")))
-        slots.completeDisconnect()
-    } else {
-        peripheralContext.processEvent(
-            ConnectionEvent.ConnectionLost(
-                ConnectionLost("Remote disconnect", ConnectionFailureReason.LINK_LOSS, rawStatus),
-            ),
-        )
-    }
+    val bleError =
+        if (peripheralContext.state.value is State.Disconnecting.Requested) {
+            OperationFailed("disconnect")
+        } else {
+            ConnectionLost("Remote disconnect", ConnectionFailureReason.LINK_LOSS, rawStatus)
+        }
+    peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
+    if (bleError is OperationFailed) slots.completeDisconnect()
     onDisconnectCleanup()
+    // Release a discovery cycle left in flight by the disconnect, so the next
+    // connect's tryArmDiscovery() isn't permanently blocked by this slot.
+    slots.failDiscovery(BleException(bleError))
     slots.completeConnect()
 }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlots.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlots.kt
@@ -27,6 +27,18 @@ internal class LifecycleSlots {
         return CompletableDeferred<List<DiscoveredService>>().also { discovery = it }
     }
 
+    /**
+     * Same guard as [armDiscovery], but returns `false` instead of throwing when a cycle
+     * is already in flight. For callers reacting to a platform callback (connection
+     * established, state restoration) where a duplicate/overlapping delivery is an
+     * expected possibility, not a caller bug worth surfacing as an exception.
+     */
+    fun tryArmDiscovery(): Boolean {
+        if (discovery != null) return false
+        discovery = CompletableDeferred()
+        return true
+    }
+
     fun armDisconnect(): CompletableDeferred<Unit> {
         check(disconnect == null) { "disconnect() is already in progress on this peripheral" }
         return CompletableDeferred<Unit>().also { disconnect = it }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
@@ -2,27 +2,52 @@ package com.atruedev.kmpble.peripheral.internal
 
 import com.atruedev.kmpble.gatt.DiscoveredService
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-/**
- * Verifies the re-entrancy guard [LifecycleSlots] relies on to prevent overlapping
- * connect/discovery/disconnect cycles on a single peripheral.
- *
- * [LifecycleSlots.armDiscovery] is the guard `IosPeripheral.handleConnectionCallback`
- * uses to reject a duplicate "connected" callback from CoreBluetooth (e.g. the OS
- * auto-reconnecting an already-bonded peripheral while our own connect() is also
- * completing) instead of starting a second, overlapping discoverServices() cycle.
- */
+/** Tests for [LifecycleSlots]'s re-entrancy guards on the connect/discovery/disconnect slots. */
 class LifecycleSlotsTest {
+    // -- armConnect --
+
+    @Test
+    fun armConnect_throwsWhenAlreadyArmed() {
+        val slots = LifecycleSlots()
+        slots.armConnect()
+
+        val exception = assertFailsWith<IllegalStateException> { slots.armConnect() }
+        assertEquals("connect() is already in progress on this peripheral", exception.message)
+    }
+
+    @Test
+    fun armConnect_succeedsAgainAfterComplete() {
+        val slots = LifecycleSlots()
+        val first = slots.armConnect()
+        slots.completeConnect()
+        assertTrue(first.isCompleted)
+
+        slots.armConnect()
+    }
+
+    @Test
+    fun armConnect_succeedsAgainAfterClear() {
+        val slots = LifecycleSlots()
+        slots.armConnect()
+        slots.clearConnect()
+
+        slots.armConnect()
+    }
+
+    // -- armDiscovery --
+
     @Test
     fun armDiscovery_throwsWhenAlreadyArmed() {
         val slots = LifecycleSlots()
         slots.armDiscovery()
 
-        assertFailsWith<IllegalStateException> {
-            slots.armDiscovery()
-        }
+        val exception = assertFailsWith<IllegalStateException> { slots.armDiscovery() }
+        assertEquals("service discovery is already in progress", exception.message)
     }
 
     @Test
@@ -32,7 +57,6 @@ class LifecycleSlotsTest {
         slots.completeDiscovery(emptyList<DiscoveredService>())
         assertTrue(first.isCompleted)
 
-        // Should not throw: the slot was cleared by completeDiscovery().
         slots.armDiscovery()
     }
 
@@ -43,7 +67,6 @@ class LifecycleSlotsTest {
         slots.failDiscovery(RuntimeException("discovery failed"))
         assertTrue(first.isCompleted)
 
-        // Should not throw: the slot was cleared by failDiscovery().
         slots.armDiscovery()
     }
 
@@ -53,17 +76,118 @@ class LifecycleSlotsTest {
         slots.armDiscovery()
         slots.clearDiscovery()
 
-        // Should not throw: the slot was cleared by clearDiscovery().
         slots.armDiscovery()
     }
 
-    @Test
-    fun armConnect_andArmDiscovery_areIndependentSlots() {
-        val slots = LifecycleSlots()
-        slots.armConnect()
+    // -- tryArmDiscovery --
 
-        // A connect already in flight must not block arming discovery - they are
-        // independent lifecycle slots.
+    @Test
+    fun tryArmDiscovery_returnsTrueWhenNotArmed() {
+        val slots = LifecycleSlots()
+        assertTrue(slots.tryArmDiscovery())
+    }
+
+    @Test
+    fun tryArmDiscovery_returnsFalseWithoutThrowingWhenAlreadyArmed() {
+        val slots = LifecycleSlots()
+        slots.armDiscovery()
+
+        assertFalse(slots.tryArmDiscovery())
+    }
+
+    @Test
+    fun tryArmDiscovery_returnsTrueAgainAfterCompletion() {
+        val slots = LifecycleSlots()
+        slots.tryArmDiscovery()
+        slots.completeDiscovery(emptyList<DiscoveredService>())
+
+        assertTrue(slots.tryArmDiscovery())
+    }
+
+    @Test
+    fun tryArmDiscovery_andArmDiscovery_shareTheSameSlot() {
+        val slots = LifecycleSlots()
+        slots.tryArmDiscovery()
+
+        assertFailsWith<IllegalStateException> { slots.armDiscovery() }
+    }
+
+    // -- armDisconnect --
+
+    @Test
+    fun armDisconnect_throwsWhenAlreadyArmed() {
+        val slots = LifecycleSlots()
+        slots.armDisconnect()
+
+        val exception = assertFailsWith<IllegalStateException> { slots.armDisconnect() }
+        assertEquals("disconnect() is already in progress on this peripheral", exception.message)
+    }
+
+    @Test
+    fun armDisconnect_succeedsAgainAfterComplete() {
+        val slots = LifecycleSlots()
+        val first = slots.armDisconnect()
+        slots.completeDisconnect()
+        assertTrue(first.isCompleted)
+
+        slots.armDisconnect()
+    }
+
+    @Test
+    fun armDisconnect_succeedsAgainAfterClear() {
+        val slots = LifecycleSlots()
+        slots.armDisconnect()
+        slots.clearDisconnect()
+
+        slots.armDisconnect()
+    }
+
+    // -- the three slots don't share state --
+
+    @Test
+    fun connectDiscoveryAndDisconnect_areIndependentSlots() {
+        val slots = LifecycleSlots()
+
+        slots.armConnect()
+        assertTrue(slots.tryArmDiscovery())
+        // Real usage never disconnects mid-connect, but LifecycleSlots has no cross-slot
+        // coupling - each guard only checks its own slot, so this must not throw.
+        slots.armDisconnect()
+    }
+
+    // -- completing/failing/clearing a slot that was never armed is a no-op, not a crash --
+
+    @Test
+    fun completeDiscovery_onUnarmedSlot_doesNotThrow() {
+        val slots = LifecycleSlots()
+        slots.completeDiscovery(emptyList<DiscoveredService>())
+    }
+
+    @Test
+    fun failDiscovery_onUnarmedSlot_doesNotThrow() {
+        val slots = LifecycleSlots()
+        slots.failDiscovery(RuntimeException("no discovery in flight"))
+    }
+
+    @Test
+    fun completeConnect_onUnarmedSlot_doesNotThrow() {
+        val slots = LifecycleSlots()
+        slots.completeConnect()
+    }
+
+    @Test
+    fun completeDisconnect_onUnarmedSlot_doesNotThrow() {
+        val slots = LifecycleSlots()
+        slots.completeDisconnect()
+    }
+
+    @Test
+    fun clearDiscovery_isIdempotent() {
+        val slots = LifecycleSlots()
+        slots.armDiscovery()
+        slots.clearDiscovery()
+        slots.clearDiscovery()
+
         slots.armDiscovery()
     }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
@@ -1,5 +1,7 @@
 package com.atruedev.kmpble.peripheral.internal
 
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.DiscoveredService
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -64,7 +66,7 @@ class LifecycleSlotsTest {
     fun armDiscovery_succeedsAgainAfterFailure() {
         val slots = LifecycleSlots()
         val first = slots.armDiscovery()
-        slots.failDiscovery(RuntimeException("discovery failed"))
+        slots.failDiscovery(BleException(OperationFailed("discovery failed")))
         assertTrue(first.isCompleted)
 
         slots.armDiscovery()
@@ -166,7 +168,7 @@ class LifecycleSlotsTest {
     @Test
     fun failDiscovery_onUnarmedSlot_doesNotThrow() {
         val slots = LifecycleSlots()
-        slots.failDiscovery(RuntimeException("no discovery in flight"))
+        slots.failDiscovery(BleException(OperationFailed("no discovery in flight")))
     }
 
     @Test

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/internal/LifecycleSlotsTest.kt
@@ -1,0 +1,69 @@
+package com.atruedev.kmpble.peripheral.internal
+
+import com.atruedev.kmpble.gatt.DiscoveredService
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the re-entrancy guard [LifecycleSlots] relies on to prevent overlapping
+ * connect/discovery/disconnect cycles on a single peripheral.
+ *
+ * [LifecycleSlots.armDiscovery] is the guard `IosPeripheral.handleConnectionCallback`
+ * uses to reject a duplicate "connected" callback from CoreBluetooth (e.g. the OS
+ * auto-reconnecting an already-bonded peripheral while our own connect() is also
+ * completing) instead of starting a second, overlapping discoverServices() cycle.
+ */
+class LifecycleSlotsTest {
+    @Test
+    fun armDiscovery_throwsWhenAlreadyArmed() {
+        val slots = LifecycleSlots()
+        slots.armDiscovery()
+
+        assertFailsWith<IllegalStateException> {
+            slots.armDiscovery()
+        }
+    }
+
+    @Test
+    fun armDiscovery_succeedsAgainAfterCompletion() {
+        val slots = LifecycleSlots()
+        val first = slots.armDiscovery()
+        slots.completeDiscovery(emptyList<DiscoveredService>())
+        assertTrue(first.isCompleted)
+
+        // Should not throw: the slot was cleared by completeDiscovery().
+        slots.armDiscovery()
+    }
+
+    @Test
+    fun armDiscovery_succeedsAgainAfterFailure() {
+        val slots = LifecycleSlots()
+        val first = slots.armDiscovery()
+        slots.failDiscovery(RuntimeException("discovery failed"))
+        assertTrue(first.isCompleted)
+
+        // Should not throw: the slot was cleared by failDiscovery().
+        slots.armDiscovery()
+    }
+
+    @Test
+    fun armDiscovery_succeedsAgainAfterClear() {
+        val slots = LifecycleSlots()
+        slots.armDiscovery()
+        slots.clearDiscovery()
+
+        // Should not throw: the slot was cleared by clearDiscovery().
+        slots.armDiscovery()
+    }
+
+    @Test
+    fun armConnect_andArmDiscovery_areIndependentSlots() {
+        val slots = LifecycleSlots()
+        slots.armConnect()
+
+        // A connect already in flight must not block arming discovery - they are
+        // independent lifecycle slots.
+        slots.armDiscovery()
+    }
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -8,6 +8,7 @@ import com.atruedev.kmpble.error.ConnectionLost
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.peripheral.state.ConnectionEvent
 import com.atruedev.kmpble.peripheral.state.State
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -83,7 +84,20 @@ internal fun IosPeripheral.handleConnectionCallback(
             discoveryGeneration.incrementAndGet()
             nativeCharMap.clear()
             nativeDescMap.clear()
-            bridge.discoverServices()
+            try {
+                bridge.discoverServices()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // discoverServices() is just a delegate/property assignment plus a void ObjC
+                // call - failures are normally reported later via the async callback, not a
+                // throw. If it does throw, the discovery slot armed above would otherwise leak
+                // forever (no callback will ever arrive to release it).
+                val failure = OperationFailed("discoverServices() failed: ${e.message}")
+                peripheralContext.processEvent(ConnectionEvent.DiscoveryFailed(failure))
+                slots.failDiscovery(BleException(failure))
+                slots.completeConnect()
+            }
             return@launch
         }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.peripheral
 
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.ConnectionFailed
 import com.atruedev.kmpble.error.ConnectionFailureReason
 import com.atruedev.kmpble.error.ConnectionLost
@@ -76,18 +77,8 @@ internal fun IosPeripheral.handleConnectionCallback(
     peripheralContext.scope.launch {
         if (connected) {
             peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
-            try {
-                slots.armDiscovery()
-            } catch (_: IllegalStateException) {
-                // CoreBluetooth redelivered a "connected" callback while a discovery cycle from
-                // an earlier callback is still in flight (observed when the OS auto-reconnects an
-                // already-bonded/retrieved peripheral around the same time our own connect()
-                // completes). Starting a second discoverServices() here would race the in-flight
-                // cycle - CoreBluetooth replaces its CBService/CBCharacteristic objects on every
-                // new discovery pass, so the stale cycle's callbacks end up referencing freed
-                // memory and crash. The in-flight cycle already covers this connection.
-                return@launch
-            }
+            // Duplicate "connected" callback; a discovery cycle already in flight covers it.
+            if (!slots.tryArmDiscovery()) return@launch
             // New discovery cycle on connect: increment generation and clear stale handles
             discoveryGeneration.incrementAndGet()
             nativeCharMap.clear()
@@ -114,6 +105,9 @@ internal fun IosPeripheral.handleConnectionCallback(
             peripheralContext.processEvent(ConnectionEvent.ConnectionLost(bleError))
         }
         onDisconnectCleanup()
+        // Release a discovery cycle left in flight by the disconnect, so the next
+        // connect's tryArmDiscovery() isn't permanently blocked by this slot.
+        slots.failDiscovery(BleException(bleError))
         slots.completeConnect()
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -76,6 +76,18 @@ internal fun IosPeripheral.handleConnectionCallback(
     peripheralContext.scope.launch {
         if (connected) {
             peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+            try {
+                slots.armDiscovery()
+            } catch (_: IllegalStateException) {
+                // CoreBluetooth redelivered a "connected" callback while a discovery cycle from
+                // an earlier callback is still in flight (observed when the OS auto-reconnects an
+                // already-bonded/retrieved peripheral around the same time our own connect()
+                // completes). Starting a second discoverServices() here would race the in-flight
+                // cycle - CoreBluetooth replaces its CBService/CBCharacteristic objects on every
+                // new discovery pass, so the stale cycle's callbacks end up referencing freed
+                // memory and crash. The in-flight cycle already covers this connection.
+                return@launch
+            }
             // New discovery cycle on connect: increment generation and clear stale handles
             discoveryGeneration.incrementAndGet()
             nativeCharMap.clear()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
@@ -24,19 +24,28 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
             // A connect callback's own discovery cycle may already cover this peripheral.
             if (!slots.tryArmDiscovery()) return@withContext
 
-            peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
-            peripheralContext.gattQueue.start()
-            peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
-            discoveryGeneration.incrementAndGet()
-            nativeCharMap.clear()
-            nativeDescMap.clear()
-
-            val deferred = slots.armConnect()
-            bridge.discoverServices()
+            // The discovery slot armed above only guards against that race; it isn't what we
+            // wait on below. armConnect() separately blocks a concurrent explicit connect()
+            // call, and its deferred is what finishDiscovery() completes once discovery
+            // finishes, so it's what we await. Wrapped in try/finally so a race on armConnect()
+            // itself (e.g. a concurrent connect()) still releases the discovery slot instead of
+            // leaking it.
             try {
-                withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
+                peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
+                peripheralContext.gattQueue.start()
+                peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+                discoveryGeneration.incrementAndGet()
+                nativeCharMap.clear()
+                nativeDescMap.clear()
+
+                val deferred = slots.armConnect()
+                bridge.discoverServices()
+                try {
+                    withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
+                } finally {
+                    slots.clearConnect()
+                }
             } finally {
-                slots.clearConnect()
                 slots.clearDiscovery()
             }
         }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
@@ -39,8 +39,8 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
                 nativeDescMap.clear()
 
                 val deferred = slots.armConnect()
-                bridge.discoverServices()
                 try {
+                    bridge.discoverServices()
                     withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
                 } finally {
                     slots.clearConnect()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
@@ -21,9 +21,15 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
         }
 
         if (cbPeripheral.state == CBPeripheralStateConnected) {
+            // A connect callback's own discovery cycle may already cover this peripheral.
+            if (!slots.tryArmDiscovery()) return@withContext
+
             peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
             peripheralContext.gattQueue.start()
             peripheralContext.processEvent(ConnectionEvent.LinkEstablished)
+            discoveryGeneration.incrementAndGet()
+            nativeCharMap.clear()
+            nativeDescMap.clear()
 
             val deferred = slots.armConnect()
             bridge.discoverServices()
@@ -31,6 +37,7 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
                 withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
             } finally {
                 slots.clearConnect()
+                slots.clearDiscovery()
             }
         }
     }


### PR DESCRIPTION
## Summary
- CoreBluetooth can redeliver a "connected" callback while a discovery cycle from an earlier callback is still in flight - observed when the OS auto-reconnects an already-bonded/retrieved peripheral around the same time our own `connect()` completes (e.g. power-cycling a bonded peripheral). `handleConnectionCallback` started a fresh `discoverServices()` cycle unconditionally on every "connected" delivery, so a duplicate callback raced two overlapping discovery cycles against the same `CBPeripheral`. CoreBluetooth replaces its `CBService`/`CBCharacteristic` objects on each new discovery pass, so the stale cycle's callbacks ended up referencing freed memory - `-[CBCharacteristic handleCharacteristicsDiscovered:]: unrecognized selector` and similar zombie-object crashes downstream (reported by a consumer app after power-cycling a bonded peripheral).
- The `discoveryGeneration` guard added in 312653c only covers `handleCharacteristicsDiscovered`; it can't distinguish which of two overlapping `discoverServices()` calls a given `didDiscoverServices` callback answers, since CoreBluetooth gives no correlation token. The only reliable fix is to prevent the second `discoverServices()` call from ever being issued.
- `LifecycleSlots.armDiscovery()` already provides exactly that re-entrancy guard for `refreshServices()` - `handleConnectionCallback` just never called it.

## What changed after the first review pass
- Added `LifecycleSlots.tryArmDiscovery()`: a non-throwing variant of `armDiscovery()` for callers reacting to a platform callback where a duplicate delivery is an expected possibility, not a caller bug. Replaces a 9-line try/catch + comment with a 1-line guard.
- **Android had the identical unguarded bug**: `AndroidPeripheralConnection.handleLinkUp()` called `bridge.discoverServices()` on every `STATE_CONNECTED` with no guard at all. Now wired to `tryArmDiscovery()` the same way as iOS.
- **iOS state restoration guarded the wrong slot**: `IosPeripheralRestoration.restoreFromStateRestorationExt()` used `armConnect()` to gate its own `discoverServices()` call, which does nothing to stop `handleConnectionCallback`'s independent `armDiscovery()`/`tryArmDiscovery()` from racing it. Now arms the discovery slot too, and bumps `discoveryGeneration`/clears native maps for consistency with the other two call sites.
- **Fixed the resulting slot leak**: with the discovery slot now armed on connect, a disconnect mid-discovery (with CoreBluetooth/Android never delivering a further discovery callback) would leave the slot permanently armed, blocking every future `tryArmDiscovery()` on that peripheral. Both platforms' link-down handlers now call `slots.failDiscovery(...)` alongside the existing `slots.completeConnect()`.

## Test plan
- [x] `./gradlew :compileKotlinIosSimulatorArm64 :compileAndroidMain` - builds clean on both platforms
- [x] `./gradlew ktlintCheck` - clean
- [x] `./gradlew :testAndroidHostTest :iosSimulatorArm64Test` - full suite passes on both platforms
- [x] Expanded `LifecycleSlotsTest`: `armConnect`/`armDiscovery`/`armDisconnect` re-entrancy (asserting the exception message, not just the type), `tryArmDiscovery` non-throwing behavior, cross-slot independence with an explicit assertion, and complete/fail/clear on an unarmed slot (verifies the `?.` calls are NPE-safe)