### PR TITLE
fix(ci): replace broken CodeQL default setup with explicit workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1' # weekly on Monday
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@641a925cfafe92d0fdf8b239ba4053e3f8d99d6d # v3.28.18
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@641a925cfafe92d0fdf8b239ba4053e3f8d99d6d # v3.28.18


### PR DESCRIPTION
## Problem
The GitHub **default setup** for CodeQL was auto-generating invalid action references:

```
Internal Server Error occurred while resolving actions/checkout@v6
Internal Server Error occurred while resolving github/codeql-action@v4
```

Neither version exists:
- `actions/checkout` latest is **v4** (v6 doesn't exist)
- `github/codeql-action` latest is **v3** (v4 doesn't exist)

This is a GitHub-side bug in their auto-generated default-setup workflow that uses non-existent major version tags.

## Fix
1. Created an explicit `.github/workflows/codeql.yml` with correct commit SHAs verified via GitHub API:
   - `actions/checkout@34e1148` (v4.2.2)
   - `github/codeql-action@641a925` (v3.28.18)
2. Disabled the broken default setup via API to avoid conflicts
3. Kept `languages: actions` as configured in the default setup

The explicit workflow overrides the default setup and uses the same SHA-pinning convention as `ci.yml` and `publish.yml`.