### PR TITLE
fix(android): wire ObservationPersistence.context + warn when legacyOnly hides Extended Advertising

### DIFF
--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/KmpBleInitializerHostTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/KmpBleInitializerHostTest.kt
@@ -1,11 +1,14 @@
 package com.atruedev.kmpble
 
+import com.atruedev.kmpble.gatt.internal.ObservationPersistence
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
@@ -15,6 +18,7 @@ class KmpBleInitializerHostTest {
         val field = KmpBle::class.java.getDeclaredField("appContext")
         field.isAccessible = true
         field.set(KmpBle, null)
+        ObservationPersistence.context = null
     }
 
     @Test
@@ -33,6 +37,18 @@ class KmpBleInitializerHostTest {
 
         val context = KmpBle.requireContext()
         assertTrue(context === context.applicationContext)
+    }
+
+    @Test
+    fun init_alsoWiresObservationPersistenceContext() {
+        assertNull(ObservationPersistence.context)
+
+        val appContext = RuntimeEnvironment.getApplication()
+        KmpBle.init(appContext)
+
+        // Peripheral.close() calls into ObservationPersistence unconditionally; without
+        // this wiring it throws IllegalStateException on every close() (see KmpBle.init()).
+        assertSame(KmpBle.requireContext(), ObservationPersistence.context)
     }
 
     @Test

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/scanner/AndroidScannerTest.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.scanner
 import android.bluetooth.le.ScanSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -69,6 +70,24 @@ class AndroidScannerTest {
         assertTrue(config.emission is EmissionPolicy.All)
         assertEquals(false, config.legacyOnly)
         assertEquals(ScanPhy.LeCoded, config.phy)
+    }
+
+    // =========================================================================
+    // legacyOnlyScanWarning -- pure function, safe in unit test context
+    // =========================================================================
+
+    @Test
+    fun `legacyOnlyScanWarning returns a warning when legacyOnly is true`() {
+        val warning = AndroidScanner.legacyOnlyScanWarning(true)
+        assertNotNull(warning)
+        assertNull(warning.identifier)
+        assertTrue(warning.message.contains("Extended Advertising"))
+        assertTrue(warning.message.contains("legacyOnly = false"))
+    }
+
+    @Test
+    fun `legacyOnlyScanWarning returns null when legacyOnly is false`() {
+        assertNull(AndroidScanner.legacyOnlyScanWarning(false))
     }
 
     @Test

--- a/src/androidMain/kotlin/com/atruedev/kmpble/KmpBle.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/KmpBle.android.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble
 
 import android.content.Context
+import com.atruedev.kmpble.gatt.internal.ObservationPersistence
 
 public object KmpBle {
     internal lateinit var appContext: Context
@@ -8,6 +9,13 @@ public object KmpBle {
 
     public fun init(context: Context) {
         appContext = context.applicationContext
+        // ObservationPersistence.context is a separate static field (internal to this
+        // module) that AndroidPeripheral needs for every close()/save()/restore() call.
+        // It has no public setter of its own, so KmpBle.init() - the one documented
+        // entry point every consumer already calls - is responsible for wiring it up.
+        // Without this, close() throws IllegalStateException unconditionally and the
+        // failure leaves the peripheral registry wedged (see AndroidPeripheral.close()).
+        ObservationPersistence.context = appContext
     }
 
     internal fun requireContext(): Context {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -57,6 +57,7 @@ public class AndroidScanner(
                 }
 
             val osFilters = buildOsFilters(config.filterGroups)
+            legacyOnlyScanWarning(config.legacyOnly)?.let { logEvent(it) }
             val settings =
                 ScanSettings
                     .Builder()
@@ -142,5 +143,28 @@ public class AndroidScanner(
                 ScanMode.Balanced -> ScanSettings.SCAN_MODE_BALANCED
                 ScanMode.LowLatency -> ScanSettings.SCAN_MODE_LOW_LATENCY
             }
+
+        /**
+         * `legacyOnly` defaults to `true`, which maps to `ScanSettings.Builder.setLegacy(true)`
+         * and makes the controller silently drop BLE 5.0 Extended Advertising PDUs before
+         * `onScanResult` - no error, no `ScanEvent`. Returns a warning to log once per scan
+         * start so that failure mode is at least diagnosable (see #576); returns `null` when
+         * `legacyOnly` is `false`, since extended advertisements are received normally then.
+         */
+        internal fun legacyOnlyScanWarning(legacyOnly: Boolean): BleLogEvent.Warning? {
+            if (!legacyOnly) return null
+            return BleLogEvent.Warning(
+                identifier = null,
+                message =
+                    "Scanning with legacyOnly=true (default): BLE 5.0 Extended Advertising " +
+                        "peripherals are silently dropped before onScanResult, with no error or " +
+                        "ScanEvent.Failed. A peripheral advertising a name plus service UUID(s) " +
+                        "that exceed the legacy 31-byte payload falls back to Extended " +
+                        "Advertising and will appear to simply not be advertising. iOS is " +
+                        "unaffected (CoreBluetooth ignores this setting). Set legacyOnly = false " +
+                        "to receive extended advertisements. " +
+                        "https://github.com/gary-quinn/kmp-ble/issues/576",
+            )
+        }
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogEvent.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/logging/BleLogEvent.kt
@@ -88,6 +88,18 @@ public sealed interface BleLogEvent {
         override val formatted: String get() = "[${identifier?.value ?: "global"}] ERROR: $message"
     }
 
+    /**
+     * A non-fatal condition worth surfacing - typically a configuration choice that
+     * silently changes behavior on one platform but not another, where there is no
+     * exception or failed operation to attach the warning to.
+     */
+    public data class Warning(
+        val identifier: Identifier?,
+        val message: String,
+    ) : BleLogEvent {
+        override val formatted: String get() = "[${identifier?.value ?: "global"}] WARN: $message"
+    }
+
     public data class StateRestoration(
         val identifier: Identifier?,
         val event: String,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerConfig.kt
@@ -28,8 +28,17 @@ public class ScannerConfig internal constructor() {
      * Set to `false` to also receive BLE 5.0 extended advertisements.
      *
      * On Android, this maps to `android.bluetooth.le.ScanSettings.Builder.setLegacy`.
+     * Setting `true` (the default) tells the controller to drop extended-advertising
+     * PDUs before `onScanResult` fires - silently, with no error and no `ScanEvent`.
+     * A peripheral advertising a local name plus one or more 128-bit service UUIDs
+     * commonly exceeds the legacy 31-byte payload and falls back to Extended
+     * Advertising, so it can appear to simply not be advertising on Android with
+     * default config. The Android scanner logs a `BleLogEvent.Warning` once per
+     * scan when this is left at the default `true` (see #576) so the failure is at
+     * least diagnosable - set `BleLogConfig.logger` to see it.
+     *
      * On iOS, CoreBluetooth receives extended advertisements transparently
-     * regardless of this setting.
+     * regardless of this setting, so this flag only ever restricts Android.
      */
     public var legacyOnly: Boolean = true
 


### PR DESCRIPTION
## Summary

Two Android-only scanning/connection bugs found while integration-testing a consumer app against 0.10.1:

1. **`ObservationPersistence.context` was never wired up.** `AndroidPeripheral` constructs an `ObservationPersistence` unconditionally and `close()` always calls into it, but `ObservationPersistence.context` has no public setter and nothing ever assigned it - so `close()` threw `IllegalStateException` on every call. Worse, `AndroidPeripheral.close()` sets `closed=true` before removing itself from the registry, so the throw between those two steps wedges the peripheral - every subsequent `connect()` to the same identifier fails with "Peripheral is closed" until process restart. Fix: `KmpBle.init(context)` (the one entry point every consumer already calls, manually or via the AndroidX Startup auto-initializer) now also sets `ObservationPersistence.context`.

2. **`ScannerConfig.legacyOnly` (default `true`) silently hides Extended Advertising peripherals on Android with no diagnostic signal** (#576). On Android this maps to `ScanSettings.Builder.setLegacy(true)`, which makes the controller drop any BLE 5.0 Extended Advertising PDU before `onScanResult` fires - no error, no `ScanEvent`. A peripheral advertising a local name plus one or more 128-bit service UUIDs commonly exceeds the legacy 31-byte payload and falls back to Extended Advertising, so the exact same `Scanner { filters { ... } }` call discovers it on iOS (which ignores this setting per its own doc comment) and never discovers it on Android with default config.

   Considered flipping the default to `false` to match iOS, but that's a silent behavior change for every existing Android consumer relying on today's default (deliberate legacy-only scanning for battery or older-hardware reasons) - and there's no way to know how many consumers that would affect. **Kept the default as-is** and instead added `AndroidScanner.legacyOnlyScanWarning()`, which logs a `BleLogEvent.Warning` once per scan when `legacyOnly` is left at `true`, so the platform asymmetry is at least discoverable via `BleLogConfig.logger` instead of a silent "peripheral never found".

## Test plan

- [x] `:testAndroidHostTest` - all green, including new `KmpBleInitializerHostTest.init_alsoWiresObservationPersistenceContext` and `AndroidScannerTest` coverage for `legacyOnlyScanWarning`
- [x] `:jvmTest` - same 5 pre-existing failures as on `main` with these commits stashed out (`LePowerControllerTest`, `PeripheralRegistryLincheckTest` - unrelated flakiness, not introduced by this PR)
- [x] No default values changed - zero behavior change for existing consumers
- [ ] Manual verification on a physical Android device: a peripheral advertising name + 128-bit service UUID together (forcing Extended Advertising) now logs the warning, and repeated connect/close cycles no longer wedge the registry