### PR TITLE
fix(android-ble): use Eagerly sharing start to ensure state reflects live changes without collector

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/adapter/AndroidBluetoothAdapter.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/adapter/AndroidBluetoothAdapter.kt
@@ -56,7 +56,7 @@ public class AndroidBluetoothAdapter(
             }
         }.stateIn(
             scope = scope,
-            started = SharingStarted.Lazily,
+            started = SharingStarted.Eagerly,
             initialValue = currentState(),
         )
 


### PR DESCRIPTION
## Problem

BluetoothAdapter.state on Android is lazily shared via . The upstream callbackFlow (which registers BroadcastReceiver for ACTION_STATE_CHANGED) only starts when something collects(). Consumers reading .value directly never trigger subscription, so state stays frozen at construction time and never reflects Bluetooth toggles.

This creates a broken contract: StateFlow users expect .value to return current state, but Android's state is stale until a collector attaches. iOS is unaffected because it pushes updates directly to MutableStateFlow via CBCentralManagerDelegate callbacks.

## Approach

Switch from  to  so the receiver registers immediately on adapter construction, independent of collector attachment. The one-line change ensures .value reads always return live state after the initial value.

## Trade-offs

- Eagerly starts the flow immediately, but the BroadcastReceiver is lightweight (just registers an intent filter for a system action). No meaningful performance or lifecycle impact.
- Aligns Android behavior with iOS, which already updates state via direct MutableStateFlow mutations in delegate callbacks.

Closes #587