### PR TITLE
fix(scanner): close flow with ScanFailedException when BluetoothLeScanner unavailable

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/scanner/AndroidScanner.kt
@@ -38,9 +38,16 @@ public class AndroidScanner(
     private fun createRawScanFlow(): Flow<Advertisement> =
         callbackFlow {
             val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-            val leScanner =
-                bluetoothManager.adapter?.bluetoothLeScanner
-                    ?: throw IllegalStateException("BluetoothLeScanner not available. Is Bluetooth enabled?")
+            val leScanner = bluetoothManager.adapter?.bluetoothLeScanner
+            if (leScanner == null) {
+                close(
+                    ScanFailedException(
+                        ERROR_SCANNER_NOT_AVAILABLE,
+                        "BluetoothLeScanner not available. Is Bluetooth enabled?",
+                    ),
+                )
+                return@callbackFlow
+            }
 
             val callback =
                 object : ScanCallback() {
@@ -76,6 +83,12 @@ public class AndroidScanner(
         }
 
     public companion object {
+        /**
+         * Error code for [ScanFailedException] when [BluetoothLeScanner] is not available
+         * (e.g. Bluetooth is off or adapter is null).
+         */
+        public const val ERROR_SCANNER_NOT_AVAILABLE: Int = -1
+
         /**
          * Builds native `ScanFilter`s from the OR-of-AND-groups DSL. [ScanPredicate.NamePrefix]
          * and [ScanPredicate.MinRssi] have no `ScanFilter` equivalent (Android only supports

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanEvent.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanEvent.kt
@@ -27,4 +27,5 @@ public sealed interface ScanEvent {
 
 public class ScanFailedException(
     public val errorCode: Int,
-) : Exception("BLE scan failed with error code: $errorCode")
+    message: String? = null,
+) : Exception(message ?: "BLE scan failed with error code: $errorCode")

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/internal/ScannerPipelineTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/internal/ScannerPipelineTest.kt
@@ -1,0 +1,52 @@
+package com.atruedev.kmpble.scanner.internal
+
+import com.atruedev.kmpble.scanner.Advertisement
+import com.atruedev.kmpble.scanner.ScanEvent
+import com.atruedev.kmpble.scanner.ScanFailedException
+import com.atruedev.kmpble.scanner.ScannerConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ScannerPipelineTest {
+    @Test
+    fun `callbackFlow closed with ScanFailedException becomes Failed event`() =
+        runTest {
+            val errorCode = -1
+            val errorMessage = "BluetoothLeScanner not available. Is Bluetooth enabled?"
+
+            // Simulate the AndroidScanner.createRawScanFlow() path when
+            // BluetoothLeScanner is null: the callbackFlow calls close() with
+            // a ScanFailedException and returns without registering awaitClose.
+            // The catch block in toScanEvents must convert this to a
+            // ScanEvent.Failed instead of crashing the scope (#590).
+            val rawFlow =
+                callbackFlow<Advertisement> {
+                    close(ScanFailedException(errorCode, errorMessage))
+                    // No awaitClose -- matches createRawScanFlow's early return
+                }
+
+            val config = ScannerConfig()
+            val scope = CoroutineScope(SupervisorJob())
+
+            val shared = rawFlow.toScanEvents(config, scope)
+            val deferred = async { shared.first() }
+            val event = deferred.await()
+
+            assertIs<ScanEvent.Failed>(event)
+            assertEquals(errorCode, event.error.errorCode)
+            assertTrue(
+                event.error.message!!.contains("BluetoothLeScanner"),
+                "expected message to contain 'BluetoothLeScanner', was: ${event.error.message}",
+            )
+            scope.cancel()
+        }
+}


### PR DESCRIPTION
## Summary

Fixes #590 -- `AndroidScanner.createRawScanFlow()` no longer throws a raw `IllegalStateException` when `BluetoothLeScanner` is unavailable (e.g. Bluetooth off). Instead, it calls `close(ScanFailedException(...))` which stays inside the existing `ScanEvent.Failed` path, letting callers observe and handle the failure like any other scan error.

## Changes

- `ScanFailedException` now accepts an optional `message` parameter for meaningful error messages (backward compatible)
- `AndroidScanner.createRawScanFlow()` replaces `throw IllegalStateException(...)` with `close(ScanFailedException(ERROR_SCANNER_NOT_AVAILABLE, ...))`
- Added `ERROR_SCANNER_NOT_AVAILABLE = -1` constant to distinguish this case from Android OS scan error codes (1-6)