### PR TITLE
feat(connection): add connectionPriority to ConnectionOptions for faster initial connect

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.ConnectionPriority
 import com.atruedev.kmpble.connection.TransportType
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
@@ -149,6 +150,27 @@ internal class AndroidGattBridge(
                 options.phyMask.value,
                 callbackHandler,
             )
+        // Request connection priority immediately so the initial link-layer
+        // negotiation uses the caller's preferred interval, not the platform
+        // default (~30-50ms). This reduces time-to-connected when callers
+        // opt into ConnectionPriority.High for scan-then-connect flows.
+        val androidPriority =
+            when (options.connectionPriority) {
+                ConnectionPriority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+                ConnectionPriority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+                ConnectionPriority.LowPower -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+            }
+        val priorityApplied = _gatt.value?.requestConnectionPriority(androidPriority) ?: false
+        if (!priorityApplied) {
+            logEvent(
+                BleLogEvent.Warning(
+                    identifier = null,
+                    message =
+                        "requestConnectionPriority(${options.connectionPriority}) " +
+                            "returned false - priority not applied",
+                ),
+            )
+        }
         return _gatt.value
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
@@ -33,6 +33,20 @@ public data class ConnectionOptions(
     val mtuRequest: Int? = null,
     val bondingPreference: BondingPreference = BondingPreference.IfRequired,
     val reconnectionStrategy: ReconnectionStrategy = ReconnectionStrategy.None,
+    /**
+     * Connection priority hint requested from the central during the initial
+     * [connect][com.atruedev.kmpble.peripheral.Peripheral.connect] call.
+     *
+     * Applying [ConnectionPriority.High] before the link-layer connection
+     * negotiation completes reduces time-to-connected for the initial
+     * connection, trading power for speed. Defaults to [ConnectionPriority.Balanced]
+     * (Android default ~30-50ms interval).
+     *
+     * Android maps to `BluetoothGatt.requestConnectionPriority()`, called
+     * immediately after `connectGatt()`. iOS is a no-op (CoreBluetooth has
+     * no public API).
+     */
+    val connectionPriority: ConnectionPriority = ConnectionPriority.Balanced,
     val gattOperationTimeout: Duration = 10.seconds,
     /**
      * Handler for pairing events that require user interaction.
@@ -78,6 +92,7 @@ public data class ConnectionOptions(
                     "mtuRequest = mtuRequest, " +
                     "bondingPreference = bondingPreference, " +
                     "reconnectionStrategy = reconnectionStrategy, " +
+                    "connectionPriority = connectionPriority, " +
                     "gattOperationTimeout = gattOperationTimeout, " +
                     "pairingHandler = pairingHandler" +
                     ")",
@@ -92,6 +107,7 @@ public data class ConnectionOptions(
         mtuRequest: Int? = null,
         bondingPreference: BondingPreference = BondingPreference.IfRequired,
         reconnectionStrategy: ReconnectionStrategy = ReconnectionStrategy.None,
+        connectionPriority: ConnectionPriority = ConnectionPriority.Balanced,
         gattOperationTimeout: Duration = 10.seconds,
         pairingHandler: PairingHandler? = null,
     ) : this(
@@ -102,6 +118,7 @@ public data class ConnectionOptions(
         mtuRequest = mtuRequest,
         bondingPreference = bondingPreference,
         reconnectionStrategy = reconnectionStrategy,
+        connectionPriority = connectionPriority,
         gattOperationTimeout = gattOperationTimeout,
         pairingHandler = pairingHandler,
         gattRetryPolicy = RetryPolicy.NONE,


### PR DESCRIPTION
## Summary

Adds \`connectionPriority: ConnectionPriority\` field to \`ConnectionOptions\` (default \`Balanced\`). When set to \`High\`, \`AndroidGattBridge.connect()\` calls \`requestConnectionPriority()\` immediately after \`connectGatt()\`, allowing the initial link-layer negotiation to use a faster interval (~11-15ms instead of the platform default ~30-50ms).

Fixes #588.

### What changed

- **ConnectionOptions.kt** — new \`connectionPriority\` field with KDoc documenting Android/iOS behavior
- **AndroidGattBridge.kt** — maps \`options.connectionPriority\` to \`BluetoothGatt.CONNECTION_PRIORITY_*\` and calls \`gatt?.requestConnectionPriority()\` right after \`connectGatt()\`

### Behavior

| Platform | Effect |
|----------|--------|
| Android | Calls \`requestConnectionPriority\` immediately post-\`connectGatt\`, before returning |
| iOS | No-op (CoreBluetooth has no public API) |

### Backward compatibility

Fully backward compatible. Default is \`Balanced\`, matching the existing behavior where no explicit priority was set.