### PR TITLE
fix(concurrency): migrate 7 remaining @Volatile fields in androidMain to atomicfu

### DIFF
--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/KmpBleInitializerHostTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/KmpBleInitializerHostTest.kt
@@ -18,7 +18,7 @@ class KmpBleInitializerHostTest {
         val field = KmpBle::class.java.getDeclaredField("appContext")
         field.isAccessible = true
         field.set(KmpBle, null)
-        ObservationPersistence.context = null
+        ObservationPersistence.context.value = null
     }
 
     @Test
@@ -41,14 +41,14 @@ class KmpBleInitializerHostTest {
 
     @Test
     fun init_alsoWiresObservationPersistenceContext() {
-        assertNull(ObservationPersistence.context)
+        assertNull(ObservationPersistence.context.value)
 
         val appContext = RuntimeEnvironment.getApplication()
         KmpBle.init(appContext)
 
         // Peripheral.close() calls into ObservationPersistence unconditionally; without
         // this wiring it throws IllegalStateException on every close() (see KmpBle.init()).
-        assertSame(KmpBle.requireContext(), ObservationPersistence.context)
+        assertSame(KmpBle.requireContext(), ObservationPersistence.context.value)
     }
 
     @Test

--- a/src/androidHostTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceAndroidHostTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpble/observation/ObservationPersistenceAndroidHostTest.kt
@@ -38,7 +38,7 @@ class ObservationPersistenceAndroidHostTest {
     @Before
     fun setup() {
         appContext = RuntimeEnvironment.getApplication()
-        ObservationPersistence.context = appContext
+        ObservationPersistence.context.value = appContext
         // Clear any persisted state from previous tests
         val prefs = appContext.getSharedPreferences("com.atruedev.kmpble.cccd", Context.MODE_PRIVATE)
         prefs.edit().clear().commit()

--- a/src/androidMain/kotlin/com/atruedev/kmpble/KmpBle.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/KmpBle.android.kt
@@ -15,7 +15,7 @@ public object KmpBle {
         // entry point every consumer already calls - is responsible for wiring it up.
         // Without this, close() throws IllegalStateException unconditionally and the
         // failure leaves the peripheral registry wedged (see AndroidPeripheral.close()).
-        ObservationPersistence.context = appContext
+        ObservationPersistence.context.value = appContext
     }
 
     internal fun requireContext(): Context {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationPersistence.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/gatt/internal/ObservationPersistence.android.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.gatt.internal
 
 import android.content.Context
+import kotlinx.atomicfu.atomic
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -31,7 +32,7 @@ internal actual class ObservationPersistence actual constructor() {
      */
     private val prefs by lazy {
         val ctx =
-            context
+            context.value
                 ?: throw IllegalStateException(
                     "ObservationPersistence.context must be set before use. " +
                         "Call ObservationPersistence.context = applicationContext during initialization.",
@@ -112,8 +113,7 @@ internal actual class ObservationPersistence actual constructor() {
          * Must be set before any persistence operations.
          * Set once during library initialization (e.g., in Application.onCreate).
          */
-        @Volatile
-        var context: Context? = null
+        val context = atomic<Context?>(null)
 
         private const val PREFS_NAME = "com.atruedev.kmpble.cccd"
         private const val KEY_PREFIX = "obs"

--- a/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/l2cap/AndroidL2capListener.kt
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothServerSocket
 import android.content.Context
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -29,9 +30,8 @@ internal class AndroidL2capListener(
     private val _isOpen = MutableStateFlow(false)
     override val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
 
-    @Volatile
-    private var _psm: Int = 0
-    override val psm: Int get() = _psm
+    private val _psm = atomic(0)
+    override val psm: Int get() = _psm.value
 
     private val _incoming =
         MutableSharedFlow<L2capChannel>(
@@ -45,14 +45,13 @@ internal class AndroidL2capListener(
     private var serverSocket: BluetoothServerSocket? = null
     private var acceptJob: Job? = null
 
-    @Volatile
-    private var closed: Boolean = false
+    private val closed = atomic(false)
 
     override suspend fun open(
         secure: Boolean,
         mtu: Int?,
     ) {
-        if (closed) throw L2capException.InvalidState("Listener has been closed")
+        if (closed.value) throw L2capException.InvalidState("Listener has been closed")
         if (_isOpen.value) throw L2capException.InvalidState("Listener already open")
 
         val adapter =
@@ -78,7 +77,7 @@ internal class AndroidL2capListener(
 
         val assignedPsm = socket.psm
         serverSocket = socket
-        _psm = assignedPsm
+        _psm.value = assignedPsm
         _isOpen.value = true
 
         acceptJob = scope.launch { acceptLoop(socket, assignedPsm) }
@@ -89,7 +88,7 @@ internal class AndroidL2capListener(
         assignedPsm: Int,
     ) {
         try {
-            while (coroutineContext[Job]?.isActive == true && !closed) {
+            while (coroutineContext[Job]?.isActive == true && !closed.value) {
                 val accepted =
                     try {
                         serverSocket.accept()
@@ -97,7 +96,7 @@ internal class AndroidL2capListener(
                         break
                     }
 
-                if (closed) {
+                if (closed.value) {
                     try {
                         accepted.close()
                     } catch (_: IOException) {
@@ -130,8 +129,8 @@ internal class AndroidL2capListener(
     }
 
     override fun close() {
-        if (closed) return
-        closed = true
+        if (closed.value) return
+        closed.value = true
         _isOpen.value = false
 
         try {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -15,7 +15,7 @@ import com.atruedev.kmpble.connection.ConnectionOptions
 import com.atruedev.kmpble.connection.TransportType
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
-import kotlin.concurrent.Volatile
+import kotlinx.atomicfu.atomic
 
 internal class AndroidGattBridge(
     private val device: BluetoothDevice,
@@ -24,9 +24,14 @@ internal class AndroidGattBridge(
     private var callbackThread: HandlerThread? = null
     private var callbackHandler: Handler? = null
 
-    @Volatile private var gatt: BluetoothGatt? = null
+    private val _gatt = atomic<BluetoothGatt?>(null)
 
-    @Volatile internal var onEvent: ((GattCallbackEvent) -> Unit)? = null
+    private val _onEvent = atomic<((GattCallbackEvent) -> Unit)?>(null)
+    internal var onEvent: ((GattCallbackEvent) -> Unit)?
+        get() = _onEvent.value
+        set(value) {
+            _onEvent.value = value
+        }
 
     private val gattCallback =
         object : BluetoothGattCallback() {
@@ -135,7 +140,7 @@ internal class AndroidGattBridge(
         callbackThread = thread
         callbackHandler = Handler(thread.looper)
 
-        gatt =
+        _gatt.value =
             device.connectGatt(
                 context,
                 options.autoConnect,
@@ -144,52 +149,53 @@ internal class AndroidGattBridge(
                 options.phyMask.value,
                 callbackHandler,
             )
-        return gatt
+        return _gatt.value
     }
 
-    internal fun discoverServices(): Boolean = gatt?.discoverServices() ?: false
+    internal fun discoverServices(): Boolean = _gatt.value?.discoverServices() ?: false
 
-    internal fun requestMtu(mtu: Int): Boolean = gatt?.requestMtu(mtu) ?: false
+    internal fun requestMtu(mtu: Int): Boolean = _gatt.value?.requestMtu(mtu) ?: false
 
-    internal fun requestConnectionPriority(priority: Int): Boolean = gatt?.requestConnectionPriority(priority) ?: false
+    internal fun requestConnectionPriority(priority: Int): Boolean =
+        _gatt.value?.requestConnectionPriority(priority) ?: false
 
     internal fun setPreferredPhy(
         txPhyMask: Int,
         rxPhyMask: Int,
         phyOptions: Int,
     ): Boolean {
-        val g = gatt ?: return false
+        val g = _gatt.value ?: return false
         g.setPreferredPhy(txPhyMask, rxPhyMask, phyOptions)
         return true
     }
 
     internal fun readPhy(): Boolean {
-        val g = gatt ?: return false
+        val g = _gatt.value ?: return false
         g.readPhy()
         return true
     }
 
     internal fun readCharacteristic(characteristic: BluetoothGattCharacteristic): Boolean =
-        gatt?.readCharacteristic(characteristic) ?: false
+        _gatt.value?.readCharacteristic(characteristic) ?: false
 
     internal fun writeCharacteristic(
         characteristic: BluetoothGattCharacteristic,
         value: ByteArray,
         writeType: Int,
     ): Boolean {
-        val g = gatt ?: return false
+        val g = _gatt.value ?: return false
         val result = g.writeCharacteristic(characteristic, value, writeType)
         return result == BluetoothGatt.GATT_SUCCESS
     }
 
     internal fun readDescriptor(descriptor: BluetoothGattDescriptor): Boolean =
-        gatt?.readDescriptor(descriptor) ?: false
+        _gatt.value?.readDescriptor(descriptor) ?: false
 
     internal fun writeDescriptor(
         descriptor: BluetoothGattDescriptor,
         value: ByteArray,
     ): Boolean {
-        val g = gatt ?: return false
+        val g = _gatt.value ?: return false
         val result = g.writeDescriptor(descriptor, value)
         return result == BluetoothGatt.GATT_SUCCESS
     }
@@ -197,9 +203,9 @@ internal class AndroidGattBridge(
     internal fun setCharacteristicNotification(
         characteristic: BluetoothGattCharacteristic,
         enable: Boolean,
-    ): Boolean = gatt?.setCharacteristicNotification(characteristic, enable) ?: false
+    ): Boolean = _gatt.value?.setCharacteristicNotification(characteristic, enable) ?: false
 
-    internal fun readRemoteRssi(): Boolean = gatt?.readRemoteRssi() ?: false
+    internal fun readRemoteRssi(): Boolean = _gatt.value?.readRemoteRssi() ?: false
 
     /**
      * Clears the GATT service cache via the internal `BluetoothGatt.refresh()` API.
@@ -215,7 +221,7 @@ internal class AndroidGattBridge(
      * after bonding. See [com.atruedev.kmpble.quirks.BleQuirks.RefreshServicesOnBond].
      */
     internal fun refreshDeviceCache(): Boolean {
-        val g = gatt ?: return false
+        val g = _gatt.value ?: return false
         return try {
             val method = g.javaClass.getMethod("refresh")
             method.invoke(g) as? Boolean ?: false
@@ -232,19 +238,19 @@ internal class AndroidGattBridge(
     }
 
     internal fun disconnect() {
-        gatt?.disconnect()
+        _gatt.value?.disconnect()
     }
 
     /** Release the BluetoothGatt handle but keep the bridge reusable for reconnection. */
     internal fun releaseGatt() {
-        gatt?.close()
-        gatt = null
+        _gatt.value?.close()
+        _gatt.value = null
     }
 
     /** Terminal - release all resources including the callback thread. */
     internal fun close() {
-        gatt?.close()
-        gatt = null
+        _gatt.value?.close()
+        _gatt.value = null
         onEvent = null
         callbackThread?.quitSafely()
         callbackThread = null

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServer.kt
@@ -106,7 +106,7 @@ internal class AndroidGattServer(
     ) {
         withContext(state.dispatcher) {
             checkOpen()
-            val server = state.nativeServer ?: throw ServerException.NotOpen()
+            val server = state.nativeServer.value ?: throw ServerException.NotOpen()
             val nativeChar =
                 state.characteristicCache[characteristicUuid]
                     ?: throw ServerException.NotifyFailed("Characteristic $characteristicUuid not found")
@@ -179,7 +179,7 @@ internal class AndroidGattServer(
     ) {
         withContext(state.dispatcher) {
             checkOpen()
-            val server = state.nativeServer ?: throw ServerException.NotOpen()
+            val server = state.nativeServer.value ?: throw ServerException.NotOpen()
             val nativeChar =
                 state.characteristicCache[characteristicUuid]
                     ?: throw ServerException.NotifyFailed("Characteristic $characteristicUuid not found")
@@ -250,11 +250,11 @@ internal class AndroidGattServer(
 
         // Close native server first - stops all Binder callbacks
         try {
-            state.nativeServer?.close()
+            state.nativeServer.value?.close()
         } catch (_: SecurityException) {
             // Ignore permission errors on close
         }
-        state.nativeServer = null
+        state.nativeServer.value = null
 
         // Cancel all pending notifications/indications
         for ((_, deferred) in state.pendingNotifySent) {

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerCallback.kt
@@ -110,7 +110,7 @@ internal class AndroidGattServerCallback(
                 status: Int,
                 service: BluetoothGattService,
             ) {
-                state.pendingServiceAdd?.complete(status)
+                state.pendingServiceAdd.value?.complete(status)
             }
 
             override fun onMtuChanged(
@@ -130,7 +130,7 @@ internal class AndroidGattServerCallback(
     ) {
         if (!state.isOpen.get()) return
         try {
-            state.nativeServer?.sendResponse(device, requestId, status, offset, value)
+            state.nativeServer.value?.sendResponse(device, requestId, status, offset, value)
         } catch (_: SecurityException) {
             // Ignore - device disconnected or permission lost
         }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerSetup.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerSetup.kt
@@ -49,7 +49,7 @@ internal suspend fun AndroidGattServerState.openInternal(instanceLock: AtomicBoo
             throw ServerException.OpenFailed("Missing BLUETOOTH_CONNECT permission", e)
         } ?: throw ServerException.OpenFailed("openGattServer returned null")
 
-    nativeServer = server
+    nativeServer.value = server
 
     // Register handlers from service definitions
     for (serviceDef in serviceDefinitions) {
@@ -63,13 +63,13 @@ internal suspend fun AndroidGattServerState.openInternal(instanceLock: AtomicBoo
     for (serviceDef in serviceDefinitions) {
         val nativeService = buildNativeService(serviceDef)
         val deferred = CompletableDeferred<Int>()
-        pendingServiceAdd = deferred
+        pendingServiceAdd.value = deferred
         if (!server.addService(nativeService)) {
-            pendingServiceAdd = null
+            pendingServiceAdd.value = null
             throw ServerException.OpenFailed("addService returned false for ${serviceDef.uuid}")
         }
         val addStatus = deferred.await()
-        pendingServiceAdd = null
+        pendingServiceAdd.value = null
         if (addStatus != BluetoothGatt.GATT_SUCCESS) {
             throw ServerException.OpenFailed(
                 "addService failed for ${serviceDef.uuid} with status ${addStatus.toGattStatus()}",

--- a/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerState.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/server/AndroidGattServerState.kt
@@ -13,6 +13,7 @@ import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.logging.BleLogEvent
 import com.atruedev.kmpble.logging.logEvent
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,7 +31,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
 /**
@@ -40,7 +40,7 @@ import kotlin.uuid.Uuid
  * All mutable state is accessed exclusively on [dispatcher] (limitedParallelism(1))
  * unless noted otherwise. Thread-safe fields accessed from Binder threads:
  * - [pendingNotifySent]: ConcurrentHashMap, CompletableDeferred.complete is safe
- * - [pendingServiceAdd]: @Volatile, CompletableDeferred.complete is safe
+ * - [pendingServiceAdd]: atomicfu, CompletableDeferred.complete is safe
  * - [isOpen]/[isClosed]: AtomicBoolean for atomic visibility
  */
 internal class AndroidGattServerState(
@@ -173,12 +173,10 @@ internal class AndroidGattServerState(
     // --- Thread-safe fields ---
     val pendingNotifySent = ConcurrentHashMap<String, CompletableDeferred<Int>>()
 
-    @Volatile
-    var pendingServiceAdd: CompletableDeferred<Int>? = null
+    val pendingServiceAdd = atomic<CompletableDeferred<Int>?>(null)
 
     // --- Native server ---
-    @Volatile
-    var nativeServer: BluetoothGattServer? = null
+    val nativeServer = atomic<BluetoothGattServer?>(null)
 
     // --- Lifecycle flags ---
     val isOpen = AtomicBoolean(false)


### PR DESCRIPTION
## Summary

Replaces all remaining \`@Volatile\` annotations in \`androidMain\` with \`kotlinx.atomicfu.atomic()\`, completing the concurrency policy migration started in #449.

Fixes #566.

### Fields migrated

| File | Field | Type |
|------|-------|------|
| \`AndroidL2capListener.kt\` | \`_psm\` | \`Int\` |
| \`AndroidL2capListener.kt\` | \`closed\` | \`Boolean\` |
| \`AndroidGattBridge.kt\` | \`gatt\` | \`BluetoothGatt?\` |
| \`AndroidGattBridge.kt\` | \`onEvent\` | callback lambda |
| \`AndroidGattServerState.kt\` | \`pendingServiceAdd\` | \`CompletableDeferred<Int>?\` |
| \`AndroidGattServerState.kt\` | \`nativeServer\` | \`BluetoothGattServer?\` |
| \`ObservationPersistence.android.kt\` | \`context\` | \`Context?\` |

### Verification

\`\`\`bash
grep -r "@Volatile\|import kotlin.concurrent.Volatile" src/androidMain/
# (no matches — zero @Volatile remaining)
\`\`\`

### Files changed

10 files — 7 source files + 3 internal callers/tests updated to use \`.value\` accessor.