### PR TITLE
feat(adapter): add BluetoothAdapter.getBondedDevices()

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/adapter/AndroidBluetoothAdapter.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/adapter/AndroidBluetoothAdapter.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.adapter
 
 import android.Manifest
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothStatusCodes
 import android.content.BroadcastReceiver
@@ -11,6 +12,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
 import androidx.core.content.ContextCompat
+import com.atruedev.kmpble.Identifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -125,6 +127,22 @@ public class AndroidBluetoothAdapter(
             -> BluetoothAdapterState.Unavailable
             else -> BluetoothAdapterState.Unavailable
         }
+    }
+
+    override fun getBondedDevices(): List<Identifier> {
+        val adapter =
+            (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+                ?: return emptyList()
+        if (context.checkPermission(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Process.myPid(),
+                Process.myUid(),
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return emptyList()
+        }
+        @Suppress("DEPRECATION")
+        return adapter.bondedDevices.map { device: BluetoothDevice -> Identifier(device.address) }
     }
 
     override fun close() {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.adapter
 
+import com.atruedev.kmpble.Identifier
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -23,6 +24,23 @@ public interface BluetoothAdapter {
      * than catching errors after attempting the operation.
      */
     public val capabilities: BleCapabilities
+
+    /**
+     * Returns the set of currently bonded (paired) devices on this device.
+     *
+     * Bonded devices have exchanged link keys and can establish encrypted
+     * connections without re-pairing. Use this to build "reconnect to known
+     * device" flows without scanning.
+     *
+     * **Android**: Maps to `BluetoothAdapter.getBondedDevices()`. Returns
+     * the system's bonded device list, which persists across app restarts.
+     *
+     * **iOS**: Returns devices that have been bonded through this library
+     * in the current process lifetime. CoreBluetooth does not expose a
+     * system-wide bonded device list. Bond state is tracked from pairing
+     * events observed during active connections.
+     */
+    public fun getBondedDevices(): List<Identifier>
 
     public fun close()
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/adapter/BluetoothAdapter.kt
@@ -35,10 +35,8 @@ public interface BluetoothAdapter {
      * **Android**: Maps to `BluetoothAdapter.getBondedDevices()`. Returns
      * the system's bonded device list, which persists across app restarts.
      *
-     * **iOS**: Returns devices that have been bonded through this library
-     * in the current process lifetime. CoreBluetooth does not expose a
-     * system-wide bonded device list. Bond state is tracked from pairing
-     * events observed during active connections.
+     * **iOS**: Returns an empty list. CoreBluetooth does not expose a
+     * system-wide bonded device API; users manage bonds via Settings > Bluetooth.
      */
     public fun getBondedDevices(): List<Identifier>
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/adapter/IosBluetoothAdapter.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/adapter/IosBluetoothAdapter.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.adapter
 
+import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import kotlinx.coroutines.flow.StateFlow
 import platform.CoreBluetooth.CBCentralManager
@@ -47,6 +48,12 @@ public class IosBluetoothAdapter : BluetoothAdapter {
             supportsPast = false,
             supportsDirectionFinding = false,
         )
+    }
+
+    override fun getBondedDevices(): List<Identifier> {
+        // CoreBluetooth does not expose a system-wide bonded device list.
+        // Users manage bonds through Settings > Bluetooth.
+        return emptyList()
     }
 
     override fun close() {


### PR DESCRIPTION
## Summary

Adds `getBondedDevices(): List<Identifier>` to `BluetoothAdapter` for discovering already-paired peripherals without scanning.

Fixes #496.

### Implementation

| Platform | Behavior |
|----------|----------|
| Android | `BluetoothAdapter.getBondedDevices()` -- returns system bonded device list |
| iOS | Returns empty list -- CoreBluetooth has no system-wide bonded device API |

### Files changed

- `BluetoothAdapter.kt` -- new `getBondedDevices()` method with KDoc
- `AndroidBluetoothAdapter.kt` -- maps to `BluetoothAdapter.bondedDevices` with permission check
- `IosBluetoothAdapter.kt` -- returns empty list (platform limitation)