### PR TITLE
fix(ios): pass discovered CBService directly into discoverCharacteristics

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
@@ -155,12 +155,9 @@ internal class ApplePeripheralBridge(
         return true
     }
 
-    internal fun discoverCharacteristics(serviceUuid: String) {
+    internal fun discoverCharacteristics(service: CBService) {
         cbPeripheral.delegate = peripheralDelegate
-        val cbServices =
-            cbPeripheral.services?.filterIsInstance<CBService>()?.filter { it.UUID.UUIDString == serviceUuid }
-                ?: emptyList()
-        cbServices.firstOrNull()?.let { cbPeripheral.discoverCharacteristics(null, it) }
+        cbPeripheral.discoverCharacteristics(null, service)
     }
 
     internal fun readCharacteristic(characteristic: CBCharacteristic): Boolean {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -55,7 +55,7 @@ internal suspend fun IosPeripheral.handleServicesDiscovered(event: AppleCallback
     val pending = cbServices.map { it.UUID.UUIDString }.toSet()
     currentDiscovery = DiscoveryCycle(generation = generation, pendingServices = pending)
 
-    cbServices.forEach { bridge.discoverCharacteristics(it.UUID.UUIDString) }
+    cbServices.forEach { bridge.discoverCharacteristics(it) }
 }
 
 @OptIn(ExperimentalUuidApi::class)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -24,7 +24,7 @@ import kotlin.uuid.ExperimentalUuidApi
  */
 internal data class DiscoveryCycle(
     val generation: Int,
-    val pendingServices: Set<String>,
+    val pendingServices: MutableList<String>,
     val discoveredServices: MutableList<DiscoveredService> = mutableListOf(),
 )
 
@@ -52,7 +52,10 @@ internal suspend fun IosPeripheral.handleServicesDiscovered(event: AppleCallback
     }
 
     val generation = discoveryGeneration.value
-    val pending = cbServices.map { it.UUID.UUIDString }.toSet()
+    // Keep one entry per service, not per UUID - a peripheral may expose more than one
+    // service with the same UUID, and each one gets its own didDiscoverCharacteristicsForService
+    // callback.
+    val pending = cbServices.map { it.UUID.UUIDString }.toMutableList()
     currentDiscovery = DiscoveryCycle(generation = generation, pendingServices = pending)
 
     cbServices.forEach { bridge.discoverCharacteristics(it) }
@@ -68,7 +71,9 @@ internal suspend fun IosPeripheral.handleCharacteristicsDiscovered(
     // Ignore stale callbacks from previous discovery generations
     if (cycle.generation != discoveryGeneration.value) return
 
-    (cycle.pendingServices as MutableSet<String>).remove(event.serviceUuid)
+    // Removes only the first matching entry, so a duplicate-UUID service still has
+    // its own outstanding entry after this one is cleared.
+    cycle.pendingServices.remove(event.serviceUuid)
 
     if (event.error != null) {
         val status = event.error.toGattStatus()

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -6,6 +6,9 @@ import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
+import platform.CoreBluetooth.CBMutableService
+import platform.CoreBluetooth.CBService
+import platform.CoreBluetooth.CBUUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -249,6 +252,56 @@ class IosGattEventHandlerTest {
         }
 
     // -- Discovery event handling (services and characteristics) --
+
+    // CBMutableService is a public, instantiable subclass of the framework's CBService,
+    // so it stands in for real discovered services without needing a live CBPeripheral
+    // (which CoreBluetooth never lets app code construct directly).
+
+    @Test
+    fun `distinct CBService instances with the same UUID are not reference-equal`() {
+        val uuid = CBUUID.UUIDWithString("180D")
+        val serviceA = CBMutableService(type = uuid, primary = true)
+        val serviceB = CBMutableService(type = uuid, primary = true)
+
+        assertEquals(serviceA.UUID.UUIDString, serviceB.UUID.UUIDString)
+        assertFalse(serviceA === serviceB)
+    }
+
+    @Test
+    fun `resolving a service by UUID string collapses duplicate-UUID services to the first match`() {
+        // Characterizes the bug fixed by passing the CBService instance through directly:
+        // ApplePeripheralBridge.discoverCharacteristics used to re-resolve the service by
+        // UUID string, so a peripheral exposing two services with the same UUID (legal per
+        // the BLE spec) always resolved to the first one - the second was never reachable.
+        val uuid = CBUUID.UUIDWithString("180D")
+        val serviceA = CBMutableService(type = uuid, primary = true)
+        val serviceB = CBMutableService(type = uuid, primary = true)
+        val services: List<CBService> = listOf(serviceA, serviceB)
+
+        fun resolveByUuid(uuidString: String) = services.filter { it.UUID.UUIDString == uuidString }.firstOrNull()
+
+        assertTrue(resolveByUuid(serviceA.UUID.UUIDString) === serviceA)
+        assertTrue(resolveByUuid(serviceB.UUID.UUIDString) === serviceA)
+        assertFalse(resolveByUuid(serviceB.UUID.UUIDString) === serviceB)
+    }
+
+    @Test
+    fun `pendingServices set still collapses duplicate-UUID services into a single entry`() {
+        // Mirrors IosPeripheralDiscovery.handleServicesDiscovered's pendingServices construction.
+        // Known remaining limitation (not addressed by the CBService pass-through fix): a
+        // discovery cycle still expects only one didDiscoverCharacteristicsForService callback
+        // per UUID, even when two distinct services share that UUID.
+        val uuid = CBUUID.UUIDWithString("180D")
+        val services: List<CBService> =
+            listOf(
+                CBMutableService(type = uuid, primary = true),
+                CBMutableService(type = uuid, primary = true),
+            )
+
+        val pending = services.map { it.UUID.UUIDString }.toSet()
+
+        assertEquals(1, pending.size)
+    }
 
     @Test
     fun `pendingOps clear resets all state`() =

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -286,11 +286,10 @@ class IosGattEventHandlerTest {
     }
 
     @Test
-    fun `pendingServices set still collapses duplicate-UUID services into a single entry`() {
+    fun `pendingServices keeps one entry per service instead of per UUID`() {
         // Mirrors IosPeripheralDiscovery.handleServicesDiscovered's pendingServices construction.
-        // Known remaining limitation (not addressed by the CBService pass-through fix): a
-        // discovery cycle still expects only one didDiscoverCharacteristicsForService callback
-        // per UUID, even when two distinct services share that UUID.
+        // A List (not a Set) preserves one entry per duplicate-UUID service, since each gets
+        // its own didDiscoverCharacteristicsForService callback.
         val uuid = CBUUID.UUIDWithString("180D")
         val services: List<CBService> =
             listOf(
@@ -298,9 +297,16 @@ class IosGattEventHandlerTest {
                 CBMutableService(type = uuid, primary = true),
             )
 
-        val pending = services.map { it.UUID.UUIDString }.toSet()
+        val pending = services.map { it.UUID.UUIDString }.toMutableList()
+        assertEquals(2, pending.size)
 
-        assertEquals(1, pending.size)
+        // Each callback removes only the first matching entry - mirrors
+        // IosPeripheralDiscovery.handleCharacteristicsDiscovered.
+        pending.remove(uuid.UUIDString)
+        assertEquals(1, pending.size, "one outstanding entry should remain for the second service")
+
+        pending.remove(uuid.UUIDString)
+        assertTrue(pending.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `discoverCharacteristics(serviceUuid: String)` re-resolved the `CBService` by filtering `cbPeripheral.services` again instead of reusing the object already produced by `handleServicesDiscovered`. Peripherals with two services sharing a UUID (legal per the BLE spec) always resolved to the first match, and the extra `cbPeripheral.services` read opened a window where CoreBluetooth may have already invalidated the previous service list between the two reads.
  - Fix: pass the `CBService` instance straight through from `handleServicesDiscovered` to `bridge.discoverCharacteristics(service)`, removing the re-resolution step.
- `pendingServices` was a `Set<String>` of service UUIDs, so those same duplicate-UUID services collapsed to one pending entry. The first `didDiscoverCharacteristicsForService` callback cleared it and the discovery cycle finished while the second service's callback was still outstanding, silently dropping its characteristics.
  - Fix: switch to a `List<String>` with one entry per service; each callback removes only its own entry (`MutableList.remove` matches a single element instead of deduping). Also removes the unchecked `Set<String> -> MutableSet<String>` cast this replaces.

## Test plan
- [x] `./gradlew :compileIosMainKotlinMetadata` passes
- [x] `./gradlew ktlintCheck` passes
- [x] Added `IosGattEventHandlerTest` coverage using `CBMutableService` (a real, instantiable `CBService` subclass, since `CBPeripheral` has no test-usable initializer):
  - distinct services can share a UUID and are never reference-equal
  - UUID-string resolution silently collapsed duplicates to the first match (the bug the first fix addresses)
  - `pendingServices` now keeps one entry per service and clears them one at a time (the bug the second fix addresses)
- [x] `./gradlew :iosSimulatorArm64Test --tests "*IosGattEventHandlerTest*"` - 17/17 passing