### PR TITLE
fix(ios): cache discovered services across reconnects via didModifyServices

### DIFF
--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/ApplePeripheralBridge.kt
@@ -57,6 +57,12 @@ internal sealed interface AppleCallbackEvent {
         val channel: CBL2CAPChannel?,
         val error: NSError?,
     ) : AppleCallbackEvent
+
+    /**
+     * The peripheral's GATT table changed (e.g. a firmware-side Service Changed
+     * indication). Previously cached services/characteristics are no longer valid.
+     */
+    data object DidModifyServices : AppleCallbackEvent
 }
 
 internal class ApplePeripheralBridge(
@@ -134,6 +140,13 @@ internal class ApplePeripheralBridge(
                 error: NSError?,
             ) {
                 _onEvent.value?.invoke(AppleCallbackEvent.DidOpenL2CAPChannel(didOpenL2CAPChannel, error))
+            }
+
+            override fun peripheral(
+                peripheral: CBPeripheral,
+                didModifyServices: List<*>,
+            ) {
+                _onEvent.value?.invoke(AppleCallbackEvent.DidModifyServices)
             }
         }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -97,6 +97,14 @@ public class IosPeripheral(
     /** Discovery generation counter - increments on each new discovery cycle to detect stale callbacks. */
     internal val discoveryGeneration = atomic(0)
 
+    /**
+     * Whether the last completed service discovery is still valid. CoreBluetooth caches
+     * discovered services/characteristics on [cbPeripheral] across reconnects, so a
+     * reconnect can reuse them instead of re-running discovery - until a
+     * `didModifyServices` callback clears this.
+     */
+    internal val knownServicesValid = atomic(false)
+
     /** Current discovery cycle state, confined to peripheralContext.dispatcher. */
     internal var currentDiscovery: DiscoveryCycle? = null
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
@@ -25,6 +25,7 @@ internal fun IosPeripheral.handleBridgeEvent(event: AppleCallbackEvent) {
                 pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
             is AppleCallbackEvent.DidReadRSSI -> handleRssi(event)
             is AppleCallbackEvent.DidOpenL2CAPChannel -> handleDidOpenL2CAPChannel(event)
+            is AppleCallbackEvent.DidModifyServices -> handleServicesModified()
         }
     }
 }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -89,8 +89,8 @@ internal fun IosPeripheral.handleConnectionCallback(
             // CoreBluetooth caches services/characteristics on the peripheral across
             // reconnects until a didModifyServices callback invalidates them - reuse
             // that cache instead of re-running discovery on every reconnect.
-            val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
-            if (cbServicesUsableFromCache(knownServicesValid.value, cachedServices)) {
+            if (canReuseServiceCache()) {
+                val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
                 finishDiscoveryFromCache(cachedServices)
                 return@launch
             }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -17,6 +17,7 @@ import platform.CoreBluetooth.CBErrorConnectionFailed
 import platform.CoreBluetooth.CBErrorConnectionLimitReached
 import platform.CoreBluetooth.CBErrorConnectionTimeout
 import platform.CoreBluetooth.CBErrorPeripheralDisconnected
+import platform.CoreBluetooth.CBService
 import platform.Foundation.NSError
 
 /**
@@ -84,6 +85,16 @@ internal fun IosPeripheral.handleConnectionCallback(
             discoveryGeneration.incrementAndGet()
             nativeCharMap.clear()
             nativeDescMap.clear()
+
+            // CoreBluetooth caches services/characteristics on the peripheral across
+            // reconnects until a didModifyServices callback invalidates them - reuse
+            // that cache instead of re-running discovery on every reconnect.
+            val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
+            if (cbServicesUsableFromCache(knownServicesValid.value, cachedServices)) {
+                finishDiscoveryFromCache(cachedServices)
+                return@launch
+            }
+
             try {
                 bridge.discoverServices()
             } catch (e: CancellationException) {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -9,9 +9,6 @@ import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.state.ConnectionEvent
 import com.atruedev.kmpble.peripheral.state.State
 import com.atruedev.kmpble.scanner.uuidFrom
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
 import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBCharacteristicPropertyAuthenticatedSignedWrites
 import platform.CoreBluetooth.CBCharacteristicPropertyIndicate
@@ -131,28 +128,6 @@ internal fun IosPeripheral.canReuseServiceCache(): Boolean {
 }
 
 /**
- * Attempts to reuse cached CoreBluetooth services to finish discovery, falling back
- * to a full native `discoverServices`/`discoverCharacteristics` round trip when the
- * cache is empty, incomplete, or invalidated. Used by both the normal connect path
- * and state restoration to avoid redundant discovery on reconnects.
- */
-@OptIn(ExperimentalUuidApi::class)
-internal suspend fun IosPeripheral.tryReuseCacheOrDiscover() {
-    if (canReuseServiceCache()) {
-        val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
-        finishDiscoveryFromCache(cbServices)
-        return
-    }
-    val deferred = slots.armConnect()
-    try {
-        bridge.discoverServices()
-        withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
-    } finally {
-        slots.clearConnect()
-    }
-}
-
-/**
  * Finalizes discovery from services CoreBluetooth already has cached on [IosPeripheral.cbPeripheral],
  * skipping a redundant native `discoverServices`/`discoverCharacteristics` round trip. Only valid
  * when [IosPeripheral.knownServicesValid] holds - i.e. no `didModifyServices` callback has
@@ -168,36 +143,23 @@ internal suspend fun IosPeripheral.finishDiscoveryFromCache(cbServices: List<CBS
  * trustworthy - invalidate them and, if still connected, rediscover immediately rather
  * than waiting for the next reconnect.
  *
- * Reuses the same armConnect/clearConnect pattern as the normal connect flow so the
- * discovery deferred is properly awaited and cleared -- unlike a fire-and-forget
- * discoverServices() call which leaves nativeCharMap empty until the callback fires.
+ * Does NOT arm a connect slot (slots.armConnect) because the peripheral is already
+ * connected when didModifyServices fires -- armConnect would throw if the original
+ * connect flow still holds the slot. Instead, uses tryArmDiscovery to guard against
+ * concurrent discovery cycles, then runs discoverServices() fire-and-forget like the
+ * normal connect path's handleConnectionCallback does. The async callback chain
+ * (didDiscoverServices -> didDiscoverCharacteristics -> finishDiscovery) handles
+ * completion, including repopulating nativeCharMap and resubscribing observations.
  */
 internal suspend fun IosPeripheral.handleServicesModified() {
     knownServicesValid.value = false
     if (peripheralContext.state.value !is State.Connected) return
-    // Guard against concurrent discovery cycles. tryArmDiscovery alone isn't
-    // enough because finishDiscovery() completes the connect deferred, so we
-    // must also arm the connect slot.
     if (!slots.tryArmDiscovery()) return
     discoveryGeneration.incrementAndGet()
     nativeCharMap.clear()
     nativeDescMap.clear()
     currentDiscovery = null
-
-    val deferred = slots.armConnect()
-    try {
-        bridge.discoverServices()
-        withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
-    } catch (_: CancellationException) {
-        throw CancellationException("Service rediscovery cancelled")
-    } catch (_: TimeoutCancellationException) {
-        peripheralContext.processEvent(
-            ConnectionEvent.DiscoveryFailed(ServiceDiscoveryError(serviceUuid = null, status = null)),
-        )
-        slots.failDiscovery(BleException(ServiceDiscoveryError(serviceUuid = null, status = null)))
-    } finally {
-        slots.clearConnect()
-    }
+    bridge.discoverServices()
 }
 
 @OptIn(ExperimentalUuidApi::class)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -9,6 +9,9 @@ import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.state.ConnectionEvent
 import com.atruedev.kmpble.peripheral.state.State
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBCharacteristicPropertyAuthenticatedSignedWrites
 import platform.CoreBluetooth.CBCharacteristicPropertyIndicate
@@ -111,17 +114,43 @@ internal suspend fun IosPeripheral.finishDiscovery(discovered: List<DiscoveredSe
 }
 
 /**
- * Whether [cbServices] can be used as-is instead of running a fresh native discovery:
- * the last discovery is still valid (no `didModifyServices` since), there is at least
- * one service, and every service already has its characteristics cached.
+ * Pure boolean check: whether [cbServices] are usable from cache given the validity flag.
+ * Extracted so tests can exercise the logic without constructing an IosPeripheral.
  */
-internal fun cbServicesUsableFromCache(
+internal fun serviceCacheUsable(
     knownServicesValid: Boolean,
     cbServices: List<CBService>,
 ): Boolean =
     knownServicesValid &&
         cbServices.isNotEmpty() &&
         cbServices.all { it.characteristics != null }
+
+internal fun IosPeripheral.canReuseServiceCache(): Boolean {
+    val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
+    return serviceCacheUsable(knownServicesValid.value, cbServices)
+}
+
+/**
+ * Attempts to reuse cached CoreBluetooth services to finish discovery, falling back
+ * to a full native `discoverServices`/`discoverCharacteristics` round trip when the
+ * cache is empty, incomplete, or invalidated. Used by both the normal connect path
+ * and state restoration to avoid redundant discovery on reconnects.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.tryReuseCacheOrDiscover() {
+    if (canReuseServiceCache()) {
+        val cbServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
+        finishDiscoveryFromCache(cbServices)
+        return
+    }
+    val deferred = slots.armConnect()
+    try {
+        bridge.discoverServices()
+        withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
+    } finally {
+        slots.clearConnect()
+    }
+}
 
 /**
  * Finalizes discovery from services CoreBluetooth already has cached on [IosPeripheral.cbPeripheral],
@@ -138,16 +167,37 @@ internal suspend fun IosPeripheral.finishDiscoveryFromCache(cbServices: List<CBS
  * The peripheral's GATT table changed. Cached services/characteristics are no longer
  * trustworthy - invalidate them and, if still connected, rediscover immediately rather
  * than waiting for the next reconnect.
+ *
+ * Reuses the same armConnect/clearConnect pattern as the normal connect flow so the
+ * discovery deferred is properly awaited and cleared -- unlike a fire-and-forget
+ * discoverServices() call which leaves nativeCharMap empty until the callback fires.
  */
 internal suspend fun IosPeripheral.handleServicesModified() {
     knownServicesValid.value = false
     if (peripheralContext.state.value !is State.Connected) return
+    // Guard against concurrent discovery cycles. tryArmDiscovery alone isn't
+    // enough because finishDiscovery() completes the connect deferred, so we
+    // must also arm the connect slot.
     if (!slots.tryArmDiscovery()) return
-    currentDiscovery = null
     discoveryGeneration.incrementAndGet()
     nativeCharMap.clear()
     nativeDescMap.clear()
-    bridge.discoverServices()
+    currentDiscovery = null
+
+    val deferred = slots.armConnect()
+    try {
+        bridge.discoverServices()
+        withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
+    } catch (_: CancellationException) {
+        throw CancellationException("Service rediscovery cancelled")
+    } catch (_: TimeoutCancellationException) {
+        peripheralContext.processEvent(
+            ConnectionEvent.DiscoveryFailed(ServiceDiscoveryError(serviceUuid = null, status = null)),
+        )
+        slots.failDiscovery(BleException(ServiceDiscoveryError(serviceUuid = null, status = null)))
+    } finally {
+        slots.clearConnect()
+    }
 }
 
 @OptIn(ExperimentalUuidApi::class)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralDiscovery.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpble.gatt.Descriptor
 import com.atruedev.kmpble.gatt.DiscoveredService
 import com.atruedev.kmpble.peripheral.internal.findCharacteristic
 import com.atruedev.kmpble.peripheral.state.ConnectionEvent
+import com.atruedev.kmpble.peripheral.state.State
 import com.atruedev.kmpble.scanner.uuidFrom
 import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBCharacteristicPropertyAuthenticatedSignedWrites
@@ -100,12 +101,53 @@ internal suspend fun IosPeripheral.handleCharacteristicsDiscovered(
 
 @OptIn(ExperimentalUuidApi::class)
 internal suspend fun IosPeripheral.finishDiscovery(discovered: List<DiscoveredService>) {
+    knownServicesValid.value = true
     peripheralContext.processEvent(ConnectionEvent.ServicesDiscovered)
     peripheralContext.updateServices(discovered)
     resubscribeObservations()
     peripheralContext.processEvent(ConnectionEvent.ConfigurationComplete)
     slots.completeConnect()
     slots.completeDiscovery(discovered)
+}
+
+/**
+ * Whether [cbServices] can be used as-is instead of running a fresh native discovery:
+ * the last discovery is still valid (no `didModifyServices` since), there is at least
+ * one service, and every service already has its characteristics cached.
+ */
+internal fun cbServicesUsableFromCache(
+    knownServicesValid: Boolean,
+    cbServices: List<CBService>,
+): Boolean =
+    knownServicesValid &&
+        cbServices.isNotEmpty() &&
+        cbServices.all { it.characteristics != null }
+
+/**
+ * Finalizes discovery from services CoreBluetooth already has cached on [IosPeripheral.cbPeripheral],
+ * skipping a redundant native `discoverServices`/`discoverCharacteristics` round trip. Only valid
+ * when [IosPeripheral.knownServicesValid] holds - i.e. no `didModifyServices` callback has
+ * invalidated the cache since the last full discovery.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal suspend fun IosPeripheral.finishDiscoveryFromCache(cbServices: List<CBService>) {
+    finishDiscovery(cbServices.map { it.toDiscoveredService(this) })
+}
+
+/**
+ * The peripheral's GATT table changed. Cached services/characteristics are no longer
+ * trustworthy - invalidate them and, if still connected, rediscover immediately rather
+ * than waiting for the next reconnect.
+ */
+internal suspend fun IosPeripheral.handleServicesModified() {
+    knownServicesValid.value = false
+    if (peripheralContext.state.value !is State.Connected) return
+    if (!slots.tryArmDiscovery()) return
+    currentDiscovery = null
+    discoveryGeneration.incrementAndGet()
+    nativeCharMap.clear()
+    nativeDescMap.clear()
+    bridge.discoverServices()
 }
 
 @OptIn(ExperimentalUuidApi::class)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
@@ -33,7 +33,6 @@ internal fun IosPeripheral.requireNativeCbDesc(d: Descriptor): CBDescriptor =
     nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
 
 internal fun IosPeripheral.onDisconnectCleanup() {
-    knownServicesValid.value = false
     nativeCharMap.clear()
     nativeDescMap.clear()
     closeL2capChannels()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
@@ -33,6 +33,7 @@ internal fun IosPeripheral.requireNativeCbDesc(d: Descriptor): CBDescriptor =
     nativeDescMap[d] ?: throw BleException(StaleGattHandle("descriptor", d.uuid.toString()))
 
 internal fun IosPeripheral.onDisconnectCleanup() {
+    knownServicesValid.value = false
     nativeCharMap.clear()
     nativeDescMap.clear()
     closeL2capChannels()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
@@ -5,6 +5,7 @@ import com.atruedev.kmpble.peripheral.state.ConnectionEvent
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import platform.CoreBluetooth.CBPeripheralStateConnected
+import platform.CoreBluetooth.CBService
 
 /**
  * Restore this peripheral from iOS state restoration.
@@ -38,12 +39,17 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
                 nativeCharMap.clear()
                 nativeDescMap.clear()
 
-                val deferred = slots.armConnect()
-                try {
-                    bridge.discoverServices()
-                    withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
-                } finally {
-                    slots.clearConnect()
+                val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
+                if (cbServicesUsableFromCache(knownServicesValid.value, cachedServices)) {
+                    finishDiscoveryFromCache(cachedServices)
+                } else {
+                    val deferred = slots.armConnect()
+                    try {
+                        bridge.discoverServices()
+                        withTimeout(currentTimeouts.serviceDiscovery) { deferred.await() }
+                    } finally {
+                        slots.clearConnect()
+                    }
                 }
             } finally {
                 slots.clearDiscovery()

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralRestoration.kt
@@ -39,8 +39,8 @@ internal suspend fun IosPeripheral.restoreFromStateRestorationExt(savedObservati
                 nativeCharMap.clear()
                 nativeDescMap.clear()
 
-                val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
-                if (cbServicesUsableFromCache(knownServicesValid.value, cachedServices)) {
+                if (canReuseServiceCache()) {
+                    val cachedServices = cbPeripheral.services?.filterIsInstance<CBService>().orEmpty()
                     finishDiscoveryFromCache(cachedServices)
                 } else {
                     val deferred = slots.armConnect()

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -6,6 +6,7 @@ import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PendingOperations
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
+import platform.CoreBluetooth.CBMutableCharacteristic
 import platform.CoreBluetooth.CBMutableService
 import platform.CoreBluetooth.CBService
 import platform.CoreBluetooth.CBUUID
@@ -213,9 +214,10 @@ class IosGattEventHandlerTest {
                 "DidWriteValueForDescriptor",
                 "DidReadRSSI",
                 "DidOpenL2CAPChannel",
+                "DidModifyServices",
             )
 
-        assertEquals(8, subtypes.size, "All AppleCallbackEvent subtypes should be documented")
+        assertEquals(9, subtypes.size, "All AppleCallbackEvent subtypes should be documented")
     }
 
     // -- Multiple pending operations don't interfere --
@@ -307,6 +309,46 @@ class IosGattEventHandlerTest {
 
         pending.remove(uuid.UUIDString)
         assertTrue(pending.isEmpty())
+    }
+
+    // -- Service cache reuse across reconnects (cbServicesUsableFromCache) --
+
+    private fun fakeServiceWithCharacteristics(): CBMutableService {
+        val service = CBMutableService(type = CBUUID.UUIDWithString("180D"), primary = true)
+        val characteristic =
+            CBMutableCharacteristic(
+                type = CBUUID.UUIDWithString("2A19"),
+                properties = 0uL,
+                value = null,
+                permissions = 0uL,
+            )
+        service.setCharacteristics(listOf(characteristic))
+        return service
+    }
+
+    @Test
+    fun `cbServicesUsableFromCache is false when the validity flag is unset`() {
+        val service = fakeServiceWithCharacteristics()
+        assertFalse(cbServicesUsableFromCache(knownServicesValid = false, cbServices = listOf(service)))
+    }
+
+    @Test
+    fun `cbServicesUsableFromCache is false with no services`() {
+        assertFalse(cbServicesUsableFromCache(knownServicesValid = true, cbServices = emptyList()))
+    }
+
+    @Test
+    fun `cbServicesUsableFromCache is false when a service has no cached characteristics`() {
+        // characteristics is null until CoreBluetooth (or a real discovery cycle) populates it -
+        // using such a service without rediscovery would leave nativeCharMap empty for it.
+        val undiscovered = CBMutableService(type = CBUUID.UUIDWithString("180D"), primary = true)
+        assertFalse(cbServicesUsableFromCache(knownServicesValid = true, cbServices = listOf(undiscovered)))
+    }
+
+    @Test
+    fun `cbServicesUsableFromCache is true when valid and every service has cached characteristics`() {
+        val service = fakeServiceWithCharacteristics()
+        assertTrue(cbServicesUsableFromCache(knownServicesValid = true, cbServices = listOf(service)))
     }
 
     @Test

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -327,28 +327,28 @@ class IosGattEventHandlerTest {
     }
 
     @Test
-    fun `cbServicesUsableFromCache is false when the validity flag is unset`() {
+    fun `serviceCacheUsable is false when the validity flag is unset`() {
         val service = fakeServiceWithCharacteristics()
-        assertFalse(cbServicesUsableFromCache(knownServicesValid = false, cbServices = listOf(service)))
+        assertFalse(serviceCacheUsable(knownServicesValid = false, cbServices = listOf(service)))
     }
 
     @Test
-    fun `cbServicesUsableFromCache is false with no services`() {
-        assertFalse(cbServicesUsableFromCache(knownServicesValid = true, cbServices = emptyList()))
+    fun `serviceCacheUsable is false with no services`() {
+        assertFalse(serviceCacheUsable(knownServicesValid = true, cbServices = emptyList()))
     }
 
     @Test
-    fun `cbServicesUsableFromCache is false when a service has no cached characteristics`() {
+    fun `serviceCacheUsable is false when a service has no cached characteristics`() {
         // characteristics is null until CoreBluetooth (or a real discovery cycle) populates it -
         // using such a service without rediscovery would leave nativeCharMap empty for it.
         val undiscovered = CBMutableService(type = CBUUID.UUIDWithString("180D"), primary = true)
-        assertFalse(cbServicesUsableFromCache(knownServicesValid = true, cbServices = listOf(undiscovered)))
+        assertFalse(serviceCacheUsable(knownServicesValid = true, cbServices = listOf(undiscovered)))
     }
 
     @Test
-    fun `cbServicesUsableFromCache is true when valid and every service has cached characteristics`() {
+    fun `serviceCacheUsable is true when valid and every service has cached characteristics`() {
         val service = fakeServiceWithCharacteristics()
-        assertTrue(cbServicesUsableFromCache(knownServicesValid = true, cbServices = listOf(service)))
+        assertTrue(serviceCacheUsable(knownServicesValid = true, cbServices = listOf(service)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Every reconnect to the same peripheral called `discoverServices()` again unconditionally, even though CoreBluetooth already caches the previously discovered services/characteristics on that `CBPeripheral` instance. Peripherals held via `PeripheralRegistry` live for the app's lifetime and can reconnect many times, so repeated no-op rediscovery accumulates on the same native object across the session.

Observed in the field as a stack overflow inside CoreBluetooth's own `-[CBService invalidate]`, which recurses over the peripheral's attribute tree on disconnect:

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Subtype: KERN_PROTECTION_FAILURE at 0x000000016f833f80
Exception Message: Could not determine thread index for stack guard region

Thread 1 Crashed:
0   CoreBluetooth   -[CBService invalidate] + 52
1   CoreBluetooth   -[CBService invalidate] + 336
1146 CoreBluetooth  -[CBPeripheral invalidateAllAttributes] + 164
1147 CoreBluetooth  -[CBPeripheral handleDisconnection] + 108
1148 CoreBluetooth  -[CBCentralManager handlePeripheralDisconnectionCompleted:] + 240
```

Zero app frames - the crash is entirely inside CoreBluetooth, triggered by repeated discovery cycles building up a pathological attribute structure on the same long-lived peripheral object over many connect/disconnect cycles.

## Fix

- Add support for `peripheral:didModifyServices:`, the callback CoreBluetooth provides specifically to signal when the cached GATT table is no longer valid (`ApplePeripheralBridge` had no handler for it at all).
- Track validity on `IosPeripheral` (`knownServicesValid`): set after a successful discovery, cleared on `didModifyServices`.
- On reconnect (both the normal connect path and state restoration), skip the native `discoverServices()`/`discoverCharacteristics()` round trip when the cache is still valid and every service already has its characteristics populated (`cbServicesUsableFromCache`) - reuse `cbPeripheral.services` directly instead.
- Falls back to a full rediscovery when the cache is empty, incomplete, or invalidated.
- If `didModifyServices` fires while still connected, proactively rediscover immediately rather than waiting for the next reconnect.

## Test plan
- [x] `./gradlew :compileIosMainKotlinMetadata` and `:compileKotlinIosSimulatorArm64` pass
- [x] `./gradlew ktlintCheck` passes
- [x] Added `cbServicesUsableFromCache` coverage in `IosGattEventHandlerTest` using `CBMutableService`/`CBMutableCharacteristic` (real, instantiable `CBService`/`CBCharacteristic` subclasses)
- [x] `./gradlew :iosSimulatorArm64Test` - full suite, 740/740 passing, 0 failures/errors
- [ ] No automated repro for the stack-overflow crash itself (requires real hardware power-cycling across two devices); needs manual/device verification