### PR TITLE
fix(ios): close two races that let a duplicate IosPeripheral corrupt CoreBluetooth wiring

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralRegistry.kt
@@ -2,37 +2,41 @@ package com.atruedev.kmpble.peripheral.internal
 
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.peripheral.Peripheral
-import kotlinx.coroutines.CancellationException
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Prevents duplicate [Peripheral] instances for the same physical device.
  * Lock-free via [AtomicReference] CAS - no blocking, no suspend, no TOCTOU.
+ *
+ * The map holds a [Lazy] per identifier rather than a realized [Peripheral]. [factory]'s
+ * side effects (assigning the native peripheral's delegate, registering into
+ * CentralDelegateState's shared connection-callback map) must run at most once per
+ * identifier: previously `factory()` ran eagerly for every racing caller, so two callers
+ * could each construct a full instance before the CAS resolved, and the loser's later
+ * close() (or simply its constructor clobbering shared native state after the winner had
+ * already started using it) could corrupt the survivor's CoreBluetooth wiring. Wrapping
+ * the candidate in a SYNCHRONIZED [Lazy] means only the caller that wins the identifier's
+ * slot ever evaluates [factory] - a losing candidate is discarded unevaluated, so its
+ * factory() body never runs, and a caller that hits the existing-entry fast path safely
+ * blocks on the same evaluation instead of racing a second one.
  */
 @OptIn(ExperimentalAtomicApi::class)
 internal object PeripheralRegistry {
-    private val registry = AtomicReference(mapOf<Identifier, Peripheral>())
+    private val registry = AtomicReference(mapOf<Identifier, Lazy<Peripheral>>())
 
     internal fun getOrCreate(
         identifier: Identifier,
         factory: () -> Peripheral,
     ): Peripheral {
-        registry.load()[identifier]?.let { return it }
+        registry.load()[identifier]?.let { return it.value }
 
-        val peripheral = factory()
+        val candidate = lazy(LazyThreadSafetyMode.SYNCHRONIZED, factory)
         while (true) {
             val current = registry.load()
-            current[identifier]?.let {
-                try {
-                    peripheral.close()
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
-                }
-                return it
-            }
-            if (registry.compareAndSet(current, current + (identifier to peripheral))) {
-                return peripheral
+            current[identifier]?.let { return it.value }
+            if (registry.compareAndSet(current, current + (identifier to candidate))) {
+                return candidate.value
             }
         }
     }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegate.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegate.kt
@@ -21,7 +21,10 @@ internal interface CentralDelegate {
         callback: (connected: Boolean, error: NSError?) -> Unit,
     )
 
-    fun unregisterConnectionCallback(peripheralId: String)
+    fun unregisterConnectionCallback(
+        peripheralId: String,
+        callback: (connected: Boolean, error: NSError?) -> Unit,
+    )
 
     fun handleConnectionFailure(
         peripheralId: String,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateImpl.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateImpl.kt
@@ -25,7 +25,10 @@ internal class CentralDelegateImpl(
         callback: (connected: Boolean, error: NSError?) -> Unit,
     ) = state.registerConnectionCallback(peripheralId, callback)
 
-    override fun unregisterConnectionCallback(peripheralId: String) = state.unregisterConnectionCallback(peripheralId)
+    override fun unregisterConnectionCallback(
+        peripheralId: String,
+        callback: (connected: Boolean, error: NSError?) -> Unit,
+    ) = state.unregisterConnectionCallback(peripheralId, callback)
 
     override fun handleConnectionFailure(
         peripheralId: String,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateState.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/internal/CentralDelegateState.kt
@@ -50,8 +50,23 @@ internal class CentralDelegateState {
         connectionCallbacks.update { it + (peripheralId to callback) }
     }
 
-    internal fun unregisterConnectionCallback(peripheralId: String) {
-        connectionCallbacks.update { it - peripheralId }
+    /**
+     * Removes [callback] only if it is still the one registered for [peripheralId].
+     *
+     * PeripheralRegistry.getOrCreate() can construct two IosPeripheral instances for the
+     * same identifier before its CAS resolves (the losing one is discarded). Both
+     * constructors call registerConnectionCallback with their own closure, so whichever
+     * registers last wins the shared map slot regardless of which instance survives. An
+     * unconditional removal-by-key here would let the discarded instance's close() delete
+     * the surviving instance's live registration - identity-checking closes that window.
+     */
+    internal fun unregisterConnectionCallback(
+        peripheralId: String,
+        callback: (connected: Boolean, error: NSError?) -> Unit,
+    ) {
+        connectionCallbacks.update { current ->
+            if (current[peripheralId] === callback) current - peripheralId else current
+        }
     }
 
     internal fun handleAdapterStateUpdate(central: CBCentralManager) {

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -51,6 +51,7 @@ import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBDescriptor
 import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSError
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -118,11 +119,17 @@ public class IosPeripheral(
             onMaxAttemptsExhausted = { observationManager.onPermanentDisconnect() },
         )
 
+    /**
+     * Stored so [connectInternal] can re-register the same instance (see there) and
+     * [closeInternal] can remove it only if it is still the registered one - both need
+     * the exact closure reference, not a newly allocated lambda.
+     */
+    internal val connectionCallback: (connected: Boolean, error: NSError?) -> Unit =
+        { connected, error -> handleConnectionCallback(connected, error) }
+
     init {
         bridge.onEvent = { event -> handleBridgeEvent(event) }
-        centralDelegate.registerConnectionCallback(identifier.value) { connected, error ->
-            handleConnectionCallback(connected, error)
-        }
+        centralDelegate.registerConnectionCallback(identifier.value, connectionCallback)
         if (CentralManagerProvider.isStateRestorationEnabled) {
             observationManager.onObservationsChanged = { observations ->
                 StateRestorationHandler.default.persistObservations(identifier.value, observations)

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralConnection.kt
@@ -34,6 +34,12 @@ internal suspend fun IosPeripheral.connectInternal(options: ConnectionOptions) {
         peripheralContext.processEvent(ConnectionEvent.ConnectRequested)
         peripheralContext.gattQueue.start(options.gattOperationTimeout)
 
+        // Re-affirm this instance's connection-callback registration before connecting,
+        // mirroring bridge.connect()'s own re-affirmation of cbPeripheral.delegate. Guards
+        // against a since-discarded duplicate IosPeripheral for this identifier (raced via
+        // PeripheralRegistry.getOrCreate) having last written the shared registration.
+        centralDelegate.registerConnectionCallback(identifier.value, connectionCallback)
+
         val deferred = slots.armConnect()
         bridge.connect()
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralInternal.kt
@@ -62,7 +62,7 @@ internal fun IosPeripheral.closeInternal() {
     bondManager.stop()
     pairingRequestHandler.closeSync()
     closeL2capChannels()
-    centralDelegate.unregisterConnectionCallback(identifier.value)
+    centralDelegate.unregisterConnectionCallback(identifier.value, connectionCallback)
 
     // Invalidate in-flight discovery cycle callbacks before teardown.
     discoveryGeneration.incrementAndGet()

--- a/src/iosTest/kotlin/com/atruedev/kmpble/internal/CentralDelegateStateTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/internal/CentralDelegateStateTest.kt
@@ -1,0 +1,78 @@
+package com.atruedev.kmpble.internal
+
+import platform.Foundation.NSError
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CentralDelegateStateTest {
+    @Test
+    fun losingDuplicateRegistrationDoesNotClobberSurvivor() {
+        val state = CentralDelegateState()
+        val id = "peripheral-1"
+
+        var loserInvoked = false
+        val loserCallback: (Boolean, NSError?) -> Unit = { _, _ -> loserInvoked = true }
+
+        var survivorInvoked = false
+        val survivorCallback: (Boolean, NSError?) -> Unit = { _, _ -> survivorInvoked = true }
+
+        // Simulates PeripheralRegistry.getOrCreate() constructing two IosPeripheral
+        // instances for the same identifier before its CAS resolves: both register in
+        // their init block, so whichever registers last wins the shared map slot
+        // regardless of which instance actually wins the CAS and survives.
+        state.registerConnectionCallback(id, loserCallback)
+        state.registerConnectionCallback(id, survivorCallback)
+
+        // The loser discovers it lost the race and closes itself. Unregistering with its
+        // own callback reference must not remove the survivor's live registration.
+        state.unregisterConnectionCallback(id, loserCallback)
+
+        state.handleConnectionFailure(id, null)
+
+        assertTrue(survivorInvoked, "survivor's callback should still be registered")
+        assertFalse(loserInvoked, "loser's callback must not fire")
+    }
+
+    @Test
+    fun unregisterConnectionCallbackRemovesItsOwnRegistration() {
+        val state = CentralDelegateState()
+        val id = "peripheral-2"
+        var invoked = false
+        val callback: (Boolean, NSError?) -> Unit = { _, _ -> invoked = true }
+
+        state.registerConnectionCallback(id, callback)
+        state.unregisterConnectionCallback(id, callback)
+
+        state.handleConnectionFailure(id, null)
+
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun unregisterConnectionCallbackIgnoresStaleCallbackAfterReRegistration() {
+        val state = CentralDelegateState()
+        val id = "peripheral-3"
+
+        var firstInvoked = false
+        val first: (Boolean, NSError?) -> Unit = { _, _ -> firstInvoked = true }
+
+        var secondInvoked = false
+        val second: (Boolean, NSError?) -> Unit = { _, _ -> secondInvoked = true }
+
+        // Mirrors IosPeripheral.connectInternal() re-affirming its own registration
+        // before every connect, the same way ApplePeripheralBridge re-affirms
+        // cbPeripheral.delegate before every native operation.
+        state.registerConnectionCallback(id, first)
+        state.registerConnectionCallback(id, second)
+
+        // A stale unregister call carrying the pre-re-affirmation reference (e.g. from a
+        // discarded duplicate that closes late) must not remove the re-affirmed one.
+        state.unregisterConnectionCallback(id, first)
+
+        state.handleConnectionFailure(id, null)
+
+        assertTrue(secondInvoked)
+        assertFalse(firstInvoked)
+    }
+}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/PeripheralRegistryLincheckTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/PeripheralRegistryLincheckTest.kt
@@ -6,6 +6,9 @@ import org.jetbrains.lincheck.datastructures.ModelCheckingOptions
 import org.jetbrains.lincheck.datastructures.Operation
 import org.jetbrains.lincheck.datastructures.StressOptions
 import org.junit.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 
@@ -74,6 +77,46 @@ class PeripheralRegistryLincheckTest {
         assertEquals(setOf("a", "b"), PeripheralRegistry.identifiers())
         PeripheralRegistry.clear()
         assertEquals(emptySet(), PeripheralRegistry.identifiers())
+    }
+
+    /**
+     * Regression test for the duplicate-construction race: factory() has side effects on
+     * the real IosPeripheral (assigning the native peripheral's delegate, registering into
+     * the shared connection-callback map), so it must run at most once per identifier even
+     * when many threads call getOrCreate() for the same identifier at the same time. Before
+     * the Lazy-based fix, factory() ran eagerly for every racing caller and the losers'
+     * instances (and later close() calls) could corrupt the survivor's native wiring.
+     */
+    @Test
+    fun factoryRunsAtMostOnceUnderConcurrentGetOrCreate() {
+        PeripheralRegistry.clear()
+        val id = Identifier("racing-device")
+        val factoryInvocations = AtomicInteger(0)
+        val threadCount = 32
+        val barrier = CyclicBarrier(threadCount)
+        val results = ConcurrentLinkedQueue<Any>()
+
+        val threads =
+            List(threadCount) {
+                Thread {
+                    barrier.await()
+                    results.add(
+                        PeripheralRegistry.getOrCreate(id) {
+                            factoryInvocations.incrementAndGet()
+                            StubPeripheral(id)
+                        },
+                    )
+                }
+            }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        assertEquals(
+            1,
+            factoryInvocations.get(),
+            "factory() must run exactly once even when many threads race getOrCreate() for the same identifier",
+        )
+        assertEquals(1, results.toSet().size, "all callers must receive the same Peripheral instance")
     }
 }
 

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.lincheck
 
+import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
@@ -30,6 +31,7 @@ import com.atruedev.kmpble.peripheral.state.State
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -56,7 +58,7 @@ internal class StubPeripheral(
 
     override fun close() {}
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override fun removeBond(): BondRemovalResult = unsupported()
 
     override suspend fun refreshServices(): List<DiscoveredService> = unsupported()
@@ -101,30 +103,33 @@ internal class StubPeripheral(
 
     override suspend fun requestMtu(mtu: Int): Int = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun requestConnectionParameterUpdate(
         params: ConnectionParameters,
     ): ConnectionParameterUpdateResult? = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun requestConnectionSubrating(
         parameters: ConnectionSubratingParameters,
     ): ConnectionSubratingResult = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun readPhy(): PhyResult? = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
-    override val phyUpdate: Flow<PhyUpdate> = unsupported()
+    // A val initializer runs unconditionally at construction, unlike the unsupported()
+    // functions above it - unsupported() here would make StubPeripheral() itself always
+    // throw, defeating every test that merely constructs one.
+    @ExperimentalBleApi
+    override val phyUpdate: Flow<PhyUpdate> = emptyFlow()
     override val dataLengthParameters: StateFlow<DataLengthParameters?> = MutableStateFlow(null)
 
     override suspend fun openL2capChannel(
@@ -137,7 +142,7 @@ internal class StubPeripheral(
 
     override suspend fun receivePastSync(): PeriodicAdvertisingSync = unsupported()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
+    @ExperimentalBleApi
     override suspend fun requestDirectionFinding(parameters: DirectionFindingParameters): DirectionFindingResult =
         unsupported()
 


### PR DESCRIPTION
## Summary

`PeripheralRegistry.getOrCreate()` could construct two `IosPeripheral` instances for the
same identifier before its lock-free CAS resolved. Both are real, independently
confirmed races on top of each other:

1. Both constructors register into `CentralDelegateState`'s shared, identifier-keyed
   `connectionCallbacks` map. `unregisterConnectionCallback()` removed by key alone, so
   the loser's `close()` (called once it discovered it lost the CAS) could delete the
   survivor's live registration.
2. Both constructors also assign `cbPeripheral.delegate` (the loser's `ApplePeripheralBridge.init`
   clobbers the survivor's assignment). Since the loser's discard (`close()`, which nils
   the delegate) is not guaranteed to happen before the survivor has already connected and
   started GATT operations, a delayed loser can nil the delegate out from under a survivor
   that is already mid-flight - a plain identity check on `close()` does not close this
   window, because the delegate was already clobbered earlier, at construction time.

Downstream this surfaced as a Sentry crash in a consumer app:

```
NSInvalidArgumentException: -[CBCharacteristic handleCharacteristicsDiscovered:]: unrecognized selector sent to instance
```

on the "already-connected/retrieved peripheral -> connect() directly" path, still
reproducing on `main` (post-#569, post-#601, post-#603) - a distinct root cause from the
overlapping-discovery races those fixed. #569 guards a single `IosPeripheral` instance
against a duplicate *delivered callback*; this is about two *separate instances* racing
to own the same identifier before either one calls `connect()`.

## Fix

Three commits, in order:

1. **`fix(ios): guard connection-callback registration against duplicate IosPeripheral race`**
   - `CentralDelegateState.unregisterConnectionCallback()` now takes the callback reference
     and only removes it if it is still the one currently registered (identity-compare-and-remove).
   - `IosPeripheral` stores its connection callback in a property so registration,
     re-registration, and unregistration all refer to the same closure instance.
   - `IosPeripheralConnection.connectInternal()` re-affirms this instance's registration
     immediately before `bridge.connect()`, mirroring the existing pattern where
     `ApplePeripheralBridge` re-affirms `cbPeripheral.delegate` before every native operation.
   - This closes the connection-callback half of the race, but not the `cbPeripheral.delegate`
     half - see commit 3.

2. **`fix(test): stop StubPeripheral's phyUpdate initializer from always throwing`**
   - Unrelated pre-existing bug found while adding a regression test: `phyUpdate`'s `val`
     initializer called `unsupported()` directly, which runs at construction time (unlike
     the `unsupported()` *functions* elsewhere in the stub, which only throw when invoked).
     `StubPeripheral()` has been throwing on construction all along, silently failing every
     test in `PeripheralRegistryLincheckTest` that builds one.
   - Also replaced 8 inline fully-qualified `@com.atruedev.kmpble.ExperimentalBleApi`
     annotations with a proper import, per this project's Kotlin conventions.

3. **`fix(peripheral): defer PeripheralRegistry factory() until CAS wins the identifier`**
   - The complete fix: `factory()` (which constructs the full `IosPeripheral`, including
     its side-effecting `init` block) must never run for a losing candidate at all - closing
     it after the fact is not enough, since damage (delegate/callback clobbering) is done at
     construction time regardless of when the loser is discarded.
   - `PeripheralRegistry` now stores a `SYNCHRONIZED Lazy<Peripheral>` per identifier instead
     of a realized one. Only whichever candidate wins the identifier's CAS slot ever evaluates
     it; a caller that hits the existing-entry fast path safely awaits that same evaluation
     instead of racing a second one. A losing `Lazy` is discarded unevaluated, so its
     `factory()` body - and thus its native delegate/callback side effects - never runs.

## Test plan

- [x] `factoryRunsAtMostOnceUnderConcurrentGetOrCreate` (new): 32 threads race `getOrCreate()`
      for the same identifier; asserts `factory()` runs exactly once and all callers observe
      the same instance. Verified this fails against the pre-fix eager-factory implementation
      (32 invocations instead of 1).
- [x] `CentralDelegateStateTest` (new, 3 cases): losing duplicate registration doesn't clobber
      the survivor, unregister removes only its own registration, stale unregister after
      re-affirmation is a no-op. Verified these fail to *compile* against the pre-fix
      `unregisterConnectionCallback(peripheralId: String)` signature.
- [x] Existing `PeripheralRegistry` Lincheck stress/model-checking tests pass against the new
      `Lazy`-based implementation (`modelCheckingTest` explores 50 iterations x 3 threads x 3
      actors against a sequential spec).
- [x] `./gradlew :jvmTest --tests PeripheralRegistryLincheckTest` - 5/5 passing
- [x] `./gradlew :iosSimulatorArm64Test --rerun-tasks` - 743/743 passing
- [x] `./gradlew :testAndroidHostTest --rerun-tasks` - 801/801 passing
- [x] `./gradlew ktlintCheck` - clean
- [ ] No automated repro for the underlying crash itself (requires racing real CoreBluetooth
      timing); needs field verification against the Sentry issue once released