### PR TITLE
build: reduce Maven Central publishing to root module only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Publish to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew :publishToMavenCentral
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/kmp-ble-benchmark/build.gradle.kts
+++ b/kmp-ble-benchmark/build.gradle.kts
@@ -1,13 +1,10 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.ktlint)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()

--- a/kmp-ble-codec-serialization/build.gradle.kts
+++ b/kmp-ble-codec-serialization/build.gradle.kts
@@ -2,12 +2,9 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()

--- a/kmp-ble-codec/build.gradle.kts
+++ b/kmp-ble-codec/build.gradle.kts
@@ -1,12 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()

--- a/kmp-ble-dfu/build.gradle.kts
+++ b/kmp-ble-dfu/build.gradle.kts
@@ -1,12 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()

--- a/kmp-ble-mesh/build.gradle.kts
+++ b/kmp-ble-mesh/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
 }
 

--- a/kmp-ble-profiles/build.gradle.kts
+++ b/kmp-ble-profiles/build.gradle.kts
@@ -1,12 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()

--- a/kmp-ble-quirks/build.gradle.kts
+++ b/kmp-ble-quirks/build.gradle.kts
@@ -1,13 +1,10 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.ktlint)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()


### PR DESCRIPTION
## Problem
Maven Central publishing limits exceeded:
- File Count: 5,640 / 1,000 (564%)
- Release Size: 339 MB / 80 MB (424%)
- Release Count: 8 / 7 (114%)

Root cause: Publishing ALL submodules (9 modules) with . Each module publishes ~70-80 artifacts (JVM, iOS arm64/simulator/x64, Android, sources, javadoc, POM, metadata).

8 releases × ~700 files = 5,600 files/month

## Solution
1. Disable  plugin for all submodules (apply false)
2. Change CI command from  to  (root only)

## Impact
- Reduces from ~700 files/release → ~10 files/release
- Reduces size from ~339 MB → ~30-40 MB per release
- Brings publishing well under Maven Central limits

## Files Changed
-  - Changed publish command
-  - Disabled publish plugin
-  - Disabled publish plugin
-  - Disabled publish plugin
-  - Disabled publish plugin
-  - Disabled publish plugin
-  - Disabled publish plugin
-  - Disabled publish plugin

Note: Submodules can still be consumed as dependencies by the root module, they just won't be published independently to Maven Central.