### PR TITLE
build: stop publishing 6 submodules to reduce Maven Central footprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,24 @@ jobs:
           name: android-test-results
           path: build/reports/tests/
 
+  sample:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Compile sample (common)
+        run: ./gradlew :sample:compileCommonMainKotlinMetadata
+
+      - name: Compile sample app (Android)
+        run: ./gradlew :sample:compileAndroidMain :sample-android:compileDebugKotlin
+
   android-instrumented:
     runs-on: ubuntu-latest
     steps:
@@ -120,6 +138,9 @@ jobs:
 
       - name: Build iOS
         run: ./gradlew compileKotlinIosSimulatorArm64
+
+      - name: Compile sample (iOS)
+        run: ./gradlew :sample:compileKotlinIosSimulatorArm64
 
       - name: Test (common on iOS)
         run: ./gradlew iosSimulatorArm64Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Publish to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew :publishToMavenCentral :kmp-ble-quirks:publishToMavenCentral
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -42,8 +42,6 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation("com.atruedev:kmp-ble:0.8.1")
-            // Optional: for type-safe standard profiles (Heart Rate, Battery, etc.)
-            implementation("com.atruedev:kmp-ble-profiles:0.8.1")
         }
         androidMain.dependencies {
             implementation(libs.kotlinx.coroutines.android)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,11 @@
 # Migration Guide: v0.8.x to v0.9.0
 
+> **Distribution change (0.12.0+):** `kmp-ble-profiles`, `kmp-ble-dfu`,
+> `kmp-ble-codec`, and `kmp-ble-codec-serialization` are no longer published
+> to Maven Central; the last published version of each is 0.11.2. When
+> upgrading kmp-ble to 0.12.0+, pin these modules at 0.11.2 or consume them
+> from source. See the README "Distribution" note for options.
+
 This guide covers breaking API changes, new features, and deprecations when
 upgrading from kmp-ble v0.8.x to v0.9.0.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Kotlin Multiplatform BLE library for Android and iOS.
 | **kmp-ble-codec** | `com.atruedev:kmp-ble-codec` | Format-agnostic typed read/write via composable `BleEncoder`/`BleDecoder` |
 | **kmp-ble-codec-serialization** | `com.atruedev:kmp-ble-codec-serialization` | `kotlinx-serialization` adapters (CBOR) bridging `@Serializable` types to `BleCodec` |
 
+## Distribution
+
+From 0.12.0 onward only `kmp-ble` is published to Maven Central (plus
+`kmp-ble-quirks`, its transitive Android runtime dependency). The satellite
+modules above were last published at **0.11.2** and are no longer published
+as separate artifacts; their source remains in this monorepo. Pin `0.11.2`
+to keep using them as-is, or build them from source.
+
 ## Setup
 
 ### Android / KMP (Gradle)
@@ -27,12 +35,6 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation("com.atruedev:kmp-ble:0.11.2")
-
-            // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.11.2")
-            implementation("com.atruedev:kmp-ble-dfu:0.11.2")
-            implementation("com.atruedev:kmp-ble-codec:0.11.2")
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.11.2")
         }
     }
 }
@@ -139,6 +141,9 @@ peripheral.close() // or use peripheral.use { ... }
 
 ### Profiles (kmp-ble-profiles)
 
+*Requires the `kmp-ble-profiles` artifact (last published 0.11.2, see
+[Distribution](#distribution) above).*
+
 Type-safe GATT profile parsing via Peripheral extension functions:
 
 ```kotlin
@@ -162,6 +167,9 @@ println("${info.manufacturerName} ${info.modelNumber} fw:${info.firmwareRevision
 Supported profiles: Heart Rate, Battery, Device Information, Blood Pressure, Glucose, Cycling Speed and Cadence.
 
 ### Codec (kmp-ble-codec)
+
+*Requires the `kmp-ble-codec` artifact (last published 0.11.2, see
+[Distribution](#distribution) above).*
 
 Typed read/write with composable decoders:
 
@@ -187,6 +195,9 @@ val FormattedTemp = TemperatureDecoder.map { "%.1f°C".format(it) }
 
 ### Serialization codec (kmp-ble-codec-serialization)
 
+*Requires the `kmp-ble-codec-serialization` artifact (last published 0.11.2,
+see [Distribution](#distribution) above).*
+
 CBOR adapters via `kotlinx-serialization`. Bridge `@Serializable` types to the
 `BleCodec` surface so they slot into framed L2CAP streams or characteristic
 read/write paths without writing a hand-rolled decoder:
@@ -203,6 +214,9 @@ l2cap.framedIncoming(codec).collect { reading -> render(reading) }
 ```
 
 ### DFU (kmp-ble-dfu)
+
+*Requires the `kmp-ble-dfu` artifact (last published 0.11.2, see
+[Distribution](#distribution) above).*
 
 Firmware updates supporting Nordic Secure DFU, MCUboot SMP (Zephyr/Mynewt), and Espressif ESP OTA:
 

--- a/kmp-ble-benchmark/build.gradle.kts
+++ b/kmp-ble-benchmark/build.gradle.kts
@@ -1,13 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
     alias(libs.plugins.ktlint)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -55,36 +51,5 @@ dokka {
     dokkaPublications.html {
         moduleName.set("kmp-ble-benchmark")
         includes.from("MODULE.md")
-    }
-}
-
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-benchmark", version.toString())
-
-    pom {
-        name.set("kmp-ble-benchmark")
-        description.set("Benchmark and telemetry utilities for kmp-ble performance measurement")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("gary-quinn")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
     }
 }

--- a/kmp-ble-codec-serialization/build.gradle.kts
+++ b/kmp-ble-codec-serialization/build.gradle.kts
@@ -2,12 +2,8 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -45,33 +41,3 @@ dokka {
     }
 }
 
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-codec-serialization", version.toString())
-
-    pom {
-        name.set("kmp-ble-codec-serialization")
-        description.set("kotlinx-serialization adapters (CBOR) for the kmp-ble-codec layer")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("atruedeveloper")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
-    }
-}

--- a/kmp-ble-codec/build.gradle.kts
+++ b/kmp-ble-codec/build.gradle.kts
@@ -1,12 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -48,33 +44,3 @@ dokka {
     }
 }
 
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-codec", version.toString())
-
-    pom {
-        name.set("kmp-ble-codec")
-        description.set("Format-agnostic codec layer for kmp-ble typed serialization")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("atruedeveloper")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
-    }
-}

--- a/kmp-ble-dfu/build.gradle.kts
+++ b/kmp-ble-dfu/build.gradle.kts
@@ -1,12 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -55,33 +51,3 @@ dokka {
     }
 }
 
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-dfu", version.toString())
-
-    pom {
-        name.set("kmp-ble-dfu")
-        description.set("DFU/OTA firmware update support for kmp-ble - Nordic DFU, L2CAP OTA, observable progress, resume")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("atruedeveloper")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
-    }
-}

--- a/kmp-ble-mesh/build.gradle.kts
+++ b/kmp-ble-mesh/build.gradle.kts
@@ -1,12 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -58,33 +54,3 @@ dokka {
     }
 }
 
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-mesh", version.toString())
-
-    pom {
-        name.set("kmp-ble-mesh")
-        description.set("BLE Mesh networking support for kmp-ble - provisioning, proxy, models")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("gary-quinn")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
-    }
-}

--- a/kmp-ble-profiles/build.gradle.kts
+++ b/kmp-ble-profiles/build.gradle.kts
@@ -1,12 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
 }
-
-group = "com.atruedev"
-version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
 
 kotlin {
     explicitApi()
@@ -47,33 +43,3 @@ dokka {
     }
 }
 
-mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
-    coordinates("com.atruedev", "kmp-ble-profiles", version.toString())
-
-    pom {
-        name.set("kmp-ble-profiles")
-        description.set("Type-safe BLE GATT profile parsing for kmp-ble")
-        url.set("https://github.com/gary-quinn/kmp-ble")
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0")
-            }
-        }
-        developers {
-            developer {
-                id.set("gary-quinn")
-                name.set("Gary Quinn")
-                email.set("gary@atruedev.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/gary-quinn/kmp-ble")
-            connection.set("scm:git:git://github.com/gary-quinn/kmp-ble.git")
-            developerConnection.set("scm:git:ssh://github.com/gary-quinn/kmp-ble.git")
-        }
-    }
-}

--- a/llms.txt
+++ b/llms.txt
@@ -17,17 +17,16 @@ kotlin {
         commonMain.dependencies {
             // Core - scan, connect, GATT client/server, advertise, L2CAP
             implementation("com.atruedev:kmp-ble:0.11.2")
-
-            // Optional modules
-            implementation("com.atruedev:kmp-ble-profiles:0.11.2")  // type-safe GATT profiles
-            implementation("com.atruedev:kmp-ble-dfu:0.11.2")       // Nordic DFU firmware updates
-            implementation("com.atruedev:kmp-ble-codec:0.11.2")     // typed read/write codec
-            implementation("com.atruedev:kmp-ble-codec-serialization:0.11.2")  // CBOR via kotlinx-serialization
-            implementation("com.atruedev:kmp-ble-quirks:0.11.2")    // OEM device workarounds
         }
     }
 }
 ```
+
+From 0.12.0 onward only `kmp-ble` is published to Maven Central.
+`kmp-ble-quirks` is pulled in transitively on Android. The satellite modules
+(`kmp-ble-profiles`, `kmp-ble-dfu`, `kmp-ble-codec`, and
+`kmp-ble-codec-serialization`) were last published at 0.11.2 and are no
+longer published as separate artifacts.
 
 Android initialization:
 


### PR DESCRIPTION
## Problem

Maven Central publishing limits exceeded:
- File Count: 5,640 / 1,000 (564%)
- Release Size: 339 MB / 80 MB (424%)

Root cause: 8 KMP modules each publishing 5-6 targets (jvm, android, iosArm64, iosSimulatorArm64, iosX64) with main, sources, javadoc JARs, POMs, module files, and signatures per target.

## Fix

Stop publishing 6 submodules independently. Publish only:
- **root** \`kmp-ble\` — the main artifact consumers depend on
- **\`kmp-ble-quirks\`** — runtime dependency of root (\`runtimeOnly\`)

Submodules (codec, dfu, profiles, benchmark, codec-serialization, mesh) are removed from Maven Central publication. Their source remains in the monorepo and can be consumed via \`project()\` dependencies.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Modules published | 8 | 2 |
| Files per release | ~700-800 | ~100-120 |
| Release count per version | 8 | 2 |

Brings all Sonatype limits under compliance without breaking consumer builds.