### PR TITLE
fix(deps): bump netty 4.1.135 -> 4.1.136 to close 10 Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
     configurations.all {
         resolutionStrategy.eachDependency {
             when (requested.group) {
-                "io.netty" -> useVersion("4.1.135.Final")
+                "io.netty" -> useVersion("4.1.136.Final")
                 "ch.qos.logback" -> useVersion("1.5.35")
                 "com.fasterxml.jackson.core" -> useVersion("2.18.9")
                 "org.bouncycastle" -> useVersion("1.84")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ androidMinSdk = "33"
 androidCompileSdk = "37"
 androidTargetSdk = "36"
 # Minimum safe versions for transitive dependencies (see build.gradle.kts resolutionStrategy)
-netty = "4.1.135.Final"
+netty = "4.1.136.Final"
 logback = "1.5.35"
 jackson = "2.18.9"
 jdom2 = "2.0.6.1"


### PR DESCRIPTION
## Summary

Bumps \`io.netty\` from \`4.1.135.Final\` to \`4.1.136.Final\` in both the version catalog and the buildscript resolutionStrategy.

Closes all 10 open Dependabot alerts:

| Severity | Advisory |
|----------|----------|
| high | HTTP/2 decompression ByteBuf reference leak (OOM DoS) |
| high | Bzip2Decoder infinite loop (event-loop hang) |
| high | SpdyHttpDecoder ByteBuf leak on RST_STREAM |
| high | SPDY zlib header expansion after maxHeaderSize truncation |
| high | SPDY SETTINGS frame unbounded settings map |
| medium | CRLF injection via multipart filename |
| medium | HTTP/2 host header deduplication bypass |
| medium | HttpContentEncoder unbounded queue growth (DoS) |
| medium | WebSockets V07/V08 handshake validation |
| medium | CORS short-circuit bypass |

## Files changed

- \`gradle/libs.versions.toml\` — \`netty = "4.1.136.Final"\`
- \`build.gradle.kts\` — buildscript resolutionStrategy (duplicated for buildscript classpath)