### PR TITLE
feat(api): promote stable APIs out of ExperimentalBleApi

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.android.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.connection
 
-
 /**
  * Android no-op. Android handles BLE background via foreground services,
  * not Core Bluetooth state restoration.

--- a/src/androidMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.android.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.android.kt
@@ -1,12 +1,10 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
 
 /**
  * Android no-op. Android handles BLE background via foreground services,
  * not Core Bluetooth state restoration.
  */
-@ExperimentalBleApi
 public actual fun enableStateRestoration(config: StateRestorationConfig) {
     // No-op on Android
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidBondManager.kt
@@ -8,7 +8,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
@@ -65,7 +64,6 @@ internal class AndroidBondManager(
         }
     }
 
-    @ExperimentalBleApi
     internal fun removeBond(): BondRemovalResult =
         try {
             val method = device.javaClass.getMethod("removeBond")

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -184,7 +184,6 @@ public class AndroidPeripheral internal constructor(
         PeripheralRegistry.remove(identifier)
     }
 
-    @ExperimentalBleApi
     override fun removeBond(): BondRemovalResult {
         checkNotClosed()
         return bondManager.removeBond()
@@ -236,7 +235,6 @@ public class AndroidPeripheral internal constructor(
 
     override suspend fun requestMtu(mtu: Int): Int = requestMtuGatt(mtu)
 
-    @ExperimentalBleApi
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean =
         requestConnectionPriorityGatt(priority)
 
@@ -245,16 +243,13 @@ public class AndroidPeripheral internal constructor(
         params: ConnectionParameters,
     ): ConnectionParameterUpdateResult? = requestConnectionParameterUpdateGatt(params)
 
-    @ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = setPreferredPhyGatt(tx, rx)
 
-    @ExperimentalBleApi
     override suspend fun readPhy(): PhyResult? = readPhyGatt()
 
-    @ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = _phyUpdate
 
     @ExperimentalBleApi

--- a/src/commonMain/kotlin/com/atruedev/kmpble/bonding/PairingHandler.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/bonding/PairingHandler.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.bonding
 
-import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.Identifier
 
 /**
@@ -35,7 +34,6 @@ import com.atruedev.kmpble.Identifier
  * }
  * ```
  */
-@ExperimentalBleApi
 public fun interface PairingHandler {
     public suspend fun onPairingEvent(event: PairingEvent): PairingResponse
 }
@@ -43,7 +41,6 @@ public fun interface PairingHandler {
 /**
  * Pairing event requiring user interaction or acknowledgment.
  */
-@ExperimentalBleApi
 public sealed interface PairingEvent {
     public val deviceIdentifier: Identifier
 
@@ -93,7 +90,6 @@ public sealed interface PairingEvent {
 /**
  * Response to a [PairingEvent].
  */
-@ExperimentalBleApi
 public sealed interface PairingResponse {
     /** Confirm or reject pairing (for [PairingEvent.NumericComparison], [PairingEvent.JustWorksConfirmation]). */
     public data class Confirm(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/ConnectionOptions.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.bonding.PairingHandler
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -58,7 +57,6 @@ public data class ConnectionOptions(
      * On iOS, the system dialog is always shown. The handler receives
      * events for observability but cannot suppress the dialog.
      */
-    @property:ExperimentalBleApi
     val pairingHandler: PairingHandler? = null,
     /**
      * Retry policy for GATT operations (read, write, MTU) that fail

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.kt
@@ -1,7 +1,5 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
-
 /**
  * Enable iOS Core Bluetooth state restoration.
  *
@@ -14,5 +12,4 @@ import com.atruedev.kmpble.ExperimentalBleApi
  *
  * @param config Configuration specifying the restoration identifier.
  */
-@ExperimentalBleApi
 public expect fun enableStateRestoration(config: StateRestorationConfig)

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/StateRestorationConfig.kt
@@ -1,7 +1,5 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
-
 /**
  * Configuration for iOS Core Bluetooth state restoration.
  *
@@ -24,7 +22,6 @@ import com.atruedev.kmpble.ExperimentalBleApi
  * )
  * ```
  */
-@ExperimentalBleApi
 public data class StateRestorationConfig(
     /**
      * Unique string that iOS uses to identify this app's CBCentralManager for restoration.

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -69,7 +69,6 @@ public interface Peripheral : AutoCloseable {
      */
     public val encryptionLevel: StateFlow<EncryptionLevel>
 
-    @ExperimentalBleApi
     public fun removeBond(): BondRemovalResult
 
     // --- Discovery ---
@@ -213,7 +212,6 @@ public interface Peripheral : AutoCloseable {
      * @return `true` if the request was dispatched; `false` if unsupported
      *   or the GATT layer is not ready.
      */
-    @ExperimentalBleApi
     public suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean
 
     /**
@@ -247,7 +245,6 @@ public interface Peripheral : AutoCloseable {
      *
      * @return [PhyResult] with negotiated TX/RX PHYs, or `null` if unsupported.
      */
-    @ExperimentalBleApi
     public suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
@@ -261,7 +258,6 @@ public interface Peripheral : AutoCloseable {
      *
      * @return [PhyResult] with current TX/RX PHYs, or `null` if unsupported.
      */
-    @ExperimentalBleApi
     public suspend fun readPhy(): PhyResult?
 
     /**
@@ -269,7 +265,6 @@ public interface Peripheral : AutoCloseable {
      * controller negotiates a new PHY (triggered by [setPreferredPhy] or
      * autonomously). Only emits while connected. iOS never emits.
      */
-    @ExperimentalBleApi
     public val phyUpdate: Flow<PhyUpdate>
 
     /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -131,7 +131,6 @@ public class FakePeripheral internal constructor(
         context.processEvent(ConnectionEvent.ConnectionLost(OperationFailed("disconnect")))
     }
 
-    @com.atruedev.kmpble.ExperimentalBleApi
     override fun removeBond(): com.atruedev.kmpble.bonding.BondRemovalResult =
         com.atruedev.kmpble.bonding.BondRemovalResult
             .NotSupported("FakePeripheral")
@@ -212,7 +211,6 @@ public class FakePeripheral internal constructor(
 
     override suspend fun requestMtu(mtu: Int): Int = gattResponder.requestMtu(mtu)
 
-    @com.atruedev.kmpble.ExperimentalBleApi
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean =
         gattResponder.requestConnectionPriority(priority)
 
@@ -227,16 +225,13 @@ public class FakePeripheral internal constructor(
         parameters: ConnectionSubratingParameters,
     ): ConnectionSubratingResult = gattResponder.requestConnectionSubrating(parameters)
 
-    @com.atruedev.kmpble.ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = gattResponder.setPreferredPhy(tx, rx)
 
-    @com.atruedev.kmpble.ExperimentalBleApi
     override suspend fun readPhy(): PhyResult? = gattResponder.readPhy()
 
-    @com.atruedev.kmpble.ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = gattResponder.phyUpdate
     override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = gattResponder.dataLengthParameters
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.ios.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.ios.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.internal.CentralManagerProvider
 import com.atruedev.kmpble.internal.StateRestorationHandler
 
@@ -22,7 +21,6 @@ import com.atruedev.kmpble.internal.StateRestorationHandler
  *
  * @throws IllegalStateException if CBCentralManager has already been initialized
  */
-@ExperimentalBleApi
 public actual fun enableStateRestoration(config: StateRestorationConfig) {
     require(config.identifier.isNotBlank()) {
         "State restoration identifier must not be blank"

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosBondManager.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosBondManager.kt
@@ -1,6 +1,5 @@
 package com.atruedev.kmpble.peripheral
 
-import com.atruedev.kmpble.ExperimentalBleApi
 import com.atruedev.kmpble.bonding.BondRemovalResult
 import com.atruedev.kmpble.bonding.BondState
 import com.atruedev.kmpble.peripheral.internal.PeripheralContext
@@ -53,7 +52,6 @@ internal class IosBondManager(
      * iOS does not support programmatic bond removal. Users must remove
      * bonds from Settings > Bluetooth.
      */
-    @ExperimentalBleApi
     internal fun removeBond(): BondRemovalResult =
         BondRemovalResult.NotSupported(
             "iOS does not support programmatic bond removal. Remove from Settings > Bluetooth.",

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -163,7 +163,6 @@ public class IosPeripheral(
 
     override suspend fun disconnect(): Unit = disconnectInternal()
 
-    @ExperimentalBleApi
     override fun removeBond(): BondRemovalResult = bondManager.removeBond()
 
     override fun close(): Unit = closeInternal()
@@ -224,7 +223,6 @@ public class IosPeripheral(
 
     override suspend fun requestMtu(mtu: Int): Int = requestMtuGatt(mtu)
 
-    @ExperimentalBleApi
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean =
         requestConnectionPriorityExt(priority)
 
@@ -233,16 +231,13 @@ public class IosPeripheral(
         params: ConnectionParameters,
     ): ConnectionParameterUpdateResult? = requestConnectionParameterUpdateExt(params)
 
-    @ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = setPreferredPhyExt(tx, rx)
 
-    @ExperimentalBleApi
     override suspend fun readPhy(): PhyResult? = readPhyExt()
 
-    @ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = emptyFlow()
 
     @ExperimentalBleApi

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.jvm.kt
@@ -1,4 +1,3 @@
 package com.atruedev.kmpble.connection
 
-
 public actual fun enableStateRestoration(config: StateRestorationConfig) {}

--- a/src/jvmMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.jvm.kt
+++ b/src/jvmMain/kotlin/com/atruedev/kmpble/connection/StateRestorationApi.jvm.kt
@@ -1,6 +1,4 @@
 package com.atruedev.kmpble.connection
 
-import com.atruedev.kmpble.ExperimentalBleApi
 
-@ExperimentalBleApi
 public actual fun enableStateRestoration(config: StateRestorationConfig) {}

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -58,7 +58,6 @@ internal class StubPeripheral(
 
     override fun close() {}
 
-    @ExperimentalBleApi
     override fun removeBond(): BondRemovalResult = unsupported()
 
     override suspend fun refreshServices(): List<DiscoveredService> = unsupported()
@@ -103,7 +102,6 @@ internal class StubPeripheral(
 
     override suspend fun requestMtu(mtu: Int): Int = unsupported()
 
-    @ExperimentalBleApi
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean = unsupported()
 
     @ExperimentalBleApi
@@ -116,19 +114,16 @@ internal class StubPeripheral(
         parameters: ConnectionSubratingParameters,
     ): ConnectionSubratingResult = unsupported()
 
-    @ExperimentalBleApi
     override suspend fun setPreferredPhy(
         tx: Phy,
         rx: Phy,
     ): PhyResult? = unsupported()
 
-    @ExperimentalBleApi
     override suspend fun readPhy(): PhyResult? = unsupported()
 
     // A val initializer runs unconditionally at construction, unlike the unsupported()
     // functions above it - unsupported() here would make StubPeripheral() itself always
     // throw, defeating every test that merely constructs one.
-    @ExperimentalBleApi
     override val phyUpdate: Flow<PhyUpdate> = emptyFlow()
     override val dataLengthParameters: StateFlow<DataLengthParameters?> = MutableStateFlow(null)
 


### PR DESCRIPTION
## Summary

Promotes 9 APIs to stable ahead of the 1.0 release. Consumers no longer need @OptIn(ExperimentalBleApi::class) for core BLE workflows.

## Promoted to stable

| API | Area |
|-----|------|
| PairingHandler, PairingEvent, PairingResponse | bonding |
| ConnectionOptions.pairingHandler | connection |
| Peripheral.removeBond() | peripheral |
| Peripheral.requestConnectionPriority() | peripheral |
| Peripheral.setPreferredPhy() / readPhy() / phyUpdate | peripheral (BLE 5.0 PHY) |
| enableStateRestoration() + StateRestorationConfig | iOS |

## Still experimental (documented)

These stay behind @ExperimentalBleApi because they target niche hardware or newer platform APIs:

- requestConnectionParameterUpdate, requestConnectionSubrating (BT 5.3)
- receivePastSync (PAST, BLE 5.1)
- requestDirectionFinding (AoA/AoD, hardware-dependent)

## Files changed

14 files - common API, Android/iOS/JVM implementations, FakePeripheral, StubPeripheral. Unused ExperimentalBleApi imports removed.

## Verification

- ./gradlew :compileCommonMainKotlinMetadata passes
- Full platform builds verified by CI