### PR TITLE
docs(mesh): mark kmp-ble-mesh experimental, document broken P-256 ECDH

### DIFF
--- a/kmp-ble-mesh/MODULE.md
+++ b/kmp-ble-mesh/MODULE.md
@@ -1,5 +1,22 @@
 # Module kmp-ble-mesh
 
+> **STATUS: EXPERIMENTAL -- NOT PART OF THE 1.0 SCOPE**
+>
+> This module is a work-in-progress research prototype. It is **not** published
+> to Maven Central and **not** covered by the kmp-ble 1.0 API stability
+> commitment.
+>
+> **Known critical issue:** the pure-Kotlin P-256 ECDH implementation
+> (`P256Ecdh.kt`) has unverified field arithmetic and does not satisfy ECDH
+> commutativity (`sharedSecret(d1, Q2) != sharedSecret(d2, Q1)`). The failure
+> is documented in `P256EcdhTest` but not yet fixed. Any mesh security that
+> relies on this implementation must be treated as broken until it is
+> rewritten and verified against NIST P-256 test vectors.
+>
+> Do not use this module in production. Consider B/C migration (platform
+> crypto via expect/actual, or a vetted library) before relying on mesh
+> security.
+
 Kotlin Multiplatform BLE Mesh library providing a coroutine-based API for Bluetooth Mesh networking across Android, iOS, and JVM.
 
 ## Core capabilities
@@ -14,11 +31,13 @@ Kotlin Multiplatform BLE Mesh library providing a coroutine-based API for Blueto
 
 ## Getting started
 
-Add the dependency to your KMP module:
+> `kmp-ble-mesh` is **not published** to Maven Central (see status note above).
+> It can only be consumed as a `project(":kmp-ble-mesh")` source dependency
+> within this repository. Published consumers should wait for a future
+> release that addresses the crypto issue.
 
 ```kotlin
 commonMain.dependencies {
-    implementation("com.atruedev:kmp-ble:<version>")
-    implementation("com.atruedev:kmp-ble-mesh:<version>")
+    implementation(project(":kmp-ble-mesh"))
 }
 ```

--- a/kmp-ble-mesh/src/commonTest/kotlin/com/atruedev/kmpble/mesh/crypto/P256EcdhTest.kt
+++ b/kmp-ble-mesh/src/commonTest/kotlin/com/atruedev/kmpble/mesh/crypto/P256EcdhTest.kt
@@ -47,7 +47,7 @@ class P256EcdhTest {
      * See kmp-ble-mesh/MODULE.md for the module-level experimental status.
      */
     @Test
-    @kotlin.test.Ignore("ECDH commutativity broken -- see KDoc; P-256 rewrite required")
+    @kotlin.test.Ignore
     fun sharedSecretIsDeterministic() {
         val kp1 = P256Ecdh.generateKeyPair()
         val kp2 = P256Ecdh.generateKeyPair()
@@ -104,7 +104,7 @@ class P256EcdhTest {
     // Superseded by sharedSecretIsDeterministic (marked @Ignored with root-cause
     // analysis in its KDoc). Remove this placeholder once the P-256 rewrite lands.
     @Test
-    @kotlin.test.Ignore("Superseded by sharedSecretIsDeterministic")
+    @kotlin.test.Ignore
     fun sharedSecretCommutativeSmallLoop() {
         // Intentionally empty -- documented in sharedSecretIsDeterministic KDoc.
     }

--- a/kmp-ble-mesh/src/commonTest/kotlin/com/atruedev/kmpble/mesh/crypto/P256EcdhTest.kt
+++ b/kmp-ble-mesh/src/commonTest/kotlin/com/atruedev/kmpble/mesh/crypto/P256EcdhTest.kt
@@ -24,11 +24,30 @@ class P256EcdhTest {
         assertFalse(keyPair.publicKey.all { it == 0.toByte() }, "Public key must not be zero")
     }
 
-    // FIXME(phase2): ECDH commutativity (d1*Q2 == d2*Q1) fails due to a
-    // subtle arithmetic bug in field reduction or point operations. The
-    // implementation is functional for same-inputs-same-output but needs
-    // systematic debugging against NIST P-256 test vectors.
+    /**
+     * KNOWN ISSUE -- DO NOT USE THIS IMPLEMENTATION FOR SECURITY.
+     *
+     * ECDH commutativity (`sharedSecret(d1, Q2) == sharedSecret(d2, Q1)`) is
+     * broken. Root cause analysis (2026-08):
+     *
+     * 1. `barrettReduce()` in P256Ecdh.kt has incorrect borrow detection --
+     *    the subtraction `x - q*p` is computed twice with conflicting borrow
+     *    logic, and only the low 256 bits are kept. Field arithmetic is not
+     *    correct, so every multiply/point operation can produce wrong values.
+     * 2. `scalarMult()` iterates words MSB-first but bits within each word
+     *    LSB-first, scrambling the scalar. Double-and-add must run MSB -> LSB
+     *    across the full 256 bits.
+     *
+     * The implementation is deterministic (same input -> same output) and
+     * passes self-consistency tests, which is why the other tests pass while
+     * commutativity fails. It has NOT been verified against NIST P-256
+     * test vectors. This test is disabled via @Ignored to keep CI green;
+     * re-enable it after the arithmetic is rewritten and verified.
+     *
+     * See kmp-ble-mesh/MODULE.md for the module-level experimental status.
+     */
     @Test
+    @kotlin.test.Ignore("ECDH commutativity broken -- see KDoc; P-256 rewrite required")
     fun sharedSecretIsDeterministic() {
         val kp1 = P256Ecdh.generateKeyPair()
         val kp2 = P256Ecdh.generateKeyPair()
@@ -36,8 +55,7 @@ class P256EcdhTest {
         val secret2 = P256Ecdh.sharedSecret(kp2.privateKey, kp1.publicKey)
         assertEquals(32, secret1.size)
         assertEquals(32, secret2.size)
-        // FIXME: commutativity is not yet working
-        // assertTrue(secret1.contentEquals(secret2), "ECDH shared secrets must match")
+        assertTrue(secret1.contentEquals(secret2), "ECDH shared secrets must match")
     }
 
     @Test
@@ -83,10 +101,12 @@ class P256EcdhTest {
             "Same private key should produce same shared secret")
     }
 
-    // FIXME(phase2): commutativity not yet working, see sharedSecretIsDeterministic
-    // @Test
+    // Superseded by sharedSecretIsDeterministic (marked @Ignored with root-cause
+    // analysis in its KDoc). Remove this placeholder once the P-256 rewrite lands.
+    @Test
+    @kotlin.test.Ignore("Superseded by sharedSecretIsDeterministic")
     fun sharedSecretCommutativeSmallLoop() {
-        // Skipped - see sharedSecretIsDeterministic FIXME
+        // Intentionally empty -- documented in sharedSecretIsDeterministic KDoc.
     }
 
     @Test


### PR DESCRIPTION
## Summary

Marks kmp-ble-mesh as EXPERIMENTAL and excluded from the 1.0 scope, and documents the known-broken P-256 ECDH implementation so the bug is explicit instead of silent.

## Background

The pure-Kotlin P-256 ECDH in `P256Ecdh.kt` does not satisfy ECDH commutativity (`sharedSecret(d1, Q2) != sharedSecret(d2, Q1)`). Root cause identified:

1. `barrettReduce()`: incorrect borrow detection -- subtraction `x - q*p` computed twice with conflicting borrow logic, only low 256 bits kept
2. `scalarMult()`: iterates words MSB-first but bits within each word LSB-first, scrambling the scalar

The module was already excluded from Maven Central publishing (PR #608), so no published consumers are affected.

## Changes

- `kmp-ble-mesh/MODULE.md`: EXPERIMENTAL status banner with crypto caveat + getting-started updated to `project()` source dependency only
- `P256EcdhTest.kt`: root-cause analysis in KDoc, commutativity tests marked `@Ignored` with reason (CI stays green, failure is documented not hidden)

## Decision

1.0 ships without mesh. Rewriting P-256 (3-5 days) or migrating to platform crypto (BouncyCastle / CommonCrypto, 1-2 days) tracked as future work.