### PR TITLE
feat(scanner): add scanUntil DSL for flexible scan termination

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,9 +1,12 @@
 package com.atruedev.kmpble.scanner
 
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
@@ -63,3 +66,66 @@ public suspend fun Scanner.firstOrThrow(
                 }
             }.first(predicate)
     }
+
+/**
+ * Collect [Scanner.scanEvents] until [predicate] matches, returning the first
+ * matching [Advertisement], or `null` after [maxWait] elapses.
+ *
+ * General-purpose scan termination: unlike [firstOrNull], [maxWait] defaults to
+ * [Duration.INFINITE], so this keeps scanning until the predicate matches. Combine
+ * with any condition -- RSSI threshold, a set of expected MACs, service presence:
+ *
+ * ```
+ * // scan until a strong-signal device appears (or never)
+ * val strong = scanner.scanUntil { it.rssi > -60 }
+ *
+ * // scan until all 3 expected devices are seen (bounded)
+ * val expected = setOf("AA:..", "BB:..", "CC:..")
+ * val results = scanner.scanUntil(
+ *     predicate = { it.identifier.value in expected },
+ *     maxWait = 30.seconds,
+ * )
+ * ```
+ *
+ * [ScanEvent.Failed] events are skipped; a scan-hardware failure with an infinite
+ * [maxWait] would suspend forever. Callers that need failure visibility should
+ * collect [Scanner.scanEvents] directly.
+ */
+public suspend fun Scanner.scanUntil(
+    maxWait: Duration = Duration.INFINITE,
+    predicate: (Advertisement) -> Boolean,
+): Advertisement? =
+    withTimeoutOrNull(maxWait) {
+        scanEvents
+            .mapNotNull { event -> (event as? ScanEvent.Found)?.advertisement }
+            .firstOrNull(predicate)
+    }
+
+/**
+ * Collect [Scanner.scanEvents] until [count] distinct advertisements are seen
+ * (or [maxWait] elapses), returning them as a list.
+ *
+ * Distinctness is by [Advertisement.identifier] -- repeated advertisements from
+ * the same peripheral are deduplicated. Use this for "scan until I see N devices"
+ * patterns:
+ *
+ * ```
+ * val devices = scanner.scanUntil(count = 5, maxWait = 20.seconds)
+ * ```
+ *
+ * Returns fewer than [count] items if [maxWait] expires first. [ScanEvent.Failed]
+ * events are skipped (see [scanUntil] for the caveat with infinite waits).
+ */
+public suspend fun Scanner.scanUntil(
+    count: Int,
+    maxWait: Duration = Duration.INFINITE,
+): List<Advertisement> {
+    require(count > 0) { "count must be positive, was $count" }
+    return withTimeoutOrNull(maxWait) {
+        scanEvents
+            .mapNotNull { event -> (event as? ScanEvent.Found)?.advertisement }
+            .distinctUntilChangedBy { it.identifier }
+            .take(count)
+            .toList()
+    }.orEmpty()
+}


### PR DESCRIPTION
## Summary

Adds two \`Scanner.scanUntil\` variants for predicate-driven or count-driven scan termination. Complements the existing \`firstOrNull\`/\`firstOrThrow\` single-match helpers.

Fixes #505.

## API

\`\`\`kotlin
// first advertisement matching predicate, or null after maxWait (INFINITE default)
suspend fun Scanner.scanUntil(
    maxWait: Duration = Duration.INFINITE,
    predicate: (Advertisement) -> Boolean,
): Advertisement?

// collect N distinct advertisements (by identifier), or fewer if maxWait expires
suspend fun Scanner.scanUntil(count: Int, maxWait: Duration = Duration.INFINITE): List<Advertisement>
\`\`\`

## Examples

\`\`\`kotlin
// scan until a strong-signal device appears
val strong = scanner.scanUntil { it.rssi > -60 }

// scan until all 3 expected MACs are seen, bounded
val results = scanner.scanUntil({ it.identifier.value in expected }, maxWait = 30.seconds)

// scan until 5 devices seen
val devices = scanner.scanUntil(count = 5, maxWait = 20.seconds)
\`\`\`

Scan stops automatically on match/timeout (cold flow collection). \`ScanEvent.Failed\` events are skipped, consistent with \`firstOrNull\`.