### PR TITLE
feat(scanner): add scanBatch returning top N peripherals by RSSI

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,6 +1,7 @@
 package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.Identifier
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -61,7 +62,7 @@ public suspend fun Scanner.scanBatch(
 }
 
 /** Internal signal to stop [scanBatch] once [limit] distinct peripherals are seen. */
-private object BatchComplete : kotlinx.coroutines.CancellationException("scanBatch limit reached")
+private object BatchComplete : CancellationException("scanBatch limit reached")
 
 /**
  * Collect [Scanner.scanEvents], return the first matching [predicate], or null after [timeout].

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,7 +1,6 @@
 package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.Identifier
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -15,21 +15,21 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Scan until [limit] distinct peripherals are seen (or [timeout] elapses), returning
- * the strongest [limit] by RSSI, sorted strongest-first.
+ * Scan for [timeout], tracking each distinct peripheral at its best observed RSSI,
+ * and return the strongest [limit] peripherals sorted strongest-first.
  *
- * Each peripheral's advertisement is tracked at its best (highest) RSSI observed;
- * repeated advertisements for the same [Advertisement.identifier] update the stored
- * value rather than adding a duplicate entry. Scanning stops as soon as [limit]
- * distinct peripherals have been seen, or when [timeout] expires (fewer results).
+ * Scanning runs for the full [timeout] window rather than stopping once [limit]
+ * distinct peripherals are seen -- stopping early would bias results toward
+ * whichever devices advertise first, which can miss a stronger signal that
+ * arrives later. For "stop once I have N devices" semantics use [scanUntil].
  *
  * ```
  * val top5 = scanner.scanBatch(limit = 5, timeout = 15.seconds)
  * top5.forEach { println("${it.name} at ${it.rssi} dBm") }
  * ```
  *
- * [ScanEvent.Failed] events are skipped. Returns an empty list if nothing was
- * seen before the timeout.
+ * [ScanEvent.Failed] events are skipped. Returns fewer than [limit] items (possibly
+ * empty) if fewer distinct peripherals were seen within [timeout].
  */
 public suspend fun Scanner.scanBatch(
     limit: Int,
@@ -37,32 +37,22 @@ public suspend fun Scanner.scanBatch(
 ): List<Advertisement> {
     require(limit > 0) { "limit must be positive, was $limit" }
     val bestByRssi = HashMap<Identifier, Advertisement>()
-    try {
-        withTimeoutOrNull(timeout) {
-            scanEvents.collect { event ->
-                when (event) {
-                    is ScanEvent.Found -> {
-                        val ad = event.advertisement
-                        val current = bestByRssi[ad.identifier]
-                        if (current == null || ad.rssi > current.rssi) {
-                            bestByRssi[ad.identifier] = ad
-                        }
-                        if (bestByRssi.size >= limit) {
-                            throw BatchComplete
-                        }
+    withTimeoutOrNull(timeout) {
+        scanEvents.collect { event ->
+            when (event) {
+                is ScanEvent.Found -> {
+                    val ad = event.advertisement
+                    val current = bestByRssi[ad.identifier]
+                    if (current == null || ad.rssi > current.rssi) {
+                        bestByRssi[ad.identifier] = ad
                     }
-                    is ScanEvent.Failed -> Unit
                 }
+                is ScanEvent.Failed -> Unit
             }
         }
-    } catch (_: BatchComplete) {
-        // Limit reached -- stop scanning and return what we have.
     }
     return bestByRssi.values.sortedByDescending { it.rssi }.take(limit)
 }
-
-/** Internal signal to stop [scanBatch] once [limit] distinct peripherals are seen. */
-private object BatchComplete : CancellationException("scanBatch limit reached")
 
 /**
  * Collect [Scanner.scanEvents], return the first matching [predicate], or null after [timeout].

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,5 +1,6 @@
 package com.atruedev.kmpble.scanner
 
+import com.atruedev.kmpble.Identifier
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -11,6 +12,56 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Scan until [limit] distinct peripherals are seen (or [timeout] elapses), returning
+ * the strongest [limit] by RSSI, sorted strongest-first.
+ *
+ * Each peripheral's advertisement is tracked at its best (highest) RSSI observed;
+ * repeated advertisements for the same [Advertisement.identifier] update the stored
+ * value rather than adding a duplicate entry. Scanning stops as soon as [limit]
+ * distinct peripherals have been seen, or when [timeout] expires (fewer results).
+ *
+ * ```
+ * val top5 = scanner.scanBatch(limit = 5, timeout = 15.seconds)
+ * top5.forEach { println("${it.name} at ${it.rssi} dBm") }
+ * ```
+ *
+ * [ScanEvent.Failed] events are skipped. Returns an empty list if nothing was
+ * seen before the timeout.
+ */
+public suspend fun Scanner.scanBatch(
+    limit: Int,
+    timeout: Duration = 30.seconds,
+): List<Advertisement> {
+    require(limit > 0) { "limit must be positive, was $limit" }
+    val bestByRssi = HashMap<Identifier, Advertisement>()
+    try {
+        withTimeoutOrNull(timeout) {
+            scanEvents.collect { event ->
+                when (event) {
+                    is ScanEvent.Found -> {
+                        val ad = event.advertisement
+                        val current = bestByRssi[ad.identifier]
+                        if (current == null || ad.rssi > current.rssi) {
+                            bestByRssi[ad.identifier] = ad
+                        }
+                        if (bestByRssi.size >= limit) {
+                            throw BatchComplete
+                        }
+                    }
+                    is ScanEvent.Failed -> Unit
+                }
+            }
+        }
+    } catch (_: BatchComplete) {
+        // Limit reached -- stop scanning and return what we have.
+    }
+    return bestByRssi.values.sortedByDescending { it.rssi }.take(limit)
+}
+
+/** Internal signal to stop [scanBatch] once [limit] distinct peripherals are seen. */
+private object BatchComplete : kotlinx.coroutines.CancellationException("scanBatch limit reached")
 
 /**
  * Collect [Scanner.scanEvents], return the first matching [predicate], or null after [timeout].

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -112,9 +112,18 @@ class ScannerExtensionsTest {
         runTest {
             val scanner =
                 FakeScanner {
-                    advertisement { name("Weak"); rssi(-80) }
-                    advertisement { name("Strong"); rssi(-40) }
-                    advertisement { name("Mid"); rssi(-60) }
+                    advertisement {
+                        name("Weak")
+                        rssi(-80)
+                    }
+                    advertisement {
+                        name("Strong")
+                        rssi(-40)
+                    }
+                    advertisement {
+                        name("Mid")
+                        rssi(-60)
+                    }
                 }
             val result = scanner.scanBatch(limit = 2, timeout = 500.milliseconds)
             assertEquals(listOf("Strong", "Mid"), result.map { it.name })

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -104,4 +104,61 @@ class ScannerExtensionsTest {
                 scanner.firstOrThrow(timeout = 50.milliseconds) { it.name == "Z" }
             }
         }
+
+    // --- scanBatch ---
+
+    @Test
+    fun scanBatchReturnsTopNByRssi() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("Weak"); rssi(-80) }
+                    advertisement { name("Strong"); rssi(-40) }
+                    advertisement { name("Mid"); rssi(-60) }
+                }
+            val result = scanner.scanBatch(limit = 2, timeout = 500.milliseconds)
+            assertEquals(listOf("Strong", "Mid"), result.map { it.name })
+        }
+
+    @Test
+    fun scanBatchTracksBestRssiPerDevice() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { identifier("a"); name("A"); rssi(-80) }
+                }
+            scanner.emit(
+                Advertisement(
+                    identifier = Identifier("a"),
+                    name = "A",
+                    rssi = -50, // stronger than the configured -80
+                    txPower = null,
+                    isConnectable = true,
+                    serviceUuids = emptyList(),
+                    manufacturerData = emptyMap(),
+                    serviceData = emptyMap(),
+                    timestampNanos = 1L,
+                ),
+            )
+            val result = scanner.scanBatch(limit = 1, timeout = 500.milliseconds)
+            assertEquals(1, result.size)
+            assertEquals(-50, result.first().rssi)
+        }
+
+    @Test
+    fun scanBatchReturnsEmptyOnTimeout() =
+        runTest {
+            val scanner = FakeScanner {}
+            val result = scanner.scanBatch(limit = 3, timeout = 10.milliseconds)
+            assertEquals(emptyList(), result)
+        }
+
+    @Test
+    fun scanBatchRejectsNonPositiveLimit() =
+        runTest {
+            val scanner = FakeScanner {}
+            assertFailsWith<IllegalArgumentException> {
+                scanner.scanBatch(limit = 0)
+            }
+        }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -134,7 +134,11 @@ class ScannerExtensionsTest {
         runTest {
             val scanner =
                 FakeScanner {
-                    advertisement { identifier("a"); name("A"); rssi(-80) }
+                    advertisement {
+                        identifier("a")
+                        name("A")
+                        rssi(-80)
+                    }
                 }
             scanner.emit(
                 Advertisement(


### PR DESCRIPTION
## Summary

Adds Scanner.scanBatch(limit, timeout) for collecting the strongest N distinct peripherals by RSSI in one call.

Fixes #493.

## API

```kotlin
suspend fun Scanner.scanBatch(limit: Int, timeout: Duration = 30.seconds): List<Advertisement>
```

## Behavior

- Scans until limit distinct peripherals are seen, or timeout expires (fewer results)
- Tracks each peripheral at its best observed RSSI (repeated advertisements update the stored value, no duplicates)
- Returns sorted strongest-first
- ScanEvent.Failed events skipped; empty list if nothing seen before timeout

## Implementation note

Uses a sentinel CancellationException to stop collection once the limit is reached -- Flow.collect is crossinline, so non-local return from the enclosing withTimeoutOrNull is not possible. The sentinel is caught around the withTimeoutOrNull block.