### PR TITLE
feat(scanner): add scanAndConnect convenience combining scan and connect

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanAndConnect.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScanAndConnect.kt
@@ -1,0 +1,66 @@
+package com.atruedev.kmpble.scanner
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.connectAndDiscover
+import com.atruedev.kmpble.peripheral.toPeripheral
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Scan for the first [Advertisement] matching [predicate], connect to it, and
+ * return the connected [Peripheral] with services discovered.
+ *
+ * Combines the common "scan -> match -> connect -> discover" workflow into a
+ * single call, reusing [com.atruedev.kmpble.peripheral.connectAndDiscover]
+ * internally. The scanner is cold: scanning starts on collect, stops on match.
+ *
+ * ```
+ * val peripheral = scanner.scanAndConnect { it.name == "HeartSensor" }
+ * try {
+ *     val hr = peripheral.findCharacteristic(uuidFrom("180D"), uuidFrom("2A37"))
+ *     peripheral.read(hr!!)
+ * } finally {
+ *     peripheral.close()
+ * }
+ * ```
+ *
+ * @param scanTimeout How long to scan for a matching device before giving up.
+ * @param predicate Match rule applied to each scan result.
+ * @param connectOptions Options passed to [com.atruedev.kmpble.peripheral.connectAndDiscover].
+ * @return A connected [Peripheral] with services discovered. The caller owns the
+ *   returned peripheral and MUST call [Peripheral.close] when done.
+ * @throws [ScanTimeoutException] if no device matches within [scanTimeout].
+ * @throws com.atruedev.kmpble.error.BleException if connect or discovery fails.
+ */
+public suspend fun Scanner.scanAndConnect(
+    scanTimeout: Duration = 30.seconds,
+    connectOptions: ConnectionOptions = ConnectionOptions(),
+    predicate: (Advertisement) -> Boolean = { true },
+): Peripheral {
+    val advertisement =
+        withTimeoutOrNull(scanTimeout) {
+            scanEvents
+                .mapNotNull { event -> (event as? ScanEvent.Found)?.advertisement }
+                .firstOrNull(predicate)
+        } ?: throw ScanTimeoutException(scanTimeout)
+    val peripheral = advertisement.toPeripheral()
+    try {
+        peripheral.connectAndDiscover(connectOptions)
+    } catch (e: Exception) {
+        peripheral.close()
+        throw e
+    }
+    return peripheral
+}
+
+/**
+ * Thrown when [Scanner.scanAndConnect] finds no matching peripheral within
+ * the configured [scanTimeout].
+ */
+public class ScanTimeoutException(
+    public val scanTimeout: Duration,
+) : IllegalStateException("No matching peripheral found within $scanTimeout")

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScanAndConnectTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScanAndConnectTest.kt
@@ -1,0 +1,39 @@
+package com.atruedev.kmpble.scanner
+
+import com.atruedev.kmpble.testing.FakeScanner
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+
+class ScanAndConnectTest {
+    @Test
+    fun throwsScanTimeoutExceptionWhenNoMatch() =
+        runTest {
+            val scanner = FakeScanner {}
+            val ex =
+                assertFailsWith<ScanTimeoutException> {
+                    scanner.scanAndConnect(
+                        scanTimeout = 10.milliseconds,
+                        predicate = { true },
+                    )
+                }
+            assertEquals(10.milliseconds, ex.scanTimeout)
+        }
+
+    @Test
+    fun throwsScanTimeoutExceptionWhenPredicateNeverMatches() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                }
+            assertFailsWith<ScanTimeoutException> {
+                scanner.scanAndConnect(
+                    scanTimeout = 50.milliseconds,
+                    predicate = { it.name == "Z" },
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Summary

Adds Scanner.scanAndConnect(...) -- the one-shot scan -> match -> connect -> discover workflow, reducing the most common BLE pattern from ~8 lines to 1.

Fixes #443.

## API

```kotlin
suspend fun Scanner.scanAndConnect(
    scanTimeout: Duration = 30.seconds,
    connectOptions: ConnectionOptions = ConnectionOptions(),
    predicate: (Advertisement) -> Boolean = { true },
): Peripheral
```

## Behavior

- Scans for first advertisement matching predicate (cold flow, auto-stop on match)
- Connects + discovers services via existing connectAndDiscover
- Returns connected Peripheral -- caller owns it and MUST close()
- Throws ScanTimeoutException (carries the scanTimeout) if no match within timeout
- On connect/discovery failure, peripheral is closed before rethrowing

## Tests

ScanAndConnectTest covers the timeout paths (no match / predicate never matches) in commonTest. The happy path requires platform toPeripheral() actuals and is exercised by the platform CI suites.