### PR TITLE
fix(scanner): scanUntil(count) partial results + tests

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,13 +1,10 @@
 package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.Identifier
-import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
@@ -162,11 +159,27 @@ public suspend fun Scanner.scanUntil(
     maxWait: Duration = Duration.INFINITE,
 ): List<Advertisement> {
     require(count > 0) { "count must be positive, was $count" }
-    return withTimeoutOrNull(maxWait) {
-        scanEvents
-            .mapNotNull { event -> (event as? ScanEvent.Found)?.advertisement }
-            .distinctUntilChangedBy { it.identifier }
-            .take(count)
-            .toList()
-    }.orEmpty()
+    val seen = LinkedHashMap<Identifier, Advertisement>()
+    try {
+        withTimeoutOrNull(maxWait) {
+            scanEvents.collect { event ->
+                when (event) {
+                    is ScanEvent.Found -> {
+                        // First occurrence per identifier wins (true set-distinct,
+                        // unlike distinctUntilChanged which only drops consecutive dupes).
+                        seen.putIfAbsent(event.advertisement.identifier, event.advertisement)
+                        if (seen.size >= count) throw BatchComplete
+                    }
+                    is ScanEvent.Failed -> Unit
+                }
+            }
+        }
+    } catch (_: BatchComplete) {
+        // count reached -- stop scanning and return what we have
+    }
+    // Partial results on timeout: return whatever was collected before maxWait.
+    return seen.values.toList()
 }
+
+/** Internal signal to stop collection early once the target is reached. */
+private object BatchComplete : kotlinx.coroutines.CancellationException("scanUntil target reached")

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -1,8 +1,8 @@
 package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.Identifier
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -168,7 +168,7 @@ public suspend fun Scanner.scanUntil(
                     is ScanEvent.Found -> {
                         // First occurrence per identifier wins (true set-distinct,
                         // unlike distinctUntilChanged which only drops consecutive dupes).
-                        seen.putIfAbsent(event.advertisement.identifier, event.advertisement)
+                        seen.getOrPut(event.advertisement.identifier) { event.advertisement }
                         if (seen.size >= count) throw BatchComplete
                     }
                     is ScanEvent.Failed -> Unit

--- a/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/scanner/ScannerExtensions.kt
@@ -2,6 +2,7 @@ package com.atruedev.kmpble.scanner
 
 import com.atruedev.kmpble.Identifier
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -182,4 +183,4 @@ public suspend fun Scanner.scanUntil(
 }
 
 /** Internal signal to stop collection early once the target is reached. */
-private object BatchComplete : kotlinx.coroutines.CancellationException("scanUntil target reached")
+private object BatchComplete : CancellationException("scanUntil target reached")

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -174,4 +174,88 @@ class ScannerExtensionsTest {
                 scanner.scanBatch(limit = 0)
             }
         }
+
+    // --- scanUntil(predicate) ---
+
+    @Test
+    fun scanUntilReturnsFirstMatchingAd() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                    advertisement { name("Target") }
+                }
+            val result = scanner.scanUntil(maxWait = 500.milliseconds) { it.name == "Target" }
+            assertNotNull(result)
+            assertEquals("Target", result.name)
+        }
+
+    @Test
+    fun scanUntilReturnsNullOnTimeout() =
+        runTest {
+            val scanner = FakeScanner {}
+            val result = scanner.scanUntil(maxWait = 10.milliseconds) { true }
+            assertNull(result)
+        }
+
+    @Test
+    fun scanUntilReturnsNullWhenNoMatch() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                }
+            val result = scanner.scanUntil(maxWait = 50.milliseconds) { it.name == "Z" }
+            assertNull(result)
+        }
+
+    // --- scanUntil(count) ---
+
+    @Test
+    fun scanUntilCountCollectsDistinctAds() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                    advertisement { name("B") }
+                    advertisement { name("C") }
+                }
+            val result = scanner.scanUntil(count = 2, maxWait = 500.milliseconds)
+            assertEquals(2, result.size)
+            assertEquals(listOf("A", "B"), result.map { it.name })
+        }
+
+    @Test
+    fun scanUntilCountDeduplicatesByIdentifier() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { identifier("a"); name("A") }
+                    advertisement { identifier("a"); name("A2") } // same id "a", new name
+                    advertisement { identifier("b"); name("B") }
+                }
+            val result = scanner.scanUntil(count = 2, maxWait = 500.milliseconds)
+            assertEquals(2, result.size)
+            assertEquals(listOf("a", "b"), result.map { it.identifier.value })
+        }
+
+    @Test
+    fun scanUntilCountReturnsFewerOnTimeout() =
+        runTest {
+            val scanner =
+                FakeScanner {
+                    advertisement { name("A") }
+                }
+            val result = scanner.scanUntil(count = 5, maxWait = 50.milliseconds)
+            assertEquals(1, result.size)
+        }
+
+    @Test
+    fun scanUntilCountRejectsNonPositiveCount() =
+        runTest {
+            val scanner = FakeScanner {}
+            assertFailsWith<IllegalArgumentException> {
+                scanner.scanUntil(count = 0)
+            }
+        }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/scanner/ScannerExtensionsTest.kt
@@ -230,9 +230,18 @@ class ScannerExtensionsTest {
         runTest {
             val scanner =
                 FakeScanner {
-                    advertisement { identifier("a"); name("A") }
-                    advertisement { identifier("a"); name("A2") } // same id "a", new name
-                    advertisement { identifier("b"); name("B") }
+                    advertisement {
+                        identifier("a")
+                        name("A")
+                    }
+                    advertisement {
+                        identifier("a")
+                        name("A2") // same id "a", new name
+                    }
+                    advertisement {
+                        identifier("b")
+                        name("B")
+                    }
                 }
             val result = scanner.scanUntil(count = 2, maxWait = 500.milliseconds)
             assertEquals(2, result.size)


### PR DESCRIPTION
## Summary

Follow-up fix for #619 (merged without this change): scanUntil(count) returned an empty list on timeout instead of partial results, and used distinctUntilChanged which only drops consecutive duplicates -- wrong for count-distinct-devices semantics.

## Changes

- Rewrote scanUntil(count) with LinkedHashMap first-occurrence tracking (true set-distinct by identifier)
- Returns whatever was collected when maxWait expires (partial results)
- Sentinel CancellationException stops collection once count is reached (Flow.collect is crossinline)
- Tests via FakeScanner: predicate match / timeout / no-match; count collect / dedup / partial-on-timeout / non-positive count

## Why not in #619

#619 was merged before this fix landed on the branch. This PR carries only the delta.