### PR TITLE
feat(peripheral): add batchRead for parallel characteristic reads

### DIFF
--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
@@ -212,7 +212,7 @@ private suspend fun Peripheral.readBatchValue(characteristic: Characteristic): R
         Result.success(read(characteristic))
     } catch (e: TimeoutCancellationException) {
         // MUST precede CancellationException -- TimeoutCancellationException extends it.
-        val timeout = lastConnectionOptions?.let { it.timeouts.read } ?: DEFAULT_READ_TIMEOUT
+        val timeout = lastConnectionOptions?.timeouts?.read ?: DEFAULT_READ_TIMEOUT
         Result.failure(BleException(PeripheralTimeout(operation = "read", timeout = timeout)))
     } catch (e: CancellationException) {
         throw e

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/PeripheralExtensions.kt
@@ -1,10 +1,20 @@
 package com.atruedev.kmpble.peripheral
 
 import com.atruedev.kmpble.connection.ConnectionOptions
+import com.atruedev.kmpble.connection.OperationTimeouts
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.ConnectionLost
+import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.error.PeripheralTimeout
+import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.DiscoveredService
+import com.atruedev.kmpble.gatt.internal.NotConnectedException
 import com.atruedev.kmpble.scanner.uuidFrom
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -152,3 +162,66 @@ public suspend fun Peripheral.connectAndDiscover(
         throw e
     }
 }
+
+/**
+ * Read multiple characteristics, returning each result individually with
+ * per-characteristic failure isolation.
+ *
+ * Reads execute sequentially: each [read] goes through the peripheral's internal
+ * GATT operation queue, which serializes operations on the radio anyway, so there
+ * is no parallel-radio win to be had. Sequential execution also gives every read a
+ * fresh, correct deadline -- each uses the connection's configured
+ * [OperationTimeouts.read] (set via [ConnectionOptions.timeouts], 5s default).
+ *
+ * A failure on one characteristic (timeout, GATT error, disconnect) does not abort
+ * the remaining reads.
+ *
+ * Failures surface as [BleException] values in the [Result], consistent with the
+ * library's error model:
+ * - queue deadline exceeded -> [PeripheralTimeout]
+ * - disconnect mid-batch -> [ConnectionLost]
+ * - GATT error -> the original [BleException]
+ * - unexpected exception -> [OperationFailed]
+ *
+ * [CancellationException] (external cancellation of the calling coroutine)
+ * propagates instead of being converted to a failure.
+ *
+ * ```
+ * val results = peripheral.batchRead(listOf(batteryChar, tempChar, hrChar))
+ * val battery = results[batteryChar]?.getOrNull()
+ * val temp = results[tempChar]?.getOrThrow()
+ * ```
+ *
+ * @throws IllegalArgumentException if [characteristics] is empty or contains
+ *   duplicates.
+ * @throws kotlinx.coroutines.CancellationException if the calling coroutine is
+ *   cancelled while reads are in flight.
+ */
+public suspend fun Peripheral.batchRead(
+    characteristics: List<Characteristic>,
+): Map<Characteristic, Result<ByteArray>> {
+    require(characteristics.isNotEmpty()) { "characteristics must not be empty" }
+    require(characteristics.distinct().size == characteristics.size) {
+        "characteristics must not contain duplicates"
+    }
+    return characteristics.associateWith { readBatchValue(it) }
+}
+
+private suspend fun Peripheral.readBatchValue(characteristic: Characteristic): Result<ByteArray> =
+    try {
+        Result.success(read(characteristic))
+    } catch (e: TimeoutCancellationException) {
+        // MUST precede CancellationException -- TimeoutCancellationException extends it.
+        val timeout = lastConnectionOptions?.let { it.timeouts.read } ?: DEFAULT_READ_TIMEOUT
+        Result.failure(BleException(PeripheralTimeout(operation = "read", timeout = timeout)))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: BleException) {
+        Result.failure(e)
+    } catch (e: NotConnectedException) {
+        Result.failure(BleException(ConnectionLost("Connection lost during batch read")))
+    } catch (e: Exception) {
+        Result.failure(BleException(OperationFailed(e.message ?: "Batch read failed")))
+    }
+
+private val DEFAULT_READ_TIMEOUT: Duration = OperationTimeouts().read

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
@@ -49,7 +49,7 @@ class BatchReadTest {
 
     private suspend fun FakePeripheral.connectedCharacteristics(): List<Characteristic> {
         connect()
-        return services.value!!.flatMap { it.characteristics }
+        return services.value.orEmpty().flatMap { it.characteristics }
     }
 
     @Test
@@ -75,9 +75,9 @@ class BatchReadTest {
             val results = peripheral.batchRead(chars)
 
             val byUuid = results.entries.associate { (char, result) -> char.uuid to result.getOrThrow() }
-            assertEquals(byteArrayOf(0x00, 0x01).toList(), byUuid[uuidFrom("2a37")]!!.toList())
-            assertEquals(byteArrayOf(0x00, 0x02).toList(), byUuid[uuidFrom("2a38")]!!.toList())
-            assertEquals(byteArrayOf(0x00, 0x03).toList(), byUuid[uuidFrom("2a19")]!!.toList())
+            assertEquals(byteArrayOf(0x00, 0x01).toList(), byUuid.getValue(uuidFrom("2a37")).toList())
+            assertEquals(byteArrayOf(0x00, 0x02).toList(), byUuid.getValue(uuidFrom("2a38")).toList())
+            assertEquals(byteArrayOf(0x00, 0x03).toList(), byUuid.getValue(uuidFrom("2a19")).toList())
             peripheral.disconnect()
             peripheral.close()
         }
@@ -325,7 +325,7 @@ class BatchReadTest {
             val results = peripheral.batchRead(listOf(char))
 
             assertEquals(1, results.size)
-            assertTrue(results[char]!!.isSuccess)
+            assertTrue(results.getValue(char).isSuccess)
             peripheral.disconnect()
             peripheral.close()
         }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
@@ -1,0 +1,331 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.ConnectionLost
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.error.PeripheralTimeout
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.internal.NotConnectedException
+import com.atruedev.kmpble.scanner.uuidFrom
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+
+@OptIn(ExperimentalUuidApi::class)
+class BatchReadTest {
+    private fun createPeripheral(): FakePeripheral =
+        FakePeripheral {
+            service("180d") {
+                characteristic("2a37") {
+                    properties(read = true)
+                    onRead { byteArrayOf(0x00, 0x01) }
+                }
+                characteristic("2a38") {
+                    properties(read = true)
+                    onRead { byteArrayOf(0x00, 0x02) }
+                }
+            }
+            service("180f") {
+                characteristic("2a19") {
+                    properties(read = true)
+                    onRead { byteArrayOf(0x00, 0x03) }
+                }
+            }
+        }
+
+    private suspend fun FakePeripheral.connectedCharacteristics(): List<Characteristic> {
+        connect()
+        return services.value!!.flatMap { it.characteristics }
+    }
+
+    @Test
+    fun batchReadReturnsAllValues() =
+        runTest {
+            val peripheral = createPeripheral()
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            assertEquals(3, results.size)
+            for ((char, result) in results) {
+                assertNotNull(result.getOrNull(), "read should succeed for $char")
+            }
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun batchReadMapsCorrectValuesToCharacteristics() =
+        runTest {
+            val peripheral = createPeripheral()
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            val byUuid = results.entries.associate { (char, result) -> char.uuid to result.getOrThrow() }
+            assertEquals(byteArrayOf(0x00, 0x01).toList(), byUuid[uuidFrom("2a37")]!!.toList())
+            assertEquals(byteArrayOf(0x00, 0x02).toList(), byUuid[uuidFrom("2a38")]!!.toList())
+            assertEquals(byteArrayOf(0x00, 0x03).toList(), byUuid[uuidFrom("2a19")]!!.toList())
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun batchReadIsolatesFailures() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead { byteArrayOf(0x00, 0x01) }
+                        }
+                        characteristic("2a38") {
+                            properties(read = true)
+                            onRead { throw BleException(GattError("read", GattStatus.Failure)) }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            assertEquals(2, results.size)
+            assertEquals(1, results.values.count { it.isSuccess })
+            assertEquals(1, results.values.count { it.isFailure })
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun gattErrorIsPreservedAsBleException() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead { throw BleException(GattError("read", GattStatus.Failure)) }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            val failure = results.values.single().exceptionOrNull()
+            assertIs<BleException>(failure)
+            assertIs<GattError>(failure.error)
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun disconnectMapsToConnectionLost() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead { throw NotConnectedException() }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            val failure = results.values.single().exceptionOrNull()
+            assertIs<BleException>(failure)
+            assertIs<ConnectionLost>(failure.error)
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun unexpectedExceptionMapsToOperationFailed() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead { throw RuntimeException("boom") }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            val failure = results.values.single().exceptionOrNull()
+            assertIs<BleException>(failure)
+            assertIs<OperationFailed>(failure.error)
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun slowReadStillCompletesSequentially() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead {
+                                delay(100)
+                                byteArrayOf(0x01)
+                            }
+                        }
+                        characteristic("2a38") {
+                            properties(read = true)
+                            onRead { byteArrayOf(0x02) }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            assertEquals(2, results.size)
+            assertTrue(results.values.all { it.isSuccess }, "both reads should succeed")
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun cancellationPropagatesInsteadOfBecomingFailure() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead {
+                                delay(10_000)
+                                byteArrayOf(0x01)
+                            }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+
+            val result =
+                runCatching {
+                    coroutineScope {
+                        val job = async { peripheral.batchRead(chars) }
+                        yield()
+                        job.cancel()
+                        job.await()
+                    }
+                }
+            assertTrue(result.isFailure)
+            assertIs<CancellationException>(result.exceptionOrNull())
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun queueTimeoutMapsToPeripheralTimeout() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead {
+                                // TimeoutCancellationException constructor is internal;
+                                // produce a real one via withTimeout.
+                                withTimeout(1) { delay(100) }
+                                byteArrayOf(0x01)
+                            }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            val failure = results.values.single().exceptionOrNull()
+            assertIs<BleException>(failure)
+            assertIs<PeripheralTimeout>(failure.error)
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun timeoutOnOneCharacteristicDoesNotAbortLaterReads() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true)
+                            onRead {
+                                withTimeout(1) { delay(100) }
+                                byteArrayOf(0x01)
+                            }
+                        }
+                        characteristic("2a38") {
+                            properties(read = true)
+                            onRead { byteArrayOf(0x02) }
+                        }
+                    }
+                }
+            val chars = peripheral.connectedCharacteristics()
+            val results = peripheral.batchRead(chars)
+
+            assertEquals(2, results.size)
+            val timedOut = results.values.first { it.isFailure }
+            assertIs<PeripheralTimeout>((timedOut.exceptionOrNull() as BleException).error)
+            assertTrue(results.values.any { it.isSuccess }, "later read should still succeed")
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun batchReadRejectsEmptyList() =
+        runTest {
+            val peripheral = createPeripheral()
+            assertFailsWith<IllegalArgumentException> {
+                peripheral.batchRead(emptyList())
+            }
+        }
+
+    @Test
+    fun batchReadRejectsDuplicateCharacteristics() =
+        runTest {
+            val peripheral = createPeripheral()
+            val chars = peripheral.connectedCharacteristics()
+            val char = chars.first()
+
+            assertFailsWith<IllegalArgumentException> {
+                peripheral.batchRead(listOf(char, char))
+            }
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun batchReadWithSingleCharacteristic() =
+        runTest {
+            val peripheral = createPeripheral()
+            val chars = peripheral.connectedCharacteristics()
+            val char = chars.first()
+
+            val results = peripheral.batchRead(listOf(char))
+
+            assertEquals(1, results.size)
+            assertTrue(results[char]!!.isSuccess)
+            peripheral.disconnect()
+            peripheral.close()
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/BatchReadTest.kt
@@ -285,7 +285,8 @@ class BatchReadTest {
 
             assertEquals(2, results.size)
             val timedOut = results.values.first { it.isFailure }
-            assertIs<PeripheralTimeout>((timedOut.exceptionOrNull() as BleException).error)
+            val exception = assertIs<BleException>(timedOut.exceptionOrNull())
+            assertIs<PeripheralTimeout>(exception.error)
             assertTrue(results.values.any { it.isSuccess }, "later read should still succeed")
             peripheral.disconnect()
             peripheral.close()


### PR DESCRIPTION
## Summary

Adds Peripheral.batchRead(characteristics) -- one-call multi-read convenience with per-characteristic failure isolation.

Fixes #473.

## API

```kotlin
suspend fun Peripheral.batchRead(
    characteristics: List<Characteristic>,
): Map<Characteristic, Result<ByteArray>>
```

## Behavior

- Reads execute SEQUENTIALLY. GATT operations are serialized by the peripheral operation queue on both platforms anyway, so there is no parallel-radio win. Sequential execution gives every read a fresh, correct deadline (the connection configured OperationTimeouts.read, 5s default).
- Failures are isolated per characteristic; one failure does not abort the rest.
- Failures are typed via the BleException error model:
  - queue deadline exceeded -> PeripheralTimeout
  - disconnect mid-batch -> ConnectionLost
  - GATT error -> original BleException preserved
  - unexpected exception -> OperationFailed
- CancellationException propagates (external cancel), never becomes Result.failure.
- Empty or duplicate characteristic lists rejected with IllegalArgumentException.

## Rewritten after review

The first revision used parallel async + a timeout param, which the review flagged as broken: the outer withTimeout was min-ed against the queue timeout (so the documented 30s was unreachable), all timers started at batch launch while the queue runs serially (spuriously failing later reads), and raw internal exceptions (NotConnectedException) leaked through Result. All three majors + four minors addressed; test suite expanded from 5 to 11 cases covering cancellation, disconnect, typed GATT errors, slow reads, and duplicates.

## Tests

BatchReadTest: all-values, value mapping, failure isolation, BleException(GattError) preservation, disconnect -> ConnectionLost, unexpected -> OperationFailed, slow-read sequential completion, cancellation propagation, empty rejection, duplicate rejection, single characteristic. JVM tests pass, ktlint clean.