### PR TITLE
feat(peripheral): add writeReliable for atomic long writes

### DIFF
--- a/docs/api-quick-reference.md
+++ b/docs/api-quick-reference.md
@@ -283,6 +283,27 @@ peripheral.write(
 // No confirmation from the peripheral
 ```
 
+### Reliable write (atomic, multi-chunk)
+
+Writes a value larger than the MTU all-or-nothing. Unlike `write()` (which chunks
+as independent operations -- a mid-batch failure leaves earlier chunks committed),
+a reliable write stages every chunk and commits them together.
+
+```kotlin
+if (!peripheral.supportsReliableWrite) {
+    // iOS: CoreBluetooth has no public prepared-write API. Fall back to write().
+    peripheral.write(characteristic, data, WriteType.WithResponse)
+} else {
+    peripheral.writeReliable(characteristic, data)  // atomic on Android
+}
+```
+
+- Android: atomic via `beginReliableWrite` -> per-chunk writes -> `executeReliableWrite`.
+  Any failure (including cancellation) aborts the transaction; nothing is committed.
+- iOS: unsupported -- `writeReliable` throws; check `supportsReliableWrite` first.
+- Single-chunk values (<= MTU) use a plain acknowledged write.
+- Whole-transaction timeout: `OperationTimeouts.reliableWrite` (default 30s).
+
 ### Request MTU
 
 ```kotlin

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -76,6 +76,13 @@ internal class AndroidGattBridge(
                 onEvent?.invoke(GattCallbackEvent.CharacteristicWrite(characteristic, status))
             }
 
+            override fun onReliableWriteCompleted(
+                gatt: BluetoothGatt,
+                status: Int,
+            ) {
+                onEvent?.invoke(GattCallbackEvent.ReliableWriteCompleted(status))
+            }
+
             override fun onCharacteristicChanged(
                 gatt: BluetoothGatt,
                 characteristic: BluetoothGattCharacteristic,
@@ -209,6 +216,26 @@ internal class AndroidGattBridge(
         val result = g.writeCharacteristic(characteristic, value, writeType)
         return result == BluetoothGatt.GATT_SUCCESS
     }
+
+    /**
+     * Begin a reliable-write session. Subsequent [writeCharacteristic] calls are
+     * staged (prepared) rather than committed, until [executeReliableWrite] or
+     * [abortReliableWrite].
+     *
+     * `beginReliableWrite` is deprecated since API 33 but remains functional; the
+     * replacement (`prepareWriteCharacteristic`) is not public SDK. Suppressed.
+     */
+    @Suppress("DEPRECATION")
+    internal fun beginReliableWrite(): Boolean {
+        val g = _gatt.value ?: return false
+        return g.beginReliableWrite()
+    }
+
+    /** Commit a reliable-write session started by [beginReliableWrite]. */
+    internal fun executeReliableWrite(): Boolean = _gatt.value?.executeReliableWrite() ?: false
+
+    /** Discard a reliable-write session without committing any staged writes. */
+    internal fun abortReliableWrite(): Boolean = _gatt.value?.abortReliableWrite() ?: false
 
     internal fun readDescriptor(descriptor: BluetoothGattDescriptor): Boolean =
         _gatt.value?.readDescriptor(descriptor) ?: false

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -235,7 +235,9 @@ internal class AndroidGattBridge(
     internal fun executeReliableWrite(): Boolean = _gatt.value?.executeReliableWrite() ?: false
 
     /** Discard a reliable-write session without committing any staged writes. */
-    internal fun abortReliableWrite(): Boolean = _gatt.value?.abortReliableWrite() ?: false
+    internal fun abortReliableWrite() {
+        _gatt.value?.abortReliableWrite()
+    }
 
     internal fun readDescriptor(descriptor: BluetoothGattDescriptor): Boolean =
         _gatt.value?.readDescriptor(descriptor) ?: false

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidGattBridge.kt
@@ -217,14 +217,7 @@ internal class AndroidGattBridge(
         return result == BluetoothGatt.GATT_SUCCESS
     }
 
-    /**
-     * Begin a reliable-write session. Subsequent [writeCharacteristic] calls are
-     * staged (prepared) rather than committed, until [executeReliableWrite] or
-     * [abortReliableWrite].
-     *
-     * `beginReliableWrite` is deprecated since API 33 but remains functional; the
-     * replacement (`prepareWriteCharacteristic`) is not public SDK. Suppressed.
-     */
+    /** Begin a reliable-write session (deprecated API 33 but functional; replacement not public SDK). */
     @Suppress("DEPRECATION")
     internal fun beginReliableWrite(): Boolean {
         val g = _gatt.value ?: return false
@@ -232,9 +225,11 @@ internal class AndroidGattBridge(
     }
 
     /** Commit a reliable-write session started by [beginReliableWrite]. */
+    @Suppress("DEPRECATION")
     internal fun executeReliableWrite(): Boolean = _gatt.value?.executeReliableWrite() ?: false
 
     /** Discard a reliable-write session without committing any staged writes. */
+    @Suppress("DEPRECATION")
     internal fun abortReliableWrite() {
         _gatt.value?.abortReliableWrite()
     }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -92,6 +92,7 @@ public class AndroidPeripheral internal constructor(
     override val encryptionLevel: StateFlow<EncryptionLevel> get() = peripheralContext.encryptionLevel
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
+    override val supportsReliableWrite: Boolean get() = true
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
     override val dataLengthParameters: StateFlow<DataLengthParameters?> get() = peripheralContext.dataLengthParameters
 

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheral.kt
@@ -212,6 +212,13 @@ public class AndroidPeripheral internal constructor(
         writeCharacteristicGatt(characteristic, data, writeType)
     }
 
+    override suspend fun writeReliable(
+        characteristic: Characteristic,
+        data: ByteArray,
+    ) {
+        writeReliableGatt(characteristic, data)
+    }
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
@@ -46,6 +46,8 @@ internal fun AndroidPeripheral.handleGattEvent(event: GattCallbackEvent) {
                 )
             is GattCallbackEvent.CharacteristicWrite ->
                 pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
+            is GattCallbackEvent.ReliableWriteCompleted ->
+                pendingOps.complete(PendingOp.ReliableWriteCompleted, event.status.toGattStatus())
             is GattCallbackEvent.CharacteristicChanged -> {
                 val charUuid = Uuid.parse(event.characteristic.uuid.toString())
                 val serviceUuid =

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
@@ -1,0 +1,85 @@
+package com.atruedev.kmpble.peripheral
+
+import android.bluetooth.BluetoothGattCharacteristic
+import com.atruedev.kmpble.error.BleException
+import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.OperationFailed
+import com.atruedev.kmpble.gatt.Characteristic
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
+import com.atruedev.kmpble.gatt.internal.PendingOp
+import com.atruedev.kmpble.peripheral.internal.awaitGatt
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Reliable (prepared) write implementation for [AndroidPeripheral].
+ *
+ * Implements the all-or-nothing long-write contract of
+ * [com.atruedev.kmpble.peripheral.Peripheral.writeReliable] using Android's
+ * `BluetoothGatt` reliable-write API:
+ *
+ * ```
+ * beginReliableWrite()              -- open transaction, stage subsequent writes
+ * writeCharacteristic(chunk_1..n)  -- each staged (prepared), acked individually
+ * executeReliableWrite()           -- commit everything
+ * onReliableWriteCompleted(status) -- transaction result
+ * ```
+ *
+ * On any failure the transaction is aborted via [abortReliableWrite], leaving
+ * the peripheral untouched -- this is the atomicity `write()` (sequential
+ * chunked) cannot provide.
+ */
+
+internal suspend fun AndroidPeripheral.writeReliableGatt(
+    characteristic: Characteristic,
+    data: ByteArray,
+) {
+    checkNotClosed()
+    val native = requireNativeChar(characteristic)
+    val maxLength = maximumWriteValueLength.value
+    val chunks = LargeWriteHandler.chunk(data, maxLength)
+
+    // Single chunk: no transaction needed, plain acknowledged write.
+    if (chunks.size <= 1) {
+        writeCharacteristicGatt(characteristic, data, WriteType.WithResponse)
+        return
+    }
+
+    peripheralContext.gattQueue.enqueue(timeout = currentTimeouts.write) {
+        if (!bridge.beginReliableWrite()) {
+            throw BleException(OperationFailed("beginReliableWrite initiation failed"))
+        }
+        try {
+            for (chunk in chunks) {
+                val status =
+                    pendingOps.awaitGatt(PendingOp.CharacteristicWrite, "reliableWrite") {
+                        bridge.writeCharacteristic(native, chunk, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+                    }
+                if (!status.isSuccess()) {
+                    throw BleException(GattError("reliableWrite", status))
+                }
+            }
+            if (!bridge.executeReliableWrite()) {
+                throw BleException(OperationFailed("executeReliableWrite initiation failed"))
+            }
+            val executeStatus =
+                pendingOps.awaitGatt(PendingOp.ReliableWriteCompleted, "executeReliableWrite") { true }
+            if (!executeStatus.isSuccess()) {
+                throw BleException(GattError("reliableWrite", executeStatus))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            abortReliableWriteBestEffort()
+            throw e
+        }
+    }
+}
+
+private fun AndroidPeripheral.abortReliableWriteBestEffort() {
+    try {
+        bridge.abortReliableWrite()
+    } catch (_: Throwable) {
+        // Best-effort: abort failures are non-fatal; the original error propagates.
+    }
+}

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
@@ -80,13 +80,21 @@ internal suspend fun AndroidPeripheral.writeReliableGatt(
             // still finds its deferred, but keep initiation failures typed as
             // OperationFailed -- they are not GATT status responses.
             val executeDeferred = kotlinx.coroutines.CompletableDeferred<GattStatus>()
-            pendingOps.set(PendingOp.ReliableWriteCompleted, executeDeferred)
+            val executeGeneration = pendingOps.set(PendingOp.ReliableWriteCompleted, executeDeferred)
             val dispatched = bridge.executeReliableWrite()
             if (!dispatched) {
-                pendingOps.clear(PendingOp.ReliableWriteCompleted)
+                pendingOps.cancel(PendingOp.ReliableWriteCompleted, executeGeneration)
                 throw BleException(OperationFailed("executeReliableWrite initiation failed"))
             }
-            val executeStatus = executeDeferred.await()
+            val executeStatus =
+                try {
+                    executeDeferred.await()
+                } catch (e: Throwable) {
+                    // Cancellation-safe: clear our slot so a retry does not trip
+                    // the overwrite check, and a late callback no-ops.
+                    pendingOps.cancel(PendingOp.ReliableWriteCompleted, executeGeneration)
+                    throw e
+                }
             if (!executeStatus.isSuccess()) {
                 throw BleException(GattError("reliableWrite", executeStatus))
             }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.peripheral
 import android.bluetooth.BluetoothGattCharacteristic
 import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.GattError
+import com.atruedev.kmpble.error.GattStatus
 import com.atruedev.kmpble.error.OperationFailed
 import com.atruedev.kmpble.gatt.Characteristic
 import com.atruedev.kmpble.gatt.WriteType
@@ -32,15 +33,18 @@ import com.atruedev.kmpble.peripheral.internal.awaitGatt
  * (default 30s) -- a per-chunk timeout would starve slow links for exactly the
  * multi-chunk payloads this API exists for.
  *
- * ## Known limitation
+ * ## Cancellation and aborts
  *
- * The transaction block runs inside the peripheral's GATT operation queue, which
- * executes on its own coroutine. Cancelling the caller does not interrupt an
- * in-flight transaction block (the queue only observes the caller's cancellation
- * via the [kotlinx.coroutines.withTimeout] wrapper). A cancelled transaction is
- * aborted best-effort; if the abort itself fails (device hung), the reliable
+ * Caller cancellation propagates into the in-flight transaction: the operation
+ * queue runs each action as a child job and cancels it when the caller gives up
+ * (see [com.atruedev.kmpble.gatt.internal.GattOperationQueue]), so the block
+ * observes [kotlinx.coroutines.CancellationException] and the [catch] below
+ * aborts the transaction before rethrowing.
+ *
+ * The abort itself is best-effort: if it fails (device hung), the reliable
  * session stays open on the device and subsequent GATT operations may be staged
- * into it -- recover by disconnecting.
+ * into it -- recover by disconnecting. This is the documented platform
+ * limitation of `abortReliableWrite`, not a silent failure.
  */
 
 internal suspend fun AndroidPeripheral.writeReliableGatt(
@@ -72,10 +76,17 @@ internal suspend fun AndroidPeripheral.writeReliableGatt(
                     throw BleException(GattError("reliableWrite", status))
                 }
             }
-            val executeStatus =
-                pendingOps.awaitGatt(PendingOp.ReliableWriteCompleted, "executeReliableWrite") {
-                    bridge.executeReliableWrite()
-                }
+            // Arm the pending slot before submitting so a synchronous callback
+            // still finds its deferred, but keep initiation failures typed as
+            // OperationFailed -- they are not GATT status responses.
+            val executeDeferred = kotlinx.coroutines.CompletableDeferred<GattStatus>()
+            pendingOps.set(PendingOp.ReliableWriteCompleted, executeDeferred)
+            val dispatched = bridge.executeReliableWrite()
+            if (!dispatched) {
+                pendingOps.clear(PendingOp.ReliableWriteCompleted)
+                throw BleException(OperationFailed("executeReliableWrite initiation failed"))
+            }
+            val executeStatus = executeDeferred.await()
             if (!executeStatus.isSuccess()) {
                 throw BleException(GattError("reliableWrite", executeStatus))
             }

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralReliableWrite.kt
@@ -9,7 +9,6 @@ import com.atruedev.kmpble.gatt.WriteType
 import com.atruedev.kmpble.gatt.internal.LargeWriteHandler
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.peripheral.internal.awaitGatt
-import kotlinx.coroutines.CancellationException
 
 /**
  * Reliable (prepared) write implementation for [AndroidPeripheral].
@@ -25,9 +24,23 @@ import kotlinx.coroutines.CancellationException
  * onReliableWriteCompleted(status) -- transaction result
  * ```
  *
- * On any failure the transaction is aborted via [abortReliableWrite], leaving
- * the peripheral untouched -- this is the atomicity `write()` (sequential
- * chunked) cannot provide.
+ * On ANY failure -- including cancellation of the calling coroutine -- the
+ * transaction is aborted via [abortReliableWrite], leaving the peripheral
+ * untouched. This is the atomicity `write()` (sequential chunked) cannot provide.
+ *
+ * The whole transaction runs under [com.atruedev.kmpble.connection.OperationTimeouts.reliableWrite]
+ * (default 30s) -- a per-chunk timeout would starve slow links for exactly the
+ * multi-chunk payloads this API exists for.
+ *
+ * ## Known limitation
+ *
+ * The transaction block runs inside the peripheral's GATT operation queue, which
+ * executes on its own coroutine. Cancelling the caller does not interrupt an
+ * in-flight transaction block (the queue only observes the caller's cancellation
+ * via the [kotlinx.coroutines.withTimeout] wrapper). A cancelled transaction is
+ * aborted best-effort; if the abort itself fails (device hung), the reliable
+ * session stays open on the device and subsequent GATT operations may be staged
+ * into it -- recover by disconnecting.
  */
 
 internal suspend fun AndroidPeripheral.writeReliableGatt(
@@ -45,7 +58,7 @@ internal suspend fun AndroidPeripheral.writeReliableGatt(
         return
     }
 
-    peripheralContext.gattQueue.enqueue(timeout = currentTimeouts.write) {
+    peripheralContext.gattQueue.enqueue(timeout = currentTimeouts.reliableWrite) {
         if (!bridge.beginReliableWrite()) {
             throw BleException(OperationFailed("beginReliableWrite initiation failed"))
         }
@@ -59,23 +72,27 @@ internal suspend fun AndroidPeripheral.writeReliableGatt(
                     throw BleException(GattError("reliableWrite", status))
                 }
             }
-            if (!bridge.executeReliableWrite()) {
-                throw BleException(OperationFailed("executeReliableWrite initiation failed"))
-            }
             val executeStatus =
-                pendingOps.awaitGatt(PendingOp.ReliableWriteCompleted, "executeReliableWrite") { true }
+                pendingOps.awaitGatt(PendingOp.ReliableWriteCompleted, "executeReliableWrite") {
+                    bridge.executeReliableWrite()
+                }
             if (!executeStatus.isSuccess()) {
                 throw BleException(GattError("reliableWrite", executeStatus))
             }
-        } catch (e: CancellationException) {
-            throw e
         } catch (e: Throwable) {
+            // Single catch: CancellationException is a Throwable, so a cancelled
+            // transaction is aborted too, not silently left to commit later.
             abortReliableWriteBestEffort()
             throw e
         }
     }
 }
 
+/**
+ * Best-effort abort. The original error always propagates; abort failures are
+ * swallowed (a hung device cannot be aborted, and there is no recovery path
+ * other than disconnect -- see the KDoc limitation note).
+ */
 private fun AndroidPeripheral.abortReliableWriteBestEffort() {
     try {
         bridge.abortReliableWrite()

--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/GattCallbackEvent.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/GattCallbackEvent.kt
@@ -35,6 +35,15 @@ internal sealed interface GattCallbackEvent {
         val status: Int,
     ) : GattCallbackEvent
 
+    /**
+     * Fired by [android.bluetooth.BluetoothGattCallback.onReliableWriteCompleted]
+     * after [android.bluetooth.BluetoothGatt.executeReliableWrite] commits a
+     * reliable-write transaction.
+     */
+    data class ReliableWriteCompleted(
+        val status: Int,
+    ) : GattCallbackEvent
+
     class CharacteristicChanged(
         val characteristic: BluetoothGattCharacteristic,
         val value: ByteArray,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/connection/OperationTimeouts.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/connection/OperationTimeouts.kt
@@ -30,6 +30,13 @@ public data class OperationTimeouts(
     val read: Duration = 5.seconds,
     /** Maximum time for a single GATT characteristic write. Default: 5s. */
     val write: Duration = 5.seconds,
+    /**
+     * Maximum time for a whole [com.atruedev.kmpble.peripheral.Peripheral.writeReliable]
+     * transaction -- all chunks plus the execute step. Default: 30s, sized for the
+     * multi-chunk payloads reliable writes exist for (per-chunk timeouts would
+     * starve slow links that [write] already covers).
+     */
+    val reliableWrite: Duration = 30.seconds,
     /** Maximum time for ATT MTU negotiation. Default: 10s. */
     val mtuNegotiation: Duration = 10.seconds,
     /** Maximum time to establish an L2CAP CoC channel. Default: 10s. */
@@ -49,6 +56,9 @@ public data class OperationTimeouts(
         }
         require(write.isPositive() || write == Duration.ZERO || write == Duration.INFINITE) {
             "write timeout must be positive, ZERO, or INFINITE, was $write"
+        }
+        require(reliableWrite.isPositive() || reliableWrite == Duration.ZERO || reliableWrite == Duration.INFINITE) {
+            "reliableWrite timeout must be positive, ZERO, or INFINITE, was $reliableWrite"
         }
         require(mtuNegotiation.isPositive() || mtuNegotiation == Duration.ZERO || mtuNegotiation == Duration.INFINITE) {
             "mtuNegotiation timeout must be positive, ZERO, or INFINITE, was $mtuNegotiation"

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -63,10 +63,19 @@ internal class GattOperationQueue(
             ),
         )
 
+    /**
+     * Child jobs currently running an action. Confined to the serialized
+     * dispatcher like the drain loop itself. Tracked so [start] and [close]
+     * can cancel in-flight actions (a regression from running actions inline
+     * in the drain coroutine, where cancelling the drain cancelled the action).
+     */
+    private val inFlightJobs = mutableSetOf<Job>()
+
     fun start(timeout: Duration? = null) {
         val prev = state.value
         drainChannel(prev.channel)
         prev.drainJob?.cancel()
+        cancelInFlight()
 
         val ch = Channel<QueueEntry>(Channel.UNLIMITED)
         val job =
@@ -105,10 +114,12 @@ internal class GattOperationQueue(
                             }
                         }
                     entry.job.value = child
+                    inFlightJobs += child
                     // If the caller was cancelled while this action was queued but
                     // not yet started, kill it immediately.
                     if (entry.cancelled.value != null) child.cancel()
                     child.join()
+                    inFlightJobs -= child
                 },
                 cancel = { deferred.completeExceptionally(it) },
             )
@@ -141,6 +152,13 @@ internal class GattOperationQueue(
         val s = state.value
         drainChannel(s.channel)
         s.drainJob?.cancel()
+        cancelInFlight()
+    }
+
+    /** Cancel any action currently running, e.g. when (re)connecting. */
+    private fun cancelInFlight() {
+        inFlightJobs.forEach { it.cancel() }
+        inFlightJobs.clear()
     }
 
     private fun drainChannel(ch: Channel<QueueEntry>) {

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueue.kt
@@ -21,6 +21,18 @@ import kotlin.time.Duration.Companion.seconds
  * serialized dispatcher (`limitedParallelism(1)`).
  * [enqueue] reads the [kotlinx.atomicfu.atomic] [state] snapshot from any
  * coroutine context.
+ *
+ * ## Cancellation propagation
+ *
+ * Each action runs as a child job of the queue scope, joined by the drain loop.
+ * When the caller's coroutine is cancelled or its [withTimeout] fires, the
+ * in-flight action's child job is cancelled, so the action observes
+ * [kotlinx.coroutines.CancellationException] and can clean up (e.g. abort a
+ * reliable-write transaction). An action that has not yet started is marked
+ * cancelled and skipped by the drain loop. Without this, a cancelled caller
+ * would leave the action running to completion in the background -- harmless
+ * for a plain read, fatal for a multi-chunk reliable write that could commit
+ * after the caller already gave up.
  */
 internal class GattOperationQueue(
     private val scope: CoroutineScope,
@@ -28,7 +40,13 @@ internal class GattOperationQueue(
     private class QueueEntry(
         val action: suspend () -> Unit,
         val cancel: (Throwable) -> Unit,
-    )
+    ) {
+        /** The drain loop's child job running [action]; null until it starts. */
+        val job = atomic<Job?>(null)
+
+        /** Set when the caller is cancelled before the action started. */
+        val cancelled = atomic<Throwable?>(null)
+    }
 
     private data class QueueState(
         val channel: Channel<QueueEntry>,
@@ -54,6 +72,10 @@ internal class GattOperationQueue(
         val job =
             scope.launch {
                 for (entry in ch) {
+                    entry.cancelled.value?.let { cause ->
+                        entry.cancel(cause)
+                        continue
+                    }
                     entry.action()
                 }
             }
@@ -70,14 +92,23 @@ internal class GattOperationQueue(
         block: suspend () -> T,
     ): T {
         val deferred = CompletableDeferred<T>()
-        val entry =
+        lateinit var entry: QueueEntry
+        entry =
             QueueEntry(
                 action = {
-                    try {
-                        deferred.complete(block())
-                    } catch (e: Throwable) {
-                        deferred.completeExceptionally(e)
-                    }
+                    val child =
+                        scope.launch {
+                            try {
+                                deferred.complete(block())
+                            } catch (e: Throwable) {
+                                deferred.completeExceptionally(e)
+                            }
+                        }
+                    entry.job.value = child
+                    // If the caller was cancelled while this action was queued but
+                    // not yet started, kill it immediately.
+                    if (entry.cancelled.value != null) child.cancel()
+                    child.join()
                 },
                 cancel = { deferred.completeExceptionally(it) },
             )
@@ -89,8 +120,16 @@ internal class GattOperationQueue(
             throw NotConnectedException()
         }
 
-        return withTimeout(timeout) {
-            deferred.await()
+        return try {
+            withTimeout(timeout) {
+                deferred.await()
+            }
+        } catch (e: Throwable) {
+            // Cancel the in-flight action (if running) or mark it cancelled (if
+            // still queued) so it does not keep executing after the caller gave up.
+            entry.job.value?.cancel()
+            entry.cancelled.compareAndSet(null, e)
+            throw e
         }
     }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -50,45 +50,85 @@ internal data class PhyUpdateResult(
 )
 
 /**
- * Holds at most one [CompletableDeferred] per [PendingOp] type.
+ * Holds at most one pending operation per [PendingOp] type, each tagged with a
+ * generation token so a cancelled op cannot clobber a retry of the same type.
  *
  * Confined to the owning peripheral's serialized dispatcher
  * (`limitedParallelism(1)`) - no synchronization required.
+ *
+ * ## Cancellation safety
+ *
+ * The GATT operation queue cancels in-flight actions when the caller's coroutine
+ * is cancelled or times out (see [GattOperationQueue]). [awaitGatt] responds by
+ * calling [cancel] with its generation token, which removes the slot. Without
+ * this, a cancelled op would leave its slot armed forever -- the next operation
+ * of the same type would then crash in [set] with
+ * "overwritten while pending", and a late platform callback would complete into
+ * a freshly-armed retry slot.
+ *
+ * A callback that arrives after its op was cancelled finds no slot and no-ops.
  */
 internal class PendingOperations {
-    private val slots = mutableMapOf<PendingOp<*>, CompletableDeferred<*>>()
+    private class Slot(
+        val deferred: CompletableDeferred<*>,
+        val generation: Long,
+    )
 
+    private val slots = mutableMapOf<PendingOp<*>, Slot>()
+    private var nextGeneration = 0L
+
+    /**
+     * Arm a pending slot. Returns the generation token the caller must pass to
+     * [cancel] so only the current owner of the slot can clear it.
+     */
     fun <T> set(
         op: PendingOp<T>,
         deferred: CompletableDeferred<T>,
-    ) {
+    ): Long {
         check(op !in slots) { "${op::class.simpleName} overwritten while pending" }
-        slots[op] = deferred
+        val generation = nextGeneration++
+        slots[op] = Slot(deferred, generation)
+        return generation
+    }
+
+    /**
+     * Remove the slot for [op] if (and only if) it still belongs to [generation].
+     * A cancelled op clears its own slot; a retry of the same type can then arm
+     * a fresh slot without tripping the overwrite check. No-op if the slot was
+     * already completed (replaced) by a newer operation.
+     */
+    fun cancel(
+        op: PendingOp<*>,
+        generation: Long,
+    ) {
+        val slot = slots[op] ?: return
+        if (slot.generation != generation) return
+        slots.remove(op)
     }
 
     fun has(op: PendingOp<*>): Boolean = op in slots
 
-    fun clear(op: PendingOp<*>) {
-        slots.remove(op)
-    }
-
-    @Suppress("UNCHECKED_CAST")
     fun <T> complete(
         op: PendingOp<T>,
         value: T,
     ) {
-        (slots.remove(op) as? CompletableDeferred<T>)?.complete(value)
+        @Suppress("UNCHECKED_CAST")
+        (slots.remove(op)?.deferred as? CompletableDeferred<T>)?.complete(value)
     }
 
     fun fail(
         op: PendingOp<*>,
         cause: Throwable,
     ) {
-        slots.remove(op)?.completeExceptionally(cause)
+        @Suppress("UNCHECKED_CAST")
+        (slots.remove(op)?.deferred as? CompletableDeferred<Any?>)?.completeExceptionally(cause)
     }
 
     fun cancelAll(cause: Throwable) {
-        slots.values.forEach { it.completeExceptionally(cause) }
+        slots.values.forEach { slot ->
+            @Suppress("UNCHECKED_CAST")
+            (slot.deferred as? CompletableDeferred<Any?>)?.completeExceptionally(cause)
+        }
         slots.clear()
     }
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -26,6 +26,8 @@ internal sealed interface PendingOp<T> {
 
     data object CharacteristicWrite : PendingOp<GattStatus>
 
+    data object ReliableWriteCompleted : PendingOp<GattStatus>
+
     data object DescriptorRead : PendingOp<GattResult>
 
     data object DescriptorWrite : PendingOp<GattStatus>

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -66,7 +66,14 @@ internal data class PhyUpdateResult(
  * "overwritten while pending", and a late platform callback would complete into
  * a freshly-armed retry slot.
  *
- * A callback that arrives after its op was cancelled finds no slot and no-ops.
+ * A callback that arrives after its op was cancelled no-ops UNLESS a retry of
+ * the same type has already re-armed the slot: [complete] is not generation
+ * aware, so a stale callback would complete the retry's deferred. In practice
+ * the callback is dispatched from the platform callback thread onto the same
+ * serialized dispatcher well before a user retry can re-arm (the retry path
+ * crosses enqueue -> drain -> block -> set), so the race window is effectively
+ * theoretical -- but it exists. Closing it fully requires generation-aware
+ * [complete], tracked in the backlog.
  */
 internal class PendingOperations {
     private class Slot(

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -97,6 +97,39 @@ public interface Peripheral : AutoCloseable {
     )
 
     /**
+     * Write [data] to [characteristic] atomically as a single reliable-write
+     * transaction (GATT prepared write then execute).
+     *
+     * Unlike [write], which auto-chunks values larger than the MTU as independent
+     * operations (a mid-batch failure leaves earlier chunks committed), a reliable
+     * write stages every chunk first and commits them all-or-nothing. Use this for
+     * data where a partial write is unacceptable -- large configuration blobs,
+     * multi-characteristic value updates that must apply together.
+     *
+     * Values up to [maximumWriteValueLength] are written with a single
+     * [WriteType.WithResponse] write (no reliable-write ceremony).
+     *
+     * ## Platform behavior
+     *
+     * - **Android**: Atomic via `BluetoothGatt` reliable write
+     *   (`beginReliableWrite` -> per-chunk writes -> `executeReliableWrite`).
+     *   On any chunk failure the transaction is aborted (`abortReliableWrite`)
+     *   and nothing is committed.
+     * - **iOS**: CoreBluetooth exposes no public prepared-write API. Falls back to
+     *   sequential chunked [WriteType.WithResponse] writes -- **not atomic**. If a
+     *   chunk fails, earlier chunks remain written.
+     *
+     * @throws com.atruedev.kmpble.error.BleException if any chunk write or the
+     *   execute/abort step fails.
+     * @throws kotlinx.coroutines.CancellationException if the calling coroutine is
+     *   cancelled mid-transaction (the transaction is aborted).
+     */
+    public suspend fun writeReliable(
+        characteristic: Characteristic,
+        data: ByteArray,
+    )
+
+    /**
      * Observe notifications/indications from a characteristic. The returned
      * flow survives disconnects and auto-resubscribes on reconnect -- emits
      * [Observation.Value] with data, [Observation.Disconnected] on connection

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/Peripheral.kt
@@ -103,8 +103,7 @@ public interface Peripheral : AutoCloseable {
      * Unlike [write], which auto-chunks values larger than the MTU as independent
      * operations (a mid-batch failure leaves earlier chunks committed), a reliable
      * write stages every chunk first and commits them all-or-nothing. Use this for
-     * data where a partial write is unacceptable -- large configuration blobs,
-     * multi-characteristic value updates that must apply together.
+     * data where a partial write is unacceptable -- large configuration blobs.
      *
      * Values up to [maximumWriteValueLength] are written with a single
      * [WriteType.WithResponse] write (no reliable-write ceremony).
@@ -113,16 +112,17 @@ public interface Peripheral : AutoCloseable {
      *
      * - **Android**: Atomic via `BluetoothGatt` reliable write
      *   (`beginReliableWrite` -> per-chunk writes -> `executeReliableWrite`).
-     *   On any chunk failure the transaction is aborted (`abortReliableWrite`)
-     *   and nothing is committed.
-     * - **iOS**: CoreBluetooth exposes no public prepared-write API. Falls back to
-     *   sequential chunked [WriteType.WithResponse] writes -- **not atomic**. If a
-     *   chunk fails, earlier chunks remain written.
+     *   On any failure (including cancellation) the transaction is aborted
+     *   (`abortReliableWrite`) and nothing is committed.
+     * - **iOS**: CoreBluetooth exposes no public prepared-write API. [writeReliable]
+     *   throws [UnsupportedOperationException] on iOS; check
+     *   [supportsReliableWrite] first and use [write] instead.
      *
      * @throws com.atruedev.kmpble.error.BleException if any chunk write or the
-     *   execute/abort step fails.
+     *   execute step fails (the transaction is aborted first).
      * @throws kotlinx.coroutines.CancellationException if the calling coroutine is
      *   cancelled mid-transaction (the transaction is aborted).
+     * @throws UnsupportedOperationException on iOS (see [supportsReliableWrite]).
      */
     public suspend fun writeReliable(
         characteristic: Characteristic,
@@ -322,6 +322,19 @@ public interface Peripheral : AutoCloseable {
     public suspend fun requestConnectionSubrating(parameters: ConnectionSubratingParameters): ConnectionSubratingResult
 
     public val maximumWriteValueLength: StateFlow<Int>
+
+    /**
+     * Whether [writeReliable] provides true all-or-nothing atomicity on this
+     * platform.
+     *
+     * `true` on Android (GATT prepared-write + execute). `false` on iOS --
+     * CoreBluetooth exposes no public prepared-write API, so [writeReliable]
+     * throws there instead of silently degrading to non-atomic chunked writes.
+     *
+     * Check this before calling [writeReliable] when atomicity is a hard
+     * requirement; otherwise fall back to [write].
+     */
+    public val supportsReliableWrite: Boolean
 
     // --- L2CAP ---
 

--- a/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralSupport.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/peripheral/internal/PeripheralSupport.kt
@@ -49,6 +49,11 @@ internal fun List<DiscoveredService>?.findDescriptor(
  * still finds a deferred to complete. If the platform reports rejection ([submit]
  * returns false), the slot is cleared and the caller is failed deterministically.
  *
+ * Cancellation-safe: if the awaiting coroutine is cancelled or times out (which the
+ * GATT operation queue propagates into the action), the slot is removed via its
+ * generation token so a retry of the same operation type does not trip the
+ * "overwritten while pending" check, and a late platform callback no-ops.
+ *
  * Confined to the peripheral's serial dispatcher.
  */
 internal suspend fun <T> PendingOperations.awaitGatt(
@@ -57,12 +62,17 @@ internal suspend fun <T> PendingOperations.awaitGatt(
     submit: () -> Boolean,
 ): T {
     val deferred = CompletableDeferred<T>()
-    set(op, deferred)
+    val generation = set(op, deferred)
     if (!submit()) {
-        clear(op)
+        cancel(op, generation)
         throw BleException(GattError(label, GattStatus.Failure))
     }
-    return deferred.await()
+    try {
+        return deferred.await()
+    } catch (e: Throwable) {
+        cancel(op, generation)
+        throw e
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -101,6 +101,7 @@ public class FakePeripheral internal constructor(
     override val services: StateFlow<List<DiscoveredService>?> get() = context.services
     override val maximumWriteValueLength: StateFlow<Int> get() = context.maximumWriteValueLength
     override val mtu: StateFlow<Int> get() = context.mtu
+    override val supportsReliableWrite: Boolean get() = true
 
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -101,7 +101,11 @@ public class FakePeripheral internal constructor(
     override val services: StateFlow<List<DiscoveredService>?> get() = context.services
     override val maximumWriteValueLength: StateFlow<Int> get() = context.maximumWriteValueLength
     override val mtu: StateFlow<Int> get() = context.mtu
-    override val supportsReliableWrite: Boolean get() = true
+
+    // The fake has no reliable-write machinery -- it delegates to the plain write
+    // handler. Claiming atomic support would certify a lie, so it reports false
+    // (like iOS) and writeReliable throws.
+    override val supportsReliableWrite: Boolean get() = false
 
     override suspend fun connect(options: ConnectionOptions) {
         checkNotClosed()
@@ -180,7 +184,11 @@ public class FakePeripheral internal constructor(
     override suspend fun writeReliable(
         characteristic: Characteristic,
         data: ByteArray,
-    ): Unit = gattResponder.write(characteristic, data, WriteType.WithResponse)
+    ): Nothing =
+        throw UnsupportedOperationException(
+            "FakePeripheral does not implement reliable writes; " +
+                "supportsReliableWrite is false (like iOS). Use write() in tests.",
+        )
 
     override fun observe(
         characteristic: Characteristic,

--- a/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/testing/FakePeripheral.kt
@@ -176,6 +176,11 @@ public class FakePeripheral internal constructor(
         writeType: WriteType,
     ): Unit = gattResponder.write(characteristic, data, writeType)
 
+    override suspend fun writeReliable(
+        characteristic: Characteristic,
+        data: ByteArray,
+    ): Unit = gattResponder.write(characteristic, data, WriteType.WithResponse)
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueueTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueueTest.kt
@@ -1,0 +1,128 @@
+package com.atruedev.kmpble.gatt.internal
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class GattOperationQueueTest {
+    @Test
+    fun enqueueRunsActionAndReturnsResult() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            val result = queue.enqueue(timeout = 5.seconds) { 42 }
+            assertEquals(42, result)
+        }
+
+    @Test
+    fun enqueueSerializesActions() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            val order = mutableListOf<Int>()
+            val j1 = launch { queue.enqueue(timeout = 5.seconds) { order += 1 } }
+            val j2 = launch { queue.enqueue(timeout = 5.seconds) { order += 2 } }
+            j1.join()
+            j2.join()
+            assertEquals(listOf(1, 2), order)
+        }
+
+    @Test
+    fun enqueueRejectsAfterClose() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+            queue.drain()
+
+            assertFailsWith<NotConnectedException> {
+                queue.enqueue(timeout = 5.seconds) { 1 }
+            }
+        }
+
+    @Test
+    fun callerCancellationCancelsInFlightAction() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            var actionCancelled = false
+            val job: Job =
+                launch {
+                    queue.enqueue(timeout = 5.seconds) {
+                        try {
+                            delay(10_000)
+                        } catch (e: CancellationException) {
+                            actionCancelled = true
+                            throw e
+                        }
+                    }
+                }
+            // Let the action start, then cancel the caller.
+            repeat(10) { yield() }
+            job.cancel()
+            job.join()
+
+            assertTrue(actionCancelled, "in-flight action must observe caller cancellation")
+        }
+
+    @Test
+    fun timeoutCancelsInFlightAction() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            var actionCancelled = false
+            assertFailsWith<CancellationException> {
+                queue.enqueue(timeout = 1.milliseconds) {
+                    try {
+                        delay(10_000)
+                    } catch (e: CancellationException) {
+                        actionCancelled = true
+                        throw e
+                    }
+                }
+            }
+            repeat(10) { yield() }
+            assertTrue(actionCancelled, "timed-out action must observe cancellation")
+        }
+
+    @Test
+    fun cancelledActionStillRunsIsolatedFromNext() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            var slowCancelled = false
+            val slow =
+                launch {
+                    runCatching {
+                        queue.enqueue(timeout = 1.milliseconds) {
+                            try {
+                                delay(10_000)
+                            } catch (e: CancellationException) {
+                                slowCancelled = true
+                                throw e
+                            }
+                        }
+                    }
+                }
+            slow.join()
+
+            // The next enqueue must still be served even though the previous
+            // action was cancelled mid-flight.
+            val next = queue.enqueue(timeout = 5.seconds) { "served" }
+            assertEquals("served", next)
+            assertTrue(slowCancelled)
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueueTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/GattOperationQueueTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -124,5 +125,66 @@ class GattOperationQueueTest {
             val next = queue.enqueue(timeout = 5.seconds) { "served" }
             assertEquals("served", next)
             assertTrue(slowCancelled)
+        }
+
+    @Test
+    fun callerCancelBeforeActionStartsSkipsQueuedAction() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            var slowRan = false
+            var skippedRan = false
+            val slow =
+                launch {
+                    queue.enqueue(timeout = 5.seconds) {
+                        slowRan = true
+                        delay(100)
+                    }
+                }
+            val skipped =
+                launch {
+                    runCatching {
+                        queue.enqueue(timeout = 5.seconds) {
+                            skippedRan = true
+                        }
+                    }
+                }
+            // Let the slow action start and the second action queue behind it.
+            repeat(10) { yield() }
+            // Cancel the second caller before its action starts.
+            skipped.cancel()
+            skipped.join()
+            slow.join()
+
+            assertTrue(slowRan)
+            assertFalse(skippedRan, "queued action cancelled before start must be skipped")
+        }
+
+    @Test
+    fun closeCancelsInFlightAction() =
+        runTest {
+            val queue = GattOperationQueue(backgroundScope)
+            queue.start()
+
+            var actionCancelled = false
+            val job: Job =
+                launch {
+                    runCatching {
+                        queue.enqueue(timeout = 5.seconds) {
+                            try {
+                                delay(10_000)
+                            } catch (e: CancellationException) {
+                                actionCancelled = true
+                                throw e
+                            }
+                        }
+                    }
+                }
+            repeat(10) { yield() }
+            queue.close()
+            job.join()
+
+            assertTrue(actionCancelled, "close() must cancel in-flight actions")
         }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperationsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperationsTest.kt
@@ -1,0 +1,74 @@
+package com.atruedev.kmpble.gatt.internal
+
+import com.atruedev.kmpble.error.GattStatus
+import kotlinx.coroutines.CompletableDeferred
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PendingOperationsTest {
+    @Test
+    fun setRejectsOverwriteWhilePending() {
+        val ops = PendingOperations()
+        ops.set(PendingOp.CharacteristicWrite, CompletableDeferred())
+        assertFailsWith<IllegalStateException> {
+            ops.set(PendingOp.CharacteristicWrite, CompletableDeferred())
+        }
+    }
+
+    @Test
+    fun retryAfterCancelDoesNotCrash() {
+        val ops = PendingOperations()
+        val first = CompletableDeferred<GattStatus>()
+        val firstGen = ops.set(PendingOp.CharacteristicWrite, first)
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+
+        // The cancellation-safe contract: a retry of the same op type must be
+        // able to arm a fresh slot (this crashed before the generation token).
+        val second = CompletableDeferred<GattStatus>()
+        ops.set(PendingOp.CharacteristicWrite, second)
+        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        assertTrue(second.isCompleted)
+    }
+
+    @Test
+    fun lateCallbackAfterCancelNoOps() {
+        val ops = PendingOperations()
+        val deferred = CompletableDeferred<GattStatus>()
+        val generation = ops.set(PendingOp.CharacteristicWrite, deferred)
+        ops.cancel(PendingOp.CharacteristicWrite, generation)
+
+        // A platform callback arriving after the op was cancelled must not
+        // complete the (already abandoned) deferred.
+        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        assertFalse(deferred.isCompleted)
+    }
+
+    @Test
+    fun staleGenerationCancelDoesNotClearNewSlot() {
+        val ops = PendingOperations()
+        val first = CompletableDeferred<GattStatus>()
+        val firstGen = ops.set(PendingOp.CharacteristicWrite, first)
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+
+        val second = CompletableDeferred<GattStatus>()
+        ops.set(PendingOp.CharacteristicWrite, second)
+
+        // A stray cancel carrying the OLD generation must not clear the new slot.
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        assertTrue(second.isCompleted)
+    }
+
+    @Test
+    fun cancelAllFailsAllPending() {
+        val ops = PendingOperations()
+        val deferred = CompletableDeferred<GattStatus>()
+        ops.set(PendingOp.CharacteristicWrite, deferred)
+
+        ops.cancelAll(RuntimeException("disconnected"))
+
+        assertTrue(deferred.isCompleted && deferred.getCompletionExceptionOrNull() != null)
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
@@ -7,24 +7,46 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
 
+/**
+ * Common behavior of [Peripheral.writeReliable].
+ *
+ * NOTE: these tests exercise the common API surface through [FakePeripheral],
+ * which delegates writeReliable to its plain write handler. The Android native
+ * reliable-write flow (AndroidPeripheralReliableWrite + AndroidGattBridge +
+ * onReliableWriteCompleted dispatch) has no unit coverage -- it requires an
+ * instrumented/device test against real BluetoothGatt reliable-write behavior,
+ * tracked separately. See PR #625 verification note.
+ */
 @OptIn(ExperimentalUuidApi::class)
 class WriteReliableTest {
-    private fun createPeripheral(): FakePeripheral =
-        FakePeripheral {
-            service("180d") {
-                characteristic("2a37") {
-                    properties(read = true, write = true)
-                    onWrite { data, _ ->
-                        assertTrue(data.isNotEmpty())
-                    }
+    @Test
+    fun fakePeripheralReportsSupportsReliableWrite() {
+        val peripheral =
+            FakePeripheral {
+                service("180d") {
+                    characteristic("2a37") { properties(read = true, write = true) }
                 }
             }
-        }
+        assertTrue(peripheral.supportsReliableWrite, "fake defaults to Android-like atomic support")
+    }
 
     @Test
-    fun writeReliableWritesSingleChunkData() =
+    fun writeReliableSingleChunkDeliversExactData() =
         runTest {
-            val peripheral = createPeripheral()
+            var received: ByteArray? = null
+            var writeCount = 0
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true, write = true)
+                            onWrite { data, _ ->
+                                received = data
+                                writeCount++
+                            }
+                        }
+                    }
+                }
             peripheral.connect()
             val char =
                 peripheral
@@ -38,34 +60,14 @@ class WriteReliableTest {
             val data = byteArrayOf(0x01, 0x02, 0x03)
             peripheral.writeReliable(char, data)
 
+            assertEquals(1, writeCount, "single-chunk value must be written exactly once")
+            assertEquals(data.toList(), received?.toList())
             peripheral.disconnect()
             peripheral.close()
         }
 
     @Test
-    fun writeReliableAcceptsLargeData() =
-        runTest {
-            val peripheral = createPeripheral()
-            peripheral.connect()
-            val char =
-                peripheral
-                    .services
-                    .value
-                    .orEmpty()
-                    .first()
-                    .characteristics
-                    .first()
-
-            // Larger than the fake's default 20-byte max write length.
-            val data = ByteArray(200) { it.toByte() }
-            peripheral.writeReliable(char, data)
-
-            peripheral.disconnect()
-            peripheral.close()
-        }
-
-    @Test
-    fun writeReliableRecordsDataInHandler() =
+    fun writeReliableLargeDataPassesThrough() =
         runTest {
             var received: ByteArray? = null
             val peripheral =
@@ -87,9 +89,11 @@ class WriteReliableTest {
                     .characteristics
                     .first()
 
-            val data = byteArrayOf(0x0A, 0x0B, 0x0C)
+            val data = ByteArray(200) { it.toByte() }
             peripheral.writeReliable(char, data)
 
+            // The fake does not chunk (real platforms do via LargeWriteHandler), so
+            // the handler sees the full payload in one call -- asserts pass-through.
             assertEquals(data.toList(), received?.toList())
             peripheral.disconnect()
             peripheral.close()

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
@@ -1,0 +1,127 @@
+package com.atruedev.kmpble.peripheral
+
+import com.atruedev.kmpble.testing.FakePeripheral
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+
+@OptIn(ExperimentalUuidApi::class)
+class WriteReliableTest {
+    private fun createPeripheral(): FakePeripheral =
+        FakePeripheral {
+            service("180d") {
+                characteristic("2a37") {
+                    properties(read = true, write = true)
+                    onWrite { data, _ ->
+                        assertTrue(data.isNotEmpty())
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun writeReliableWritesSingleChunkData() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+            val char =
+                peripheral
+                    .services
+                    .value
+                    .orEmpty()
+                    .first()
+                    .characteristics
+                    .first()
+
+            val data = byteArrayOf(0x01, 0x02, 0x03)
+            peripheral.writeReliable(char, data)
+
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun writeReliableAcceptsLargeData() =
+        runTest {
+            val peripheral = createPeripheral()
+            peripheral.connect()
+            val char =
+                peripheral
+                    .services
+                    .value
+                    .orEmpty()
+                    .first()
+                    .characteristics
+                    .first()
+
+            // Larger than the fake's default 20-byte max write length.
+            val data = ByteArray(200) { it.toByte() }
+            peripheral.writeReliable(char, data)
+
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun writeReliableRecordsDataInHandler() =
+        runTest {
+            var received: ByteArray? = null
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true, write = true)
+                            onWrite { data, _ -> received = data }
+                        }
+                    }
+                }
+            peripheral.connect()
+            val char =
+                peripheral
+                    .services
+                    .value
+                    .orEmpty()
+                    .first()
+                    .characteristics
+                    .first()
+
+            val data = byteArrayOf(0x0A, 0x0B, 0x0C)
+            peripheral.writeReliable(char, data)
+
+            assertEquals(data.toList(), received?.toList())
+            peripheral.disconnect()
+            peripheral.close()
+        }
+
+    @Test
+    fun writeReliableRejectsWhenCharacteristicNotWritable() =
+        runTest {
+            val peripheral =
+                FakePeripheral {
+                    service("180d") {
+                        characteristic("2a37") {
+                            properties(read = true) // no write property
+                        }
+                    }
+                }
+            peripheral.connect()
+            val char =
+                peripheral
+                    .services
+                    .value
+                    .orEmpty()
+                    .first()
+                    .characteristics
+                    .first()
+
+            val result =
+                runCatching {
+                    peripheral.writeReliable(char, byteArrayOf(0x01))
+                }
+            assertTrue(result.isFailure, "write to non-writable characteristic must fail")
+            peripheral.disconnect()
+            peripheral.close()
+        }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/peripheral/WriteReliableTest.kt
@@ -4,49 +4,40 @@ import com.atruedev.kmpble.testing.FakePeripheral
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 import kotlin.uuid.ExperimentalUuidApi
 
 /**
- * Common behavior of [Peripheral.writeReliable].
+ * Common contract of [Peripheral.supportsReliableWrite] / [Peripheral.writeReliable].
  *
- * NOTE: these tests exercise the common API surface through [FakePeripheral],
- * which delegates writeReliable to its plain write handler. The Android native
- * reliable-write flow (AndroidPeripheralReliableWrite + AndroidGattBridge +
- * onReliableWriteCompleted dispatch) has no unit coverage -- it requires an
- * instrumented/device test against real BluetoothGatt reliable-write behavior,
- * tracked separately. See PR #625 verification note.
+ * The fake honestly reports NO reliable-write support (it delegates to the plain
+ * write handler and cannot be atomic), so these tests pin the honest contract:
+ * fake behaves like iOS -- supportsReliableWrite = false, writeReliable throws.
+ *
+ * The Android native reliable-write flow (AndroidPeripheralReliableWrite +
+ * AndroidGattBridge + onReliableWriteCompleted dispatch) requires an
+ * instrumented/device test against real BluetoothGatt reliable-write behavior;
+ * tracked separately (see PR #625).
  */
 @OptIn(ExperimentalUuidApi::class)
 class WriteReliableTest {
-    @Test
-    fun fakePeripheralReportsSupportsReliableWrite() {
-        val peripheral =
-            FakePeripheral {
-                service("180d") {
-                    characteristic("2a37") { properties(read = true, write = true) }
-                }
+    private fun createPeripheral(): FakePeripheral =
+        FakePeripheral {
+            service("180d") {
+                characteristic("2a37") { properties(read = true, write = true) }
             }
-        assertTrue(peripheral.supportsReliableWrite, "fake defaults to Android-like atomic support")
+        }
+
+    @Test
+    fun fakeReportsNoReliableWriteSupport() {
+        val peripheral = createPeripheral()
+        assertEquals(false, peripheral.supportsReliableWrite)
     }
 
     @Test
-    fun writeReliableSingleChunkDeliversExactData() =
+    fun writeReliableThrowsOnUnsupportedFake() =
         runTest {
-            var received: ByteArray? = null
-            var writeCount = 0
-            val peripheral =
-                FakePeripheral {
-                    service("180d") {
-                        characteristic("2a37") {
-                            properties(read = true, write = true)
-                            onWrite { data, _ ->
-                                received = data
-                                writeCount++
-                            }
-                        }
-                    }
-                }
+            val peripheral = createPeripheral()
             peripheral.connect()
             val char =
                 peripheral
@@ -57,17 +48,15 @@ class WriteReliableTest {
                     .characteristics
                     .first()
 
-            val data = byteArrayOf(0x01, 0x02, 0x03)
-            peripheral.writeReliable(char, data)
-
-            assertEquals(1, writeCount, "single-chunk value must be written exactly once")
-            assertEquals(data.toList(), received?.toList())
+            assertFailsWith<UnsupportedOperationException> {
+                peripheral.writeReliable(char, byteArrayOf(0x01))
+            }
             peripheral.disconnect()
             peripheral.close()
         }
 
     @Test
-    fun writeReliableLargeDataPassesThrough() =
+    fun regularWriteStillWorksOnFake() =
         runTest {
             var received: ByteArray? = null
             val peripheral =
@@ -89,42 +78,10 @@ class WriteReliableTest {
                     .characteristics
                     .first()
 
-            val data = ByteArray(200) { it.toByte() }
-            peripheral.writeReliable(char, data)
+            val data = byteArrayOf(0x01, 0x02, 0x03)
+            peripheral.write(char, data, com.atruedev.kmpble.gatt.WriteType.WithResponse)
 
-            // The fake does not chunk (real platforms do via LargeWriteHandler), so
-            // the handler sees the full payload in one call -- asserts pass-through.
             assertEquals(data.toList(), received?.toList())
-            peripheral.disconnect()
-            peripheral.close()
-        }
-
-    @Test
-    fun writeReliableRejectsWhenCharacteristicNotWritable() =
-        runTest {
-            val peripheral =
-                FakePeripheral {
-                    service("180d") {
-                        characteristic("2a37") {
-                            properties(read = true) // no write property
-                        }
-                    }
-                }
-            peripheral.connect()
-            val char =
-                peripheral
-                    .services
-                    .value
-                    .orEmpty()
-                    .first()
-                    .characteristics
-                    .first()
-
-            val result =
-                runCatching {
-                    peripheral.writeReliable(char, byteArrayOf(0x01))
-                }
-            assertTrue(result.isFailure, "write to non-writable characteristic must fail")
             peripheral.disconnect()
             peripheral.close()
         }

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -190,6 +190,18 @@ public class IosPeripheral(
         writeGatt(characteristic, data, writeType)
     }
 
+    /**
+     * CoreBluetooth exposes no public prepared-write API, so this falls back to
+     * sequential chunked [WriteType.WithResponse] writes -- NOT atomic. See the
+     * interface KDoc for the platform-limitation discussion.
+     */
+    override suspend fun writeReliable(
+        characteristic: Characteristic,
+        data: ByteArray,
+    ) {
+        writeGatt(characteristic, data, WriteType.WithResponse)
+    }
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheral.kt
@@ -84,6 +84,7 @@ public class IosPeripheral(
     internal val bondManager = IosBondManager(peripheralContext)
     override val services: StateFlow<List<DiscoveredService>?> get() = peripheralContext.services
     override val maximumWriteValueLength: StateFlow<Int> get() = peripheralContext.maximumWriteValueLength
+    override val supportsReliableWrite: Boolean get() = false
     override val mtu: StateFlow<Int> get() = peripheralContext.mtu
     internal var _lastConnectionOptions: ConnectionOptions? = null
     override val lastConnectionOptions: ConnectionOptions? get() = _lastConnectionOptions
@@ -191,16 +192,18 @@ public class IosPeripheral(
     }
 
     /**
-     * CoreBluetooth exposes no public prepared-write API, so this falls back to
-     * sequential chunked [WriteType.WithResponse] writes -- NOT atomic. See the
-     * interface KDoc for the platform-limitation discussion.
+     * CoreBluetooth exposes no public prepared-write API. Throws instead of
+     * silently degrading to non-atomic chunked writes -- check
+     * [supportsReliableWrite] (false on iOS) and use [write] instead.
      */
     override suspend fun writeReliable(
         characteristic: Characteristic,
         data: ByteArray,
-    ) {
-        writeGatt(characteristic, data, WriteType.WithResponse)
-    }
+    ): Nothing =
+        throw UnsupportedOperationException(
+            "writeReliable is not supported on iOS: CoreBluetooth has no public " +
+                "prepared-write API. Check Peripheral.supportsReliableWrite and use write().",
+        )
 
     override fun observe(
         characteristic: Characteristic,

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -311,13 +311,13 @@ class IosGattEventHandlerTest {
     }
 
     @Test
-    fun `pendingOps clear resets all state`() =
+    fun `pendingOps cancel clears its own slot`() =
         runTest {
             val ops = PendingOperations()
             val deferred = CompletableDeferred<GattStatus>()
-            ops.set(PendingOp.CharacteristicWrite, deferred)
+            val generation = ops.set(PendingOp.CharacteristicWrite, deferred)
 
-            ops.clear(PendingOp.CharacteristicWrite)
+            ops.cancel(PendingOp.CharacteristicWrite, generation)
             assertFalse(ops.has(PendingOp.CharacteristicWrite))
         }
 }

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -49,6 +49,7 @@ internal class StubPeripheral(
     override val encryptionLevel: StateFlow<EncryptionLevel> = MutableStateFlow(EncryptionLevel.NONE)
     override val services: StateFlow<List<DiscoveredService>?> = MutableStateFlow(null)
     override val maximumWriteValueLength: StateFlow<Int> = MutableStateFlow(20)
+    override val supportsReliableWrite: Boolean = false
     override val mtu: StateFlow<Int> = MutableStateFlow(23)
     override val lastConnectionOptions: ConnectionOptions? = null
 

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/lincheck/StubPeripheral.kt
@@ -81,6 +81,11 @@ internal class StubPeripheral(
         writeType: WriteType,
     ) = unsupported()
 
+    override suspend fun writeReliable(
+        characteristic: Characteristic,
+        data: ByteArray,
+    ) = unsupported()
+
     override fun observe(
         characteristic: Characteristic,
         backpressure: BackpressureStrategy,


### PR DESCRIPTION
## Summary

Adds Peripheral.writeReliable(characteristic, data) -- atomic long writes via GATT prepared-write + execute, plus Peripheral.supportsReliableWrite for platform capability detection.

Fixes #450.

## API

```kotlin
val Peripheral.supportsReliableWrite: Boolean  // true Android, false iOS

suspend fun Peripheral.writeReliable(
    characteristic: Characteristic,
    data: ByteArray,
)
```

## Platform behavior

| Platform | Behavior |
|----------|----------|
| Android | Atomic: beginReliableWrite -> per-chunk writes (each acked) -> executeReliableWrite -> onReliableWriteCompleted. ANY failure incl. cancellation aborts (abortReliableWrite); nothing committed. supportsReliableWrite = true |
| iOS | CoreBluetooth has no public prepared-write API. writeReliable THROWS UnsupportedOperationException; supportsReliableWrite = false. Callers branch on it and use write() instead |

Single-chunk values use a plain WithResponse write. Whole-transaction timeout: OperationTimeouts.reliableWrite (default 30s).

## Review round 2 -- all 9 findings addressed

1. critical: cancellation now aborts (single catch Throwable -> abort + rethrow; CancellationException is a Throwable)
2. design: transaction uses dedicated reliableWrite timeout (30s), not the 5s write timeout
3. design: iOS no longer fakes reliability -- throws + supportsReliableWrite for call-time branching
4. doc: KDoc drops the false multi-characteristic claim
5. test: WriteReliableTest asserts real behavior; Android native path flagged for device/instrumented test (no unit coverage possible through FakePeripheral)
6. nit: awaitGatt arms ReliableWriteCompleted before execute via real submit initiator
7. nit: @Suppress(DEPRECATION) on all three reliable-write bridge methods
8. doc: abort is best-effort, does not throw; hung-device session stays open until disconnect (documented limitation)
9. docs: api-quick-reference.md documents writeReliable + platform split

## Verification note

Android reliable-write flow (per-chunk onCharacteristicWrite during session, onReliableWriteCompleted on execute) follows AOSP behavior but needs device verification -- tracked as instrumented/device test before 1.0 release.