### PR TITLE
fix(gatt): make PendingOperations.complete generation-aware

### DIFF
--- a/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpble/peripheral/AndroidPeripheralGattHandler.kt
@@ -19,6 +19,7 @@ import com.atruedev.kmpble.gatt.internal.DISABLE_NOTIFICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.ENABLE_INDICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.ENABLE_NOTIFICATION_VALUE
 import com.atruedev.kmpble.gatt.internal.GattResult
+import com.atruedev.kmpble.gatt.internal.GenerationSnapshot
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.gatt.internal.PhyUpdateResult
 import com.atruedev.kmpble.peripheral.internal.awaitGatt
@@ -34,20 +35,35 @@ import kotlin.uuid.Uuid
  */
 
 internal fun AndroidPeripheral.handleGattEvent(event: GattCallbackEvent) {
+    // Runs on the platform callback thread. Stamp the armed generation per op
+    // BEFORE dispatch: the launch below executes later on the serialized
+    // dispatcher, where a retry may have re-armed a slot. Completing with the
+    // stamped generation makes a stale callback no-op instead of clobbering the
+    // retry (see PendingOperations).
+    val generations = pendingOps.generationSnapshot()
     peripheralContext.scope.launch {
         when (event) {
             is GattCallbackEvent.ConnectionStateChanged -> handleConnectionStateChanged(event)
             is GattCallbackEvent.ServicesDiscovered -> handleServicesDiscovered(event)
-            is GattCallbackEvent.MtuChanged -> handleMtuChanged(event)
+            is GattCallbackEvent.MtuChanged -> handleMtuChanged(event, generations)
             is GattCallbackEvent.CharacteristicRead ->
                 pendingOps.complete(
                     PendingOp.CharacteristicRead,
+                    generations[PendingOp.CharacteristicRead],
                     GattResult(event.value, event.status.toGattStatus()),
                 )
             is GattCallbackEvent.CharacteristicWrite ->
-                pendingOps.complete(PendingOp.CharacteristicWrite, event.status.toGattStatus())
+                pendingOps.complete(
+                    PendingOp.CharacteristicWrite,
+                    generations[PendingOp.CharacteristicWrite],
+                    event.status.toGattStatus(),
+                )
             is GattCallbackEvent.ReliableWriteCompleted ->
-                pendingOps.complete(PendingOp.ReliableWriteCompleted, event.status.toGattStatus())
+                pendingOps.complete(
+                    PendingOp.ReliableWriteCompleted,
+                    generations[PendingOp.ReliableWriteCompleted],
+                    event.status.toGattStatus(),
+                )
             is GattCallbackEvent.CharacteristicChanged -> {
                 val charUuid = Uuid.parse(event.characteristic.uuid.toString())
                 val serviceUuid =
@@ -60,14 +76,19 @@ internal fun AndroidPeripheral.handleGattEvent(event: GattCallbackEvent) {
             is GattCallbackEvent.DescriptorRead ->
                 pendingOps.complete(
                     PendingOp.DescriptorRead,
+                    generations[PendingOp.DescriptorRead],
                     GattResult(event.value, event.status.toGattStatus()),
                 )
             is GattCallbackEvent.DescriptorWrite ->
-                pendingOps.complete(PendingOp.DescriptorWrite, event.status.toGattStatus())
-            is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event)
-            is GattCallbackEvent.PhyUpdated -> handlePhyUpdated(event)
-            is GattCallbackEvent.PhyRead -> handlePhyRead(event)
-            is GattCallbackEvent.SubrateChanged -> handleSubrateChanged(event)
+                pendingOps.complete(
+                    PendingOp.DescriptorWrite,
+                    generations[PendingOp.DescriptorWrite],
+                    event.status.toGattStatus(),
+                )
+            is GattCallbackEvent.ReadRemoteRssi -> handleRssiResult(event, generations)
+            is GattCallbackEvent.PhyUpdated -> handlePhyUpdated(event, generations)
+            is GattCallbackEvent.PhyRead -> handlePhyRead(event, generations)
+            is GattCallbackEvent.SubrateChanged -> handleSubrateChanged(event, generations)
         }
     }
 }
@@ -98,21 +119,34 @@ internal suspend fun AndroidPeripheral.resubscribeObservations() {
     }
 }
 
-internal suspend fun AndroidPeripheral.handleMtuChanged(event: GattCallbackEvent.MtuChanged) {
+internal suspend fun AndroidPeripheral.handleMtuChanged(
+    event: GattCallbackEvent.MtuChanged,
+    generations: GenerationSnapshot,
+) {
     if (event.status.toGattStatus().isSuccess()) peripheralContext.updateMtu(event.mtu)
-    pendingOps.complete(PendingOp.MtuRequest, event.mtu)
+    pendingOps.complete(PendingOp.MtuRequest, generations[PendingOp.MtuRequest], event.mtu)
 }
 
-internal fun AndroidPeripheral.handleRssiResult(event: GattCallbackEvent.ReadRemoteRssi) {
+internal fun AndroidPeripheral.handleRssiResult(
+    event: GattCallbackEvent.ReadRemoteRssi,
+    generations: GenerationSnapshot,
+) {
     val status = event.status.toGattStatus()
     if (status.isSuccess()) {
-        pendingOps.complete(PendingOp.RssiRead, event.rssi)
+        pendingOps.complete(PendingOp.RssiRead, generations[PendingOp.RssiRead], event.rssi)
     } else {
-        pendingOps.fail(PendingOp.RssiRead, BleException(GattError("readRssi", status)))
+        pendingOps.fail(
+            PendingOp.RssiRead,
+            generations[PendingOp.RssiRead],
+            BleException(GattError("readRssi", status)),
+        )
     }
 }
 
-internal fun AndroidPeripheral.handlePhyUpdated(event: GattCallbackEvent.PhyUpdated) {
+internal fun AndroidPeripheral.handlePhyUpdated(
+    event: GattCallbackEvent.PhyUpdated,
+    generations: GenerationSnapshot,
+) {
     val status = event.status.toGattStatus()
     val phyUpdate =
         PhyUpdate(
@@ -122,6 +156,7 @@ internal fun AndroidPeripheral.handlePhyUpdated(event: GattCallbackEvent.PhyUpda
     if (pendingOps.has(PendingOp.PhyUpdate)) {
         pendingOps.complete(
             PendingOp.PhyUpdate,
+            generations[PendingOp.PhyUpdate],
             PhyUpdateResult(
                 txPhyConstant = event.txPhy,
                 rxPhyConstant = event.rxPhy,
@@ -132,11 +167,15 @@ internal fun AndroidPeripheral.handlePhyUpdated(event: GattCallbackEvent.PhyUpda
     _phyUpdate.tryEmit(phyUpdate)
 }
 
-internal fun AndroidPeripheral.handlePhyRead(event: GattCallbackEvent.PhyRead) {
+internal fun AndroidPeripheral.handlePhyRead(
+    event: GattCallbackEvent.PhyRead,
+    generations: GenerationSnapshot,
+) {
     if (pendingOps.has(PendingOp.PhyRead)) {
         val status = event.status.toGattStatus()
         pendingOps.complete(
             PendingOp.PhyRead,
+            generations[PendingOp.PhyRead],
             PhyUpdateResult(
                 txPhyConstant = event.txPhy,
                 rxPhyConstant = event.rxPhy,
@@ -146,12 +185,16 @@ internal fun AndroidPeripheral.handlePhyRead(event: GattCallbackEvent.PhyRead) {
     }
 }
 
-internal fun AndroidPeripheral.handleSubrateChanged(event: GattCallbackEvent.SubrateChanged) {
+internal fun AndroidPeripheral.handleSubrateChanged(
+    event: GattCallbackEvent.SubrateChanged,
+    generations: GenerationSnapshot,
+) {
     val status = event.status.toGattStatus()
     if (pendingOps.has(PendingOp.SubrateRequest)) {
         if (status.isSuccess()) {
             pendingOps.complete(
                 PendingOp.SubrateRequest,
+                generations[PendingOp.SubrateRequest],
                 ConnectionSubratingResult.Accepted(
                     ConnectionSubratingParameters(
                         subrateFactor = event.subrateFactor,
@@ -164,6 +207,7 @@ internal fun AndroidPeripheral.handleSubrateChanged(event: GattCallbackEvent.Sub
         } else {
             pendingOps.complete(
                 PendingOp.SubrateRequest,
+                generations[PendingOp.SubrateRequest],
                 ConnectionSubratingResult.Rejected("status=$status"),
             )
         }

--- a/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperation.kt
@@ -2,6 +2,8 @@ package com.atruedev.kmpble.gatt.internal
 
 import com.atruedev.kmpble.connection.ConnectionSubratingResult
 import com.atruedev.kmpble.error.GattStatus
+import kotlinx.atomicfu.AtomicLong
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 
 internal data class GattResult(
@@ -41,7 +43,30 @@ internal sealed interface PendingOp<T> {
     data object PhyRead : PendingOp<PhyUpdateResult>
 
     data object SubrateRequest : PendingOp<ConnectionSubratingResult>
+
+    companion object {
+        val all: List<PendingOp<*>> =
+            listOf(
+                CharacteristicRead,
+                CharacteristicWrite,
+                ReliableWriteCompleted,
+                DescriptorRead,
+                DescriptorWrite,
+                RssiRead,
+                MtuRequest,
+                PhyUpdate,
+                PhyRead,
+                SubrateRequest,
+            )
+    }
 }
+
+/**
+ * Armed-generation stamp for every op type, captured at event receipt (on the
+ * platform callback thread) before the event is dispatched onto the peripheral's
+ * serialized dispatcher.
+ */
+internal typealias GenerationSnapshot = Map<PendingOp<*>, Long?>
 
 internal data class PhyUpdateResult(
     val txPhyConstant: Int,
@@ -54,26 +79,31 @@ internal data class PhyUpdateResult(
  * generation token so a cancelled op cannot clobber a retry of the same type.
  *
  * Confined to the owning peripheral's serialized dispatcher
- * (`limitedParallelism(1)`) - no synchronization required.
+ * (`limitedParallelism(1)`) - no synchronization required. The one exception is
+ * [generationOf]/[generationSnapshot], which read [armedGenerations] (an
+ * atomicfu view kept in sync with the slots) from the platform callback thread
+ * so callback events can be stamped before dispatch.
  *
- * ## Cancellation safety
+ * ## Cancellation and staleness safety
  *
  * The GATT operation queue cancels in-flight actions when the caller's coroutine
  * is cancelled or times out (see [GattOperationQueue]). [awaitGatt] responds by
  * calling [cancel] with its generation token, which removes the slot. Without
  * this, a cancelled op would leave its slot armed forever -- the next operation
  * of the same type would then crash in [set] with
- * "overwritten while pending", and a late platform callback would complete into
- * a freshly-armed retry slot.
+ * "overwritten while pending".
  *
- * A callback that arrives after its op was cancelled no-ops UNLESS a retry of
- * the same type has already re-armed the slot: [complete] is not generation
- * aware, so a stale callback would complete the retry's deferred. In practice
- * the callback is dispatched from the platform callback thread onto the same
- * serialized dispatcher well before a user retry can re-arm (the retry path
- * crosses enqueue -> drain -> block -> set), so the race window is effectively
- * theoretical -- but it exists. Closing it fully requires generation-aware
- * [complete], tracked in the backlog.
+ * [complete] and [fail] are generation-aware in the same way as [cancel]: the
+ * callback handlers stamp each event with the generation armed when the event
+ * was RECEIVED ([generationSnapshot], before the event is dispatched) and pass
+ * it back here. A callback for a cancelled op therefore no-ops even when its
+ * dispatch onto the serialized dispatcher runs after a retry already re-armed
+ * the slot -- the stale callback can no longer complete the retry's deferred.
+ * Residual window: if the retry's `set` executes before the platform even
+ * delivers the stale response, the snapshot carries the retry's generation and
+ * the response is indistinguishable from the retry's own; the platform
+ * serializes responses in submission order, so this is the next response the
+ * retry would have consumed anyway.
  */
 internal class PendingOperations {
     private class Slot(
@@ -83,6 +113,14 @@ internal class PendingOperations {
 
     private val slots = mutableMapOf<PendingOp<*>, Slot>()
     private var nextGeneration = 0L
+
+    /**
+     * Thread-safe mirror of the armed generation per op type, readable from the
+     * platform callback thread to stamp events before dispatch. [NO_SLOT] when
+     * no slot is armed. Written only by the dispatcher-confined mutations below.
+     */
+    private val armedGenerations: Map<PendingOp<*>, AtomicLong> =
+        PendingOp.all.associateWith { atomic(NO_SLOT) }
 
     /**
      * Arm a pending slot. Returns the generation token the caller must pass to
@@ -95,6 +133,7 @@ internal class PendingOperations {
         check(op !in slots) { "${op::class.simpleName} overwritten while pending" }
         val generation = nextGeneration++
         slots[op] = Slot(deferred, generation)
+        armedGenerations.getValue(op).value = generation
         return generation
     }
 
@@ -111,24 +150,54 @@ internal class PendingOperations {
         val slot = slots[op] ?: return
         if (slot.generation != generation) return
         slots.remove(op)
+        armedGenerations.getValue(op).value = NO_SLOT
     }
 
     fun has(op: PendingOp<*>): Boolean = op in slots
 
+    /** Armed generation for [op], or null when no slot is armed. */
+    fun generationOf(op: PendingOp<*>): Long? = armedGenerations.getValue(op).value.takeIf { it != NO_SLOT }
+
+    /**
+     * Armed generation for every op type at the moment of the call. Invoked on
+     * the platform callback thread before the event is dispatched onto the
+     * serialized dispatcher: the stamped generation is what the callback
+     * belongs to, so a slot re-armed later by a retry cannot be completed by a
+     * stale callback.
+     */
+    fun generationSnapshot(): GenerationSnapshot = PendingOp.all.associateWith { generationOf(it) }
+
+    /**
+     * Complete the slot for [op] only if it still holds [generation] -- the
+     * generation stamped onto the event at receipt time. Null when no slot was
+     * armed at receipt: the callback is stale and must no-op even if a retry
+     * re-armed the slot before this ran.
+     */
     fun <T> complete(
         op: PendingOp<T>,
+        generation: Long?,
         value: T,
     ) {
+        val slot = slots[op] ?: return
+        if (generation == null || slot.generation != generation) return
+        slots.remove(op)
+        armedGenerations.getValue(op).value = NO_SLOT
         @Suppress("UNCHECKED_CAST")
-        (slots.remove(op)?.deferred as? CompletableDeferred<T>)?.complete(value)
+        (slot.deferred as? CompletableDeferred<T>)?.complete(value)
     }
 
+    /** Generation-guarded failure; same staleness semantics as [complete]. */
     fun fail(
         op: PendingOp<*>,
+        generation: Long?,
         cause: Throwable,
     ) {
+        val slot = slots[op] ?: return
+        if (generation == null || slot.generation != generation) return
+        slots.remove(op)
+        armedGenerations.getValue(op).value = NO_SLOT
         @Suppress("UNCHECKED_CAST")
-        (slots.remove(op)?.deferred as? CompletableDeferred<Any?>)?.completeExceptionally(cause)
+        (slot.deferred as? CompletableDeferred<Any?>)?.completeExceptionally(cause)
     }
 
     fun cancelAll(cause: Throwable) {
@@ -137,5 +206,10 @@ internal class PendingOperations {
             (slot.deferred as? CompletableDeferred<Any?>)?.completeExceptionally(cause)
         }
         slots.clear()
+        armedGenerations.values.forEach { it.value = NO_SLOT }
+    }
+
+    private companion object {
+        const val NO_SLOT = -1L
     }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperationsTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpble/gatt/internal/PendingOperationsTest.kt
@@ -27,8 +27,8 @@ class PendingOperationsTest {
         // The cancellation-safe contract: a retry of the same op type must be
         // able to arm a fresh slot (this crashed before the generation token).
         val second = CompletableDeferred<GattStatus>()
-        ops.set(PendingOp.CharacteristicWrite, second)
-        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        val secondGen = ops.set(PendingOp.CharacteristicWrite, second)
+        ops.complete(PendingOp.CharacteristicWrite, secondGen, GattStatus.Success)
         assertTrue(second.isCompleted)
     }
 
@@ -39,10 +39,69 @@ class PendingOperationsTest {
         val generation = ops.set(PendingOp.CharacteristicWrite, deferred)
         ops.cancel(PendingOp.CharacteristicWrite, generation)
 
-        // A platform callback arriving after the op was cancelled must not
-        // complete the (already abandoned) deferred.
-        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        // A platform callback arriving after the op was cancelled carries no
+        // armed generation (the handler stamps null) and must not complete the
+        // (already abandoned) deferred.
+        ops.complete(PendingOp.CharacteristicWrite, null, GattStatus.Success)
         assertFalse(deferred.isCompleted)
+    }
+
+    @Test
+    fun staleCallbackAfterRetryReArmDoesNotCompleteRetry() {
+        val ops = PendingOperations()
+        val first = CompletableDeferred<GattStatus>()
+        val firstGen = ops.set(PendingOp.CharacteristicWrite, first)
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+
+        // Retry re-arms the slot before the stale callback's dispatch runs.
+        val retry = CompletableDeferred<GattStatus>()
+        val retryGen = ops.set(PendingOp.CharacteristicWrite, retry)
+
+        // The stale callback was received while no slot was armed, so the
+        // handler stamped null: it must not complete, let alone clear, the
+        // retry's slot.
+        ops.complete(PendingOp.CharacteristicWrite, null, GattStatus.Success)
+        assertFalse(retry.isCompleted)
+        assertTrue(ops.has(PendingOp.CharacteristicWrite))
+
+        // The retry's own response still completes it.
+        ops.complete(PendingOp.CharacteristicWrite, retryGen, GattStatus.Success)
+        assertTrue(retry.isCompleted)
+    }
+
+    @Test
+    fun staleGenerationCompleteDoesNotClearNewSlot() {
+        val ops = PendingOperations()
+        val first = CompletableDeferred<GattStatus>()
+        val firstGen = ops.set(PendingOp.CharacteristicWrite, first)
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+
+        val retry = CompletableDeferred<GattStatus>()
+        ops.set(PendingOp.CharacteristicWrite, retry)
+
+        // A completion carrying the OLD generation must not clear the new slot.
+        ops.complete(PendingOp.CharacteristicWrite, firstGen, GattStatus.Success)
+        assertFalse(retry.isCompleted)
+        assertTrue(ops.has(PendingOp.CharacteristicWrite))
+    }
+
+    @Test
+    fun staleGenerationFailDoesNotClearNewSlot() {
+        val ops = PendingOperations()
+        val first = CompletableDeferred<GattStatus>()
+        val firstGen = ops.set(PendingOp.CharacteristicWrite, first)
+        ops.cancel(PendingOp.CharacteristicWrite, firstGen)
+
+        val retry = CompletableDeferred<GattStatus>()
+        val retryGen = ops.set(PendingOp.CharacteristicWrite, retry)
+
+        // A failure carrying the OLD generation must not clear the new slot.
+        ops.fail(PendingOp.CharacteristicWrite, firstGen, RuntimeException("stale"))
+        assertFalse(retry.isCompleted)
+        assertTrue(ops.has(PendingOp.CharacteristicWrite))
+
+        ops.complete(PendingOp.CharacteristicWrite, retryGen, GattStatus.Success)
+        assertTrue(retry.isCompleted)
     }
 
     @Test
@@ -53,11 +112,11 @@ class PendingOperationsTest {
         ops.cancel(PendingOp.CharacteristicWrite, firstGen)
 
         val second = CompletableDeferred<GattStatus>()
-        ops.set(PendingOp.CharacteristicWrite, second)
+        val secondGen = ops.set(PendingOp.CharacteristicWrite, second)
 
         // A stray cancel carrying the OLD generation must not clear the new slot.
         ops.cancel(PendingOp.CharacteristicWrite, firstGen)
-        ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+        ops.complete(PendingOp.CharacteristicWrite, secondGen, GattStatus.Success)
         assertTrue(second.isCompleted)
     }
 

--- a/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpble/peripheral/IosPeripheralBridgeHandlers.kt
@@ -3,6 +3,7 @@ package com.atruedev.kmpble.peripheral
 import com.atruedev.kmpble.error.BleException
 import com.atruedev.kmpble.error.GattError
 import com.atruedev.kmpble.gatt.internal.GattResult
+import com.atruedev.kmpble.gatt.internal.GenerationSnapshot
 import com.atruedev.kmpble.gatt.internal.PendingOp
 import com.atruedev.kmpble.scanner.uuidFrom
 import kotlinx.coroutines.launch
@@ -13,17 +14,31 @@ import platform.Foundation.NSData
  */
 
 internal fun IosPeripheral.handleBridgeEvent(event: AppleCallbackEvent) {
+    // Runs on the CoreBluetooth delegate queue. Stamp the armed generation per
+    // op BEFORE dispatch: the launch below executes later on the serialized
+    // dispatcher, where a retry may have re-armed a slot. Completing with the
+    // stamped generation makes a stale callback no-op instead of clobbering the
+    // retry (see PendingOperations).
+    val generations = pendingOps.generationSnapshot()
     peripheralContext.scope.launch {
         when (event) {
             is AppleCallbackEvent.DidDiscoverServices -> handleServicesDiscovered(event)
             is AppleCallbackEvent.DidDiscoverCharacteristics -> handleCharacteristicsDiscovered(event)
-            is AppleCallbackEvent.DidUpdateValueForCharacteristic -> handleCharacteristicValue(event)
+            is AppleCallbackEvent.DidUpdateValueForCharacteristic -> handleCharacteristicValue(event, generations)
             is AppleCallbackEvent.DidWriteValueForCharacteristic ->
-                pendingOps.complete(PendingOp.CharacteristicWrite, event.error.toGattStatus())
-            is AppleCallbackEvent.DidUpdateValueForDescriptor -> handleDescriptorValue(event)
+                pendingOps.complete(
+                    PendingOp.CharacteristicWrite,
+                    generations[PendingOp.CharacteristicWrite],
+                    event.error.toGattStatus(),
+                )
+            is AppleCallbackEvent.DidUpdateValueForDescriptor -> handleDescriptorValue(event, generations)
             is AppleCallbackEvent.DidWriteValueForDescriptor ->
-                pendingOps.complete(PendingOp.DescriptorWrite, event.error.toGattStatus())
-            is AppleCallbackEvent.DidReadRSSI -> handleRssi(event)
+                pendingOps.complete(
+                    PendingOp.DescriptorWrite,
+                    generations[PendingOp.DescriptorWrite],
+                    event.error.toGattStatus(),
+                )
+            is AppleCallbackEvent.DidReadRSSI -> handleRssi(event, generations)
             is AppleCallbackEvent.DidOpenL2CAPChannel -> handleDidOpenL2CAPChannel(event)
             is AppleCallbackEvent.DidModifyServices -> handleServicesModified()
         }
@@ -35,15 +50,26 @@ internal fun IosPeripheral.handleBridgeEvent(event: AppleCallbackEvent) {
  * (write response) to this single signature. Disambiguate by which slot is armed:
  * the GATT queue ensures only one read/write is pending.
  */
-internal fun IosPeripheral.handleCharacteristicValue(event: AppleCallbackEvent.DidUpdateValueForCharacteristic) {
+internal fun IosPeripheral.handleCharacteristicValue(
+    event: AppleCallbackEvent.DidUpdateValueForCharacteristic,
+    generations: GenerationSnapshot,
+) {
     val cbChar = event.characteristic
     val error = event.error
     when {
         pendingOps.has(PendingOp.CharacteristicWrite) ->
-            pendingOps.complete(PendingOp.CharacteristicWrite, error.toGattStatus())
+            pendingOps.complete(
+                PendingOp.CharacteristicWrite,
+                generations[PendingOp.CharacteristicWrite],
+                error.toGattStatus(),
+            )
         pendingOps.has(PendingOp.CharacteristicRead) -> {
             val value = cbChar.value?.toByteArray() ?: byteArrayOf()
-            pendingOps.complete(PendingOp.CharacteristicRead, GattResult(value, error.toGattStatus()))
+            pendingOps.complete(
+                PendingOp.CharacteristicRead,
+                generations[PendingOp.CharacteristicRead],
+                GattResult(value, error.toGattStatus()),
+            )
         }
         else -> {
             val value = cbChar.value?.toByteArray() ?: return
@@ -54,22 +80,37 @@ internal fun IosPeripheral.handleCharacteristicValue(event: AppleCallbackEvent.D
     }
 }
 
-internal fun IosPeripheral.handleDescriptorValue(event: AppleCallbackEvent.DidUpdateValueForDescriptor) {
+internal fun IosPeripheral.handleDescriptorValue(
+    event: AppleCallbackEvent.DidUpdateValueForDescriptor,
+    generations: GenerationSnapshot,
+) {
     val error = event.error
     if (pendingOps.has(PendingOp.DescriptorWrite)) {
-        pendingOps.complete(PendingOp.DescriptorWrite, error.toGattStatus())
+        pendingOps.complete(
+            PendingOp.DescriptorWrite,
+            generations[PendingOp.DescriptorWrite],
+            error.toGattStatus(),
+        )
     } else {
         val value = (event.descriptor.value as? NSData)?.toByteArray() ?: byteArrayOf()
-        pendingOps.complete(PendingOp.DescriptorRead, GattResult(value, error.toGattStatus()))
+        pendingOps.complete(
+            PendingOp.DescriptorRead,
+            generations[PendingOp.DescriptorRead],
+            GattResult(value, error.toGattStatus()),
+        )
     }
 }
 
-internal fun IosPeripheral.handleRssi(event: AppleCallbackEvent.DidReadRSSI) {
+internal fun IosPeripheral.handleRssi(
+    event: AppleCallbackEvent.DidReadRSSI,
+    generations: GenerationSnapshot,
+) {
     if (event.error == null) {
-        pendingOps.complete(PendingOp.RssiRead, event.rssi.intValue)
+        pendingOps.complete(PendingOp.RssiRead, generations[PendingOp.RssiRead], event.rssi.intValue)
     } else {
         pendingOps.fail(
             PendingOp.RssiRead,
+            generations[PendingOp.RssiRead],
             BleException(GattError("readRssi", event.error.toGattStatus())),
         )
     }

--- a/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
+++ b/src/iosTest/kotlin/com/atruedev/kmpble/peripheral/IosGattEventHandlerTest.kt
@@ -36,7 +36,11 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.CharacteristicRead, deferred)
             assertTrue(ops.has(PendingOp.CharacteristicRead))
 
-            ops.complete(PendingOp.CharacteristicRead, GattResult(byteArrayOf(0x42), GattStatus.Success))
+            ops.complete(
+                PendingOp.CharacteristicRead,
+                ops.generationOf(PendingOp.CharacteristicRead),
+                GattResult(byteArrayOf(0x42), GattStatus.Success),
+            )
             assertEquals(byteArrayOf(0x42).toList(), deferred.await().value.toList())
             assertFalse(ops.has(PendingOp.CharacteristicRead))
         }
@@ -50,7 +54,11 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.CharacteristicWrite, deferred)
             assertTrue(ops.has(PendingOp.CharacteristicWrite))
 
-            ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+            ops.complete(
+                PendingOp.CharacteristicWrite,
+                ops.generationOf(PendingOp.CharacteristicWrite),
+                GattStatus.Success,
+            )
             assertEquals(GattStatus.Success, deferred.await())
             assertFalse(ops.has(PendingOp.CharacteristicWrite))
         }
@@ -62,7 +70,11 @@ class IosGattEventHandlerTest {
             val deferred = CompletableDeferred<GattStatus>()
 
             ops.set(PendingOp.CharacteristicWrite, deferred)
-            ops.fail(PendingOp.CharacteristicWrite, RuntimeException("GATT error"))
+            ops.fail(
+                PendingOp.CharacteristicWrite,
+                ops.generationOf(PendingOp.CharacteristicWrite),
+                RuntimeException("GATT error"),
+            )
 
             assertTrue(deferred.getCompletionExceptionOrNull() != null)
             assertFalse(ops.has(PendingOp.CharacteristicWrite))
@@ -100,7 +112,11 @@ class IosGattEventHandlerTest {
             // Simulated handleCharacteristicValue logic:
             // when { pendingOps.has(CharacteristicWrite) -> complete(CharacteristicWrite, ...) }
             if (ops.has(PendingOp.CharacteristicWrite)) {
-                ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+                ops.complete(
+                    PendingOp.CharacteristicWrite,
+                    ops.generationOf(PendingOp.CharacteristicWrite),
+                    GattStatus.Success,
+                )
             }
 
             assertEquals(GattStatus.Success, writeDeferred.await())
@@ -117,7 +133,11 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.CharacteristicRead, readDeferred)
 
             if (!ops.has(PendingOp.CharacteristicWrite) && ops.has(PendingOp.CharacteristicRead)) {
-                ops.complete(PendingOp.CharacteristicRead, GattResult(byteArrayOf(0x01, 0x02), GattStatus.Success))
+                ops.complete(
+                    PendingOp.CharacteristicRead,
+                    ops.generationOf(PendingOp.CharacteristicRead),
+                    GattResult(byteArrayOf(0x01, 0x02), GattStatus.Success),
+                )
             }
 
             val result = readDeferred.await()
@@ -135,7 +155,11 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.DescriptorWrite, writeDeferred)
 
             if (ops.has(PendingOp.DescriptorWrite)) {
-                ops.complete(PendingOp.DescriptorWrite, GattStatus.Success)
+                ops.complete(
+                    PendingOp.DescriptorWrite,
+                    ops.generationOf(PendingOp.DescriptorWrite),
+                    GattStatus.Success,
+                )
             }
 
             assertEquals(GattStatus.Success, writeDeferred.await())
@@ -149,7 +173,11 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.DescriptorRead, readDeferred)
 
             if (!ops.has(PendingOp.DescriptorWrite) && ops.has(PendingOp.DescriptorRead)) {
-                ops.complete(PendingOp.DescriptorRead, GattResult(byteArrayOf(0x03), GattStatus.Success))
+                ops.complete(
+                    PendingOp.DescriptorRead,
+                    ops.generationOf(PendingOp.DescriptorRead),
+                    GattResult(byteArrayOf(0x03), GattStatus.Success),
+                )
             }
 
             val result = readDeferred.await()
@@ -166,7 +194,7 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.RssiRead, rssiDeferred)
 
             // Simulate handleRssi: complete with RSSI value on success
-            ops.complete(PendingOp.RssiRead, -42)
+            ops.complete(PendingOp.RssiRead, ops.generationOf(PendingOp.RssiRead), -42)
 
             assertEquals(-42, rssiDeferred.await())
         }
@@ -179,7 +207,7 @@ class IosGattEventHandlerTest {
             ops.set(PendingOp.RssiRead, rssiDeferred)
 
             // Simulate handleRssi: fail on error
-            ops.fail(PendingOp.RssiRead, RuntimeException("RSSI read failed"))
+            ops.fail(PendingOp.RssiRead, ops.generationOf(PendingOp.RssiRead), RuntimeException("RSSI read failed"))
 
             assertTrue(rssiDeferred.getCompletionExceptionOrNull() != null)
         }
@@ -238,17 +266,25 @@ class IosGattEventHandlerTest {
             assertTrue(ops.has(PendingOp.RssiRead))
 
             // Complete write first - shouldn't affect read or RSSI
-            ops.complete(PendingOp.CharacteristicWrite, GattStatus.Success)
+            ops.complete(
+                PendingOp.CharacteristicWrite,
+                ops.generationOf(PendingOp.CharacteristicWrite),
+                GattStatus.Success,
+            )
             assertFalse(ops.has(PendingOp.CharacteristicWrite))
             assertTrue(ops.has(PendingOp.CharacteristicRead))
             assertTrue(ops.has(PendingOp.RssiRead))
 
             // Complete read
-            ops.complete(PendingOp.CharacteristicRead, GattResult(byteArrayOf(0x07), GattStatus.Success))
+            ops.complete(
+                PendingOp.CharacteristicRead,
+                ops.generationOf(PendingOp.CharacteristicRead),
+                GattResult(byteArrayOf(0x07), GattStatus.Success),
+            )
             assertFalse(ops.has(PendingOp.CharacteristicRead))
 
             // Complete RSSI
-            ops.complete(PendingOp.RssiRead, -50)
+            ops.complete(PendingOp.RssiRead, ops.generationOf(PendingOp.RssiRead), -50)
             assertFalse(ops.has(PendingOp.RssiRead))
         }
 

--- a/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
+++ b/src/jvmTest/kotlin/com/atruedev/kmpble/monitoring/LePowerControllerTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -488,7 +489,7 @@ class LePowerControllerTest {
     }
 
     @Test
-    fun `request when not connected still works with default`() {
+    fun `request while not connected fails fast with not-connected error`() {
         val scheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(scheduler)
         runTest(scheduler) {
@@ -501,10 +502,12 @@ class LePowerControllerTest {
             controller.start()
             scheduler.runCurrent()
 
-            // No connection established
-            // FakePeripheral.requestConnectionParameterUpdate returns default response
-            val response = controller.requestPeerPowerChange(-4)
-            assertNotNull(response)
+            // No connection established: the not-connected path must fail fast
+            // rather than fabricate a response. Mirrors the real peripheral,
+            // whose GATT queue rejects operations while disconnected.
+            assertFailsWith<IllegalStateException> {
+                controller.requestPeerPowerChange(-4)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #627. `PendingOperations.cancel(op, generation)` was generation-aware, but `complete`/`fail` were not: a stale platform callback could remove a retry's re-armed slot and complete the retry's deferred with stale data.

**Mechanism**: the callback handlers stamp each event with the generation armed when the event was **received** (on the platform callback thread, before dispatch onto the peripheral's serialized dispatcher). `complete`/`fail` no-op unless the slot still holds the stamped generation.

- `PendingOperations` gains `generationOf` (a thread-safe AtomicLong mirror of armed generations, written only by dispatcher-confined mutations) and generation-guarded `complete`/`fail`; a new `PendingOp` subtype missing from `PendingOp.all` now fails loudly instead of throwing `NoSuchElementException`.
- Android + iOS handlers stamp per event type at receipt — a single atomic read, no allocation. Events that can never complete a pending op (notifications, which heart-rate monitors emit at 50-100/s) skip the stamp entirely.
- iOS write/read disambiguation now happens at receipt (via the stamped generations) instead of dispatch-time `has()` checks, keeping the branch decision consistent with the stamp.
- Residual window (documented in KDoc): if the retry's `set` executes before the platform even delivers the stale response, the stamped generation is the retry's and the response is indistinguishable from the retry's own — the platform serializes responses in submission order.

## Test plan

- `PendingOperationsTest`: 8/8 pass, including 3 new tests (stale null-generation callback no-ops against a retry slot; stale old-generation complete/fail no-op and leave the retry slot intact).
- `IosGattEventHandlerTest` (iOS simulator): pass.
- `:jvmTest` gatt/peripheral/monitoring suites: 216 tests, 0 failures.
- `ktlintCheck` + `compileAndroidMain` + iOS compiles: pass.

## Also includes

`test(monitoring)`: fix the `LePowerControllerTest` "request when not connected" test — it claimed a default response is returned while disconnected, but the fake (like the real peripheral) fails fast with a not-connected error, so the test was broken from introduction in #305. CI never runs jvmTest, so main stayed green. Rewritten to pin the real fail-fast contract.